### PR TITLE
Typo fix - calculateFormula

### DIFF
--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -3050,7 +3050,7 @@ export class HyperFormula implements TypedEmitter {
    * });
    *
    * // returns the value of calculated formula, '32' for this example
-   * const calculatedFormula = hfInstance.calculateFormula('=A1+10', 'Sheet1'));
+   * const calculatedFormula = hfInstance.calculateFormula('=A1+10', 'Sheet1');
    * ```
    *
    * @category Helpers


### PR DESCRIPTION
The following PR removes duplicated parentheses in the calculateFormula example.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/hyperformula/issues/202

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation,
- [ ] I described the modification in the CHANGELOG.md file.