### PR TITLE
Correct the misunderstanding with the language packs.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,6 @@
 !dist/**/*
 !es/**/*
 !typings/**/*
-!languages/**/*
 !non-commercial-license.pdf
 !github-hf-logo-blue.svg
 !agpl-3.0.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- Add the `languages` directory to the `.npmignore` whitelist to allow using the language packs, which were previously 
-missing from the npm package.
-
 ## [0.1.0] - 2020-06-25
 
 ### Added

--- a/docs/guide/localizing-functions.md
+++ b/docs/guide/localizing-functions.md
@@ -9,11 +9,20 @@ register the language like so:
 
 ```javascript
 // import the French language pack
-import { frFR } from 'hyperformula';
+import frFR from 'hyperformula/es/i18n/languages/frFR';
 
 // register the language
 HyperFormula.registerLanguage('frFR', frFR);
 ```
+
+::: tip
+To import the language packs, use the module-system-specific dedicated bundles at:
+* **ES**: `hyperformula/es/i18n/languages/`
+* **CommonJS**: `hyperformula/commonjs/i18n/languages/`
+* **UMD**: `hyperformula/dist/languages/`
+
+For the UMD build, the languages are accessible through `HyperFormula.languages`, e.g. `HyperFormula.languages.frFR`.
+:::
 
 Then set it inside it the [configuration options](configuration-options.md):
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "docs:api": "typedoc --options .typedoc.md.ts",
     "docs:dev": "vuepress dev docs --silent --no-clear-screen --no-cache",
     "docs:build": "vuepress build docs",
-    "bundle-all": "cross-env HF_COMPILE=1 npm-run-all compile bundle:** typings:generate verify-bundles",
+    "bundle-all": "cross-env HF_COMPILE=1 npm-run-all clean compile bundle:** typings:generate verify-bundles",
     "bundle:es": "node script/if-ne-env.js HF_COMPILE=1 || npm run compile && cross-env-shell BABEL_ENV=es env-cmd -f ht.config.js babel lib --out-dir es",
     "bundle:cjs": "node script/if-ne-env.js HF_COMPILE=1 || npm run compile && cross-env-shell BABEL_ENV=commonjs env-cmd -f ht.config.js babel lib --out-dir commonjs",
     "bundle:development": "node script/if-ne-env.js HF_COMPILE=1 || npm run compile && cross-env-shell BABEL_ENV=commonjs NODE_ENV=development env-cmd -f ht.config.js webpack ./lib/index.js",

--- a/script/check-publish-package.js
+++ b/script/check-publish-package.js
@@ -33,6 +33,9 @@ const FILES_CHECKLIST = [
   'es/HyperFormula.js',
   'typings/index.d.ts',
   'typings/HyperFormula.d.ts',
+  'dist/languages/plPL.js',
+  'es/i18n/languages/plPL.js',
+  'commonjs/i18n/languages/plPL.js',
 ]
 
 process.stdin.resume()

--- a/script/check-publish-package.js
+++ b/script/check-publish-package.js
@@ -33,7 +33,6 @@ const FILES_CHECKLIST = [
   'es/HyperFormula.js',
   'typings/index.d.ts',
   'typings/HyperFormula.d.ts',
-  'languages/all.js',
 ]
 
 process.stdin.resume()


### PR DESCRIPTION
### Context
#424 added the `/languages` directory to the npm package, which turned not needed, as the language packs are already present in their bundle-specific directories.

#### Changes in this PR:
- Remove the `languages` directory from the `.npmignore` whitelist (rollback #424)
- Prepend the `bundle-all` command with the `clean` command
- Correct and extend the information about importing the language packs in the documentation
- Rollback the #424 entry from the `CHANGELOG.md` file
- Remove the test for the `languages` directory from the package-checking script.

### How has this been tested?
Tested manually + with the codesandbox example.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #424