### PR TITLE
Remove doubled category - helper

### DIFF
--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -5,10 +5,12 @@ pass on both of them because the library might be used
 [server-side](server-side-installation) or in a browser, so you have
 to be sure that both environments are fine.
 
-* **`npm run test`** - runs the linter and all tests 
+* **`npm run test`** - runs the linter and all tests
 * **`npm run test:unit`** - runs unit tests
-* **`npm run test:browser` -** runs karma test runner in browsers,
-prints the results in a console
+* **`npm run test:browser`** - runs tests in **karma** once and closes all open browsers
+* **`npm run test:browser.debug`** - runs test in **karma** only in Chrome until you exit the process. It watches changes in `src` and `test` directories and rebuilds them automatically.
+
+An additional flag for **karma** tests: `-spec`. For example: `npm run test:browser.debug -- --spec=matrix.spec.ts`
 
 ## Linting
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -5,12 +5,10 @@ pass on both of them because the library might be used
 [server-side](server-side-installation) or in a browser, so you have
 to be sure that both environments are fine.
 
-* **`npm run test`** - runs the linter and all tests
+* **`npm run test`** - runs the linter and all tests 
 * **`npm run test:unit`** - runs unit tests
-* **`npm run test:browser`** - runs tests in **karma** once and closes all open browsers
-* **`npm run test:browser.debug`** - runs test in **karma** only in Chrome until you exit the process. It watches changes in `src` and `test` directories and rebuilds them automatically.
-
-An additional flag for **karma** tests: `-spec`. For example: `npm run test:browser.debug -- --spec=matrix.spec.ts`
+* **`npm run test:browser` -** runs karma test runner in browsers,
+prints the results in a console
 
 ## Linting
 

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -3168,7 +3168,7 @@ export class HyperFormula implements TypedEmitter {
    *
    * ```
    *
-   * @category Helper
+   * @category Helpers
    */
   public numberToDateTime(val: number): DateTime {
     return this._evaluator.dateHelper.numberToSimpleDateTime(val)
@@ -3189,7 +3189,7 @@ export class HyperFormula implements TypedEmitter {
    * const dateFromNumber = hfInstance.numberToDate(43845);
    * ```
    *
-   * @category Helper
+   * @category Helpers
    */
   public numberToDate(val: number): DateTime {
     return this._evaluator.dateHelper.numberToSimpleDate(val)
@@ -3209,7 +3209,7 @@ export class HyperFormula implements TypedEmitter {
    * const timeFromNumber = hfInstance.numberToTime(1.1);
    * ```
    *
-   * @category Helper
+   * @category Helpers
    */
   public numberToTime(val: number): DateTime {
     return this._evaluator.dateHelper.numberToSimpleTime(val)


### PR DESCRIPTION
### Context
We doubled a category by mistake - `Helper` and `Helpers` in the API reference.
Keep `Helpers` only.