### PR TITLE
Change `exclude` to `include` in the webpack settings.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ const buildConfiguration = ({ name, mode, excludeDependencies, plugins = [] }) =
         {
           test: /\.tsx?$/,
           use: 'ts-loader',
-          exclude: /node_modules/
+          include: /src/
         }
       ]
     },


### PR DESCRIPTION
With the `exclude: /node_modules/` setting in the `ts-loader` configuration for webpack, the package has troubles building, when placed inside `node_modules`.

What I'm trying to do is:
1 - install the package from github using `npm`
2 - install it's dependencies and build the bundles, so I can use them in the parent project

What happens is, when the `ts-loader` excludes everything from `node_modules` it excludes itself from being processed. Changing it to `include: /src/` seems to work alright, let me know if it breaks anything on your end.