### PR TITLE
Store options with named expressions

### DIFF
--- a/src/UndoRedo.ts
+++ b/src/UndoRedo.ts
@@ -16,7 +16,7 @@ import {
   RowsRemoval
 } from './Operations'
 import {Config} from './Config'
-import {NamedExpression} from './NamedExpressions'
+import {InternalNamedExpression, NamedExpressionOptions} from './NamedExpressions'
 
 export class RemoveRowsUndoEntry {
   constructor(
@@ -141,25 +141,27 @@ export class AddNamedExpressionUndoEntry {
     public readonly name: string,
     public readonly newContent: RawCellContent,
     public readonly scope?: number,
+    public readonly options?: NamedExpressionOptions
   ) {
   }
 }
 
 export class RemoveNamedExpressionUndoEntry {
   constructor(
-    public readonly namedExpression: NamedExpression,
+    public readonly namedExpression: InternalNamedExpression,
     public readonly content: ClipboardCell,
-    public readonly scope?: number
+    public readonly scope?: number,
   ) {
   }
 }
 
 export class ChangeNamedExpressionUndoEntry {
   constructor(
-    public readonly namedExpression: NamedExpression,
+    public readonly namedExpression: InternalNamedExpression,
     public readonly newContent: RawCellContent,
     public readonly oldContent: ClipboardCell,
-    public readonly scope?: number
+    public readonly scope?: number,
+    public readonly options?: NamedExpressionOptions
   ) {
   }
 }
@@ -583,7 +585,7 @@ export class UndoRedo {
   }
 
   private redoAddNamedExpression(operation: AddNamedExpressionUndoEntry) {
-    this.operations.addNamedExpression(operation.name, operation.newContent, operation.scope)
+    this.operations.addNamedExpression(operation.name, operation.newContent, operation.scope, operation.options)
   }
 
   private redoRemoveNamedExpression(operation: RemoveNamedExpressionUndoEntry) {
@@ -591,7 +593,7 @@ export class UndoRedo {
   }
 
   private redoChangeNamedExpression(operation: ChangeNamedExpressionUndoEntry) {
-    this.operations.changeNamedExpressionExpression(operation.namedExpression.displayName, operation.newContent, operation.scope)
+    this.operations.changeNamedExpressionExpression(operation.namedExpression.displayName, operation.newContent, operation.scope, operation.options)
   }
 
   private restoreOldDataFromVersion(version: number) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {Config, ConfigParams} from './Config'
 import {languages, RawTranslationPackage} from './i18n'
 import {Sheet, SheetDimensions, Sheets} from './Sheet'
 import {RawCellContent} from './CellContentParser'
+import {NamedExpression, NamedExpressionOptions} from './NamedExpressions'
 import {
   ConfigValueTooBigError,
   ConfigValueTooSmallError,
@@ -110,6 +111,8 @@ export {
   ColumnRowIndex,
   RawTranslationPackage,
   FunctionPluginDefinition,
+  NamedExpression,
+  NamedExpressionOptions,
   HyperFormula,
   CellType,
   CellValueType,

--- a/test/named-expressions.spec.ts
+++ b/test/named-expressions.spec.ts
@@ -833,3 +833,129 @@ describe('Named expressions - named ranges', () => {
     expect(engine.getCellValue(adr('C1'))).toEqual(6)
   })
 })
+
+describe('Named expressions - options', () => {
+  it('should return named expression with empty options', () => {
+    const engine = HyperFormula.buildEmpty()
+
+    engine.addNamedExpression('foo', '=foo')
+
+    expect(engine.getNamedExpression('foo')).toEqual({
+      name: 'foo',
+      expression: '=foo',
+      scope: undefined,
+      options: undefined
+    })
+  })
+
+  it('should return named expression with options', () => {
+    const engine = HyperFormula.buildEmpty()
+
+    engine.addNamedExpression('foo', '=foo', undefined, { visible: false, comment: 'bar' })
+
+    expect(engine.getNamedExpression('foo')).toEqual({
+      name: 'foo',
+      expression: '=foo',
+      scope: undefined,
+      options: {
+        visible: false,
+        comment: 'bar'
+      }
+    })
+  })
+
+  it('should preserve options after undo-redo', () => {
+    const engine = HyperFormula.buildEmpty()
+
+    engine.addNamedExpression('foo', '=foo', undefined, { visible: false, comment: 'bar' })
+
+    engine.undo()
+    engine.redo()
+
+    expect(engine.getNamedExpression('foo')).toEqual({
+      name: 'foo',
+      expression: '=foo',
+      scope: undefined,
+      options: {
+        visible: false,
+        comment: 'bar'
+      }
+    })
+  })
+
+  it('should change options of named expression', () => {
+    const engine = HyperFormula.buildEmpty()
+
+    engine.addNamedExpression('foo', '=foo', undefined, { visible: false, comment: 'foo' })
+
+    engine.changeNamedExpression('foo', '=bar', undefined, { visible: true, comment: 'bar' })
+
+    expect(engine.getNamedExpression('foo')).toEqual({
+      name: 'foo',
+      expression: '=bar',
+      scope: undefined,
+      options: {
+        visible: true,
+        comment: 'bar'
+      }
+    })
+  })
+
+  it('should undo changing options of named expression', () => {
+    const engine = HyperFormula.buildEmpty()
+
+    engine.addNamedExpression('foo', '=foo', undefined, { visible: false, comment: 'foo' })
+    engine.changeNamedExpression('foo', '=bar', undefined, { visible: true, comment: 'bar' })
+
+    engine.undo()
+
+    expect(engine.getNamedExpression('foo')).toEqual({
+      name: 'foo',
+      expression: '=foo',
+      scope: undefined,
+      options: {
+        visible: false,
+        comment: 'foo'
+      }
+    })
+  })
+
+  it('should undo-redo changing options of named expression', () => {
+    const engine = HyperFormula.buildEmpty()
+
+    engine.addNamedExpression('foo', '=foo', undefined, { visible: false, comment: 'foo' })
+    engine.changeNamedExpression('foo', '=bar', undefined, { visible: true, comment: 'bar' })
+
+    engine.undo()
+    engine.redo()
+
+    expect(engine.getNamedExpression('foo')).toEqual({
+      name: 'foo',
+      expression: '=bar',
+      scope: undefined,
+      options: {
+        visible: true,
+        comment: 'bar'
+      }
+    })
+  })
+
+  it('should restore named expression with options', () => {
+    const engine = HyperFormula.buildEmpty()
+
+    engine.addNamedExpression('foo', '=foo', undefined, { visible: false, comment: 'foo' })
+    engine.removeNamedExpression('foo')
+
+    engine.undo()
+
+    expect(engine.getNamedExpression('foo')).toEqual({
+      name: 'foo',
+      expression: '=foo',
+      scope: undefined,
+      options: {
+        visible: false,
+        comment: 'foo'
+      }
+    })
+  })
+})


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Adds ability to store additional options with named expression. 

```typescript
export interface NamedExpression {
  name: string,
  scope?: string,
  expression?: string,
  options?: NamedExpressionOptions,
}

export type NamedExpressionOptions = Record<string, string | number | boolean>

public addNamedExpression(expressionName: string, expression: RawCellContent, scope?: string, options?: NamedExpressionOptions)
public changeNamedExpression(expressionName: string, newExpression: RawCellContent, scope?: string, options?: NamedExpressionOptions)
```

Adds API to retrieve all informations about namedExpression
```typescript
public getNamedExpression(expressionName: string, scope?: string): Maybe<NamedExpression>
```

Along with #367 PR completes #240 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #240
2. #126 
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project,
- [x] My change requires a change to the documentation,
- [ ] I described the modification in the CHANGELOG.md file.