### PR TITLE
Move core-js and regenerator-runtime to devdependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@typescript-eslint/parser": "^2.20.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
+    "core-js": "^3.6.4",
     "cross-env": "^7.0.0",
     "env-cmd": "^10.1.0",
     "eslint": "^6.8.0",
@@ -61,6 +62,7 @@
     "jest": "^25.1.0",
     "license-checker": "^25.0.1",
     "moment": "^2.22.2",
+    "regenerator-runtime": "^0.13.3",
     "ts-jest": "^25.2.1",
     "ts-node": "^8.0.1",
     "typedoc": "^0.16.10",
@@ -71,9 +73,7 @@
   },
   "dependencies": {
     "chevrotain": "^6.5.0",
-    "core-js": "^3.6.4",
     "gpu.js": "2.3.0",
-    "regenerator-runtime": "^0.13.3",
     "tiny-emitter": "^2.1.0"
   }
 }


### PR DESCRIPTION
As far as I see, these are used only in babel

### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project,
- [ ] My change requires a change to the documentation,
- [ ] I described the modification in the CHANGELOG.md file.