### PR TITLE
Change LICENSE path to COPYING.md path in the bundle config.

### DIFF
--- a/.config/base.js
+++ b/.config/base.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require('fs');
 const { BannerPlugin } = require('webpack');
 
-let licenseBody = fs.readFileSync(path.resolve(__dirname, '../LICENSE'), 'utf8');
+let licenseBody = fs.readFileSync(path.resolve(__dirname, '../COPYING.md'), 'utf8');
 
 licenseBody += '\nVersion: ' + process.env.HT_VERSION;
 licenseBody += '\nRelease date: ' + process.env.HT_RELEASE_DATE + ' (built at ' + process.env.HT_BUILD_DATE + ')';


### PR DESCRIPTION
### Context
Running `make bundle` results in an error regarding the missing `LICENSE` file:

`ENOENT: no such file or directory`

I'm guessing the license in in the `COPYING.md` file now (764ef934e5369d1689cffc7fdc9de8fd532c20b3), so it probably needs to be changed in the build config file.