### PR TITLE
Export version, build date and unify API

### DIFF
--- a/.config/base.js
+++ b/.config/base.js
@@ -17,6 +17,7 @@ module.exports.create = function create(processedFile) {
     output: {
       globalObject: `typeof self !== 'undefined' ? self : this`,
       library: 'HyperFormula',
+      libraryExport: 'default',
       libraryTarget: 'umd',
       path: path.resolve(__dirname, '../dist'),
       umdNamedDefine: true,
@@ -33,6 +34,9 @@ module.exports.create = function create(processedFile) {
           exclude: [
             /node_modules/,
           ],
+          options: {
+            cacheDirectory: false, // Disable cache. Necessary for injected variables into source code via ht.config.js
+          },
         },
       ]
     },

--- a/Makefile
+++ b/Makefile
@@ -38,16 +38,16 @@ clean: ## Clean compiled files
 bundle: compile bundle-es bundle-commonjs bundle-development bundle-production bundle-typings check-bundle ## Bundle library by making CommonJS, ES and UMD compatible files
 
 bundle-es: compile ## Transpiles files to ES
-	@yarn cross-env-shell BABEL_ENV=es babel lib --out-dir es
+	@yarn cross-env-shell BABEL_ENV=es env-cmd -f ht.config.js babel lib --out-dir es
 
 bundle-commonjs: compile ## Transpiles files to CommonJS
-	@yarn cross-env-shell BABEL_ENV=commonjs babel lib --out-dir commonjs
+	@yarn cross-env-shell BABEL_ENV=commonjs env-cmd -f ht.config.js babel lib --out-dir commonjs
 
 bundle-development: compile ## Transpiles and bundles files to UMD format (without minification)
-	@yarn cross-env-shell BABEL_ENV=commonjs NODE_ENV=development webpack ./lib/index.js
+	@yarn cross-env-shell BABEL_ENV=commonjs NODE_ENV=development env-cmd -f ht.config.js webpack ./lib/index.js
 
 bundle-production: compile ## Transpiles and bundles files to UMD format (with minification)
-	@yarn cross-env-shell BABEL_ENV=commonjs NODE_ENV=production webpack ./lib/index.js
+	@yarn cross-env-shell BABEL_ENV=commonjs NODE_ENV=production env-cmd -f ht.config.js webpack ./lib/index.js
 
 bundle-typings: ## Generates TypeScript declaration files
 	@yarn tsc --emitDeclarationOnly -d --outDir typings

--- a/ht.config.js
+++ b/ht.config.js
@@ -1,0 +1,10 @@
+const moment = require('moment');
+const packageBody = require('./package.json');
+
+module.exports = {
+  HT_FILENAME: 'hyperformula',
+  HT_VERSION: packageBody.version,
+  HT_PACKAGE_NAME: packageBody.name,
+  HT_BUILD_DATE: moment().format('DD/MM/YYYY HH:mm:ss'),
+  HT_RELEASE_DATE: '12/01/2020',
+};

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "babel-loader": "^8.0.6",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "cross-env": "^6.0.3",
+    "env-cmd": "^9.0.3",
     "jest": "^23.6.0",
     "license-checker": "^25.0.1",
     "ts-jest": "^23.10.1",

--- a/script/check-file.js
+++ b/script/check-file.js
@@ -7,16 +7,22 @@ if (!fileToCheck) {
   throw Error('Missing file to check');
 }
 
-const { HyperFormula: Engine, Config } = require(resolve(fileToCheck));
+try {
+  const { HyperFormula, Config } = require(resolve(fileToCheck));
 
-const engine = Engine.buildFromArray([
-  ['42', '=A1 + 2']
-], new Config({ gpuMode: 'cpu' }))
+  const engine = HyperFormula.buildFromArray([
+    ['42', '=A1 + 2']
+  ], new Config({ gpuMode: 'cpu' }))
 
-const valueA1 = engine.getCellValue({ sheet: 0, row: 0, col: 0 })
-const valueB1 = engine.getCellValue({ sheet: 0, row: 0, col: 1 })
+  const valueA1 = engine.getCellValue({ sheet: 0, row: 0, col: 0 })
+  const valueB1 = engine.getCellValue({ sheet: 0, row: 0, col: 1 })
 
-assert(valueA1 === 42)
-assert(valueB1 === 44)
+  assert(valueA1 === 42)
+  assert(valueB1 === 44)
 
-console.log(`Bundle check: \u001b[32m${fileToCheck}\u001b[0m OK`)
+  console.log(`Bundle check: \u001b[1;37m${fileToCheck}\u001b[0m \u001b[0;32mOK\u001b[0m`)
+} catch (ex) {
+  console.log(`Bundle check: \u001b[1;37m${fileToCheck}\u001b[0m \u001b[0;31mERROR\u001b[0m`)
+
+  throw ex;
+}

--- a/src/Evaluator.ts
+++ b/src/Evaluator.ts
@@ -1,5 +1,5 @@
 import {Vertex} from './DependencyGraph'
-import {ContentChanges} from "./ContentChanges";
+import {ContentChanges} from './ContentChanges'
 
 export interface Evaluator {
   run(): void,

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -58,6 +58,9 @@ export type Index = [number, number]
  */
 export class HyperFormula {
 
+  public static version = (process.env.HT_VERSION || '')
+  public static buildDate = (process.env.HT_BUILD_DATE || '')
+
   public get graph(): Graph<Vertex> {
     return this.dependencyGraph.graph
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,28 @@
-export {Sheets} from './GraphBuilder'
-export {Config} from './Config'
-export {HyperFormula, NoSheetWithIdError, InvalidAddressError} from './HyperFormula'
-export {CellValue, EmptyValue, CellError} from './Cell'
-export {LazilyTransformingAstService} from './LazilyTransformingAstService'
+import {Sheets} from './GraphBuilder'
+import {Config} from './Config'
+import {HyperFormula, NoSheetWithIdError, InvalidAddressError} from './HyperFormula'
+import {CellValue, EmptyValue, CellError} from './Cell'
+import {LazilyTransformingAstService} from './LazilyTransformingAstService'
+
+class HyperFormulaNS extends HyperFormula {
+  public static Config = Config
+  public static HyperFormula = HyperFormula
+  public static NoSheetWithIdError = NoSheetWithIdError
+  public static InvalidAddressError = InvalidAddressError
+  public static EmptyValue = EmptyValue
+  public static CellError = CellError
+  public static LazilyTransformingAstService = LazilyTransformingAstService
+}
+
+export default HyperFormulaNS
+export {
+  Sheets,
+  Config,
+  HyperFormula,
+  NoSheetWithIdError,
+  InvalidAddressError,
+  CellValue,
+  EmptyValue,
+  CellError,
+  LazilyTransformingAstService,
+}

--- a/src/parser/ParserConfig.ts
+++ b/src/parser/ParserConfig.ts
@@ -1,5 +1,5 @@
-import {TranslationPackage} from "../i18n";
-import {ErrorType} from "../Cell";
+import {TranslationPackage} from '../i18n'
+import {ErrorType} from '../Cell'
 
 export interface ParserConfig {
   functionArgSeparator: string,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,3 @@
-const packageBody = require('./package.json');
-
-process.env.HT_FILENAME = 'hyperformula';
-process.env.HT_VERSION = packageBody.version;
-process.env.HT_PACKAGE_NAME = packageBody.name;
-process.env.HT_BUILD_DATE = new Date();
-process.env.HT_RELEASE_DATE = '12/01/2020';
-
 const configFactory = require(`./.config/${process.env.NODE_ENV}`);
 
 module.exports = function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1893,6 +1893,11 @@ combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^2.0.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 commander@^2.12.1:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
@@ -2355,6 +2360,14 @@ enhanced-resolve@^4.1.0:
     graceful-fs "^4.1.2"
     memory-fs "^0.4.0"
     tapable "^1.0.0"
+
+env-cmd@9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/env-cmd/-/env-cmd-9.0.3.tgz#b85265f5a9fd4c5fc7d7eff34e341dc28c3f9801"
+  integrity sha512-DXNeSkLMlYOmq9At+GyvqpdIDuy3gRvz2Z77kN4cAhRbAGVmeiYaqdWqgHSTJ9wCck6ZD0rtbhHVcN7cc2j7rw==
+  dependencies:
+    commander "^2.0.0"
+    cross-spawn "^6.0.0"
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
@@ -4660,22 +4673,6 @@ node-notifier@^5.2.1:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-pre-gyp@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
@@ -6264,7 +6261,7 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
-tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
Add ht.config.js file which defines library version and build date variables. Unify API between NodeJS environment and browsers.

As described here https://github.com/handsontable/hyperformula/issues/83 it is possible to initialize engine as follows:

NodeJS
```js
import { HyperFormula, Config } from 'hyperformula';

const config = new Config({ gpuMode: 'cpu' });
const engine = HyperFormula.buildFromArray([['1', '=A1'], config);
```
or
```js
import HyperFormula from 'hyperformula';

const config = new HyperFormula.Config({ gpuMode: 'cpu' });
const engine = HyperFormula.buildFromArray([['1', '=A1'], config);
```
The above syntax works for all builds, commonJS, ES and UMD.

In the browser
```js
var config = new HyperFormula.Config({ gpuMode: 'gpu' });
var engine = HyperFormula.buildFromArray([['1', '=A1'], config);
```

The current version or build date can be checked through static props:
```js
console.log('HyperFormula v:', HyperFormula.version, 'build date:', HyperFormula.buildDate);
```

Issue: #83