### PR TITLE
Remove doubled datetime category

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -251,7 +251,7 @@ export interface ConfigParams {
    *
    * @default defaultStringifyDuration
    *
-   * @category DateTime
+   * @category Date and Time
    */
   stringifyDuration: (time: SimpleTime, timeFormat: string) => Maybe<string>,
   /**


### PR DESCRIPTION
### Context
We doubled a category by mistake - `DateTime` and `Date and Time` in the API reference.
Keep `Date and Time` only.