### PR TITLE
Add  the documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 ### Description
-<!--- [mandatory] Describe the need, add pictures, code snippets, if applies-->
+<!--- [mandatory] Describe the need, add pictures and code snippets, if applies-->
 
 ### Type of issue
 <!--- [mandatory] You can choose several options here e.g. a tutorial with a demo-->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -3,11 +3,14 @@ name: Documentation
 about: A general template for documentation requests and suggestions
 title: ''
 labels: Documentation
-assignees: ''
+assignees: 'scarletfog'
 
 ---
 ### Description
 <!--- [mandatory] Describe the need, add pictures and code snippets, if applies-->
+
+### Links
+<!--- [mandatory] Add a link (or links) to the page that should be improved or the mistake is on-->
 
 ### Type of issue
 <!--- [mandatory] You can choose several options here e.g. a tutorial with a demo-->
@@ -16,6 +19,3 @@ assignees: ''
 - [ ] Request for a demo
 - [ ] Request for a tutorial, guide etc.
 - [ ] Other issues, suggestions or ideas
-
-### Links
-<!--- [optional] Any links that are related -->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -3,7 +3,7 @@ name: Documentation
 about: A general template for documentation requests and suggestions
 title: ''
 labels: Documentation
-assignees: 'scarletfog'
+assignees: scarletfog
 
 ---
 ### Description

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,21 @@
+---
+name: Documentation
+about: A general template for documentation requests and suggestions
+title: ''
+labels: Documentation
+assignees: ''
+
+---
+### Description
+<!--- [mandatory] Describe the need, add pictures, code snippets, if applies-->
+
+### Type of issue
+<!--- [mandatory] You can choose several options here e.g. a tutorial with a demo-->
+- [ ] Missing documentation
+- [ ] Error in the documentation
+- [ ] Request for a demo
+- [ ] Request for a tutorial, guide etc.
+- [ ] Other issues, suggestions or ideas
+
+### Links
+<!--- [optional] Any links that are related -->


### PR DESCRIPTION
### Context
We need a separate issue template for all sorts of documentation to facilitate a smoother process of requesting new pieces of documentation and tracking errors. The issue template should add the "Documentation" label automatically so it is easily distinguishable from other tasks.

@wojciechczerniak do you have any ideas on how to make it better?