### PR TITLE
Add 'languages' to the npmignore whitelist.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@
 !dist/**/*
 !es/**/*
 !typings/**/*
+!languages/**/*
 !non-commercial-license.pdf
 !github-hf-logo-blue.svg
 !agpl-3.0.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add the `languages` directory to the `.npmignore` whitelist.
 
 ## [0.1.0] - 2020-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Add the `languages` directory to the `.npmignore` whitelist.
+
+### Fixed
+- Add the `languages` directory to the `.npmignore` whitelist to allow using the language packs, which were previously 
+missing from the npm package.
 
 ## [0.1.0] - 2020-06-25
 

--- a/script/check-publish-package.js
+++ b/script/check-publish-package.js
@@ -33,6 +33,7 @@ const FILES_CHECKLIST = [
   'es/HyperFormula.js',
   'typings/index.d.ts',
   'typings/HyperFormula.d.ts',
+  'languages/all.js',
 ]
 
 process.stdin.resume()
@@ -78,7 +79,7 @@ process.stdout.on('error', (err) => {
 
 async function checkDirectoryTreeStructure() {
   for (let i = 0; i < FILES_CHECKLIST.length; i++) {
-    const stats = await stat(FILES_CHECKLIST[i])
+    const stats = await stat(`${UNPACKED_DIR_NAME}/${FILES_CHECKLIST[i]}`)
 
     if (!stats || !stats.isFile()) {
       throw new Error(`No such file (${file}) in the checklist or it is not described as a regular file`);


### PR DESCRIPTION
### Context
In `0.1.0` the `languages` directory is missing from the `npm` package, which makes languages impossible to import.