### PR TITLE
Exclude './languages' directory from being tested by eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,6 +12,7 @@ coverage
 dist
 doc
 es
+languages
 lib
 script
 test-jasmine


### PR DESCRIPTION
### Context
#266 introduces `languages` directory. It's temp directory, used to bundle languages' UMD files and should not be checked by eslint.

### How has this been tested?
Run `npm run lint`

### Types of changes
- [x] development env improvement