### PR TITLE
Changes a path to resolve `hyperformula` in webpack's configuration for languages packages

### DIFF
--- a/.config/webpack/languages.js
+++ b/.config/webpack/languages.js
@@ -80,9 +80,9 @@ module.exports.create = function create() {
     externals: {
       ['../..']: {
         root: 'HyperFormula',
-        commonjs2: '../..',
-        commonjs: '../..',
-        amd: '../..',
+        commonjs2: 'hyperformula',
+        commonjs: 'hyperformula',
+        amd: 'hyperformula',
       },
     },
     module: {


### PR DESCRIPTION
### Context
@jansiegel found the problem with using language packages from the npm's package. There was a mismatch 

### How has this been tested?
1. Bundle package by `npm pack`
2. Install it into `parcel`'s project as @jansiegel wrote in #428

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #428