### PR TITLE
Fix API descriptions 

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -83,7 +83,7 @@ export interface ConfigParams {
    *
    * Any configuration of at least two of hh, mm, ss is accepted as a time, and they can be put in any order.
    *
-   * @default ['hh:mm', 'hh:mm:ss']
+   * @default ['hh:mm', 'hh:mm:ss.sss']
    *
    * @category Date and Time
    */

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -2194,10 +2194,10 @@ export class HyperFormula implements TypedEmitter {
    *  ['=SUM(A2:A3)', '2'],
    * ]);
    *
-   * // should return 'false' since the selcted cell contains a simple value
+   * // should return 'true' since the selected cell contains a simple value
    * const isA1Simple = hfInstance.doesCellHaveSimpleValue({ sheet: 0, col: 0, row: 0 });
    *
-   * // should return 'true' since the selcted cell does not contain a simple value
+   * // should return 'false' since the selected cell does not contain a simple value
    * const isB1Simple = hfInstance.doesCellHaveSimpleValue({ sheet: 0, col: 1, row: 0 });
    * ```
    *
@@ -2367,6 +2367,8 @@ export class HyperFormula implements TypedEmitter {
    * @fires [[sheetRenamed]] after the sheet was renamed
    *
    * @throws [[NoSheetWithIdError]] when the given sheet ID does not exist
+   *
+   * @throws [[SheetNameAlreadyTakenError]] when the provided sheet name already exists
    *
    * @example
    * ```js


### PR DESCRIPTION
### Context
Fixed API descriptions:
- defaults for date and time changed,
- `renameSheet` method missed `@throws` tag
- `doesCellHaveSimpleValue` example was a mismatch 