### PR TITLE
`make bundle` fails on a fresh clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ bundle-commonjs: compile ## Transpiles files to CommonJS
 	@yarn cross-env-shell BABEL_ENV=commonjs env-cmd -f ht.config.js babel lib --out-dir commonjs
 
 bundle-development: compile ## Transpiles and bundles files to UMD format (without minification)
-	@yarn cross-env-shell BABEL_ENV=commonjs NODE_ENV=development env-cmd -f ht.config.js webpack ./lib/index.js
+	@yarn cross-env-shell BABEL_ENV=commonjs NODE_ENV=development env-cmd -f ht.config.js webpack ./lib/src/index.js
 
 bundle-production: compile ## Transpiles and bundles files to UMD format (with minification)
-	@yarn cross-env-shell BABEL_ENV=commonjs NODE_ENV=production env-cmd -f ht.config.js webpack ./lib/index.js
+	@yarn cross-env-shell BABEL_ENV=commonjs NODE_ENV=production env-cmd -f ht.config.js webpack ./lib/src/index.js
 
 bundle-typings: ## Generates TypeScript declaration files
 	@yarn tsc --emitDeclarationOnly -d --outDir typings


### PR DESCRIPTION
On a fresh clone of the project, `make bundle` fails with an error:

`ERROR in Entry module not found: Error: Can't resolve './lib/index.js'`

I believe it should point to `/lib/src/index.js` instead? 

Correct me if I'm wrong.