### PR TITLE
Fix moving cells/rows/columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Operation `moveCells` creating cyclic dependencies does not cause losing original formula
+
+### Fixed
+- Fixed `moveCells` behaviour when moving part of a range
+- Fixed `moveCells`/`moveRows` inconsistent behaviour
+- Fixed undo of `moveCells`/`moveRows` operations
+
 ## [0.1.2] - 2020-07-13
 
 ### Fixed

--- a/src/CrudOperations.ts
+++ b/src/CrudOperations.ts
@@ -141,15 +141,15 @@ export class CrudOperations {
     this.ensureItIsPossibleToMoveRows(sheet, startRow, numberOfRows, targetRow)
     this.undoRedo.clearRedoStack()
     this.clipboardOperations.abortCut()
-    this.operations.moveRows(sheet, startRow, numberOfRows, targetRow)
-    this.undoRedo.saveOperation(new MoveRowsUndoEntry(sheet, startRow, numberOfRows, targetRow))
+    const version = this.operations.moveRows(sheet, startRow, numberOfRows, targetRow)
+    this.undoRedo.saveOperation(new MoveRowsUndoEntry(sheet, startRow, numberOfRows, targetRow, version))
   }
 
   public moveColumns(sheet: number, startColumn: number, numberOfColumns: number, targetColumn: number): void {
     this.ensureItIsPossibleToMoveColumns(sheet, startColumn, numberOfColumns, targetColumn)
     this.undoRedo.clearRedoStack()
-    this.operations.moveColumns(sheet, startColumn, numberOfColumns, targetColumn)
-    this.undoRedo.saveOperation(new MoveColumnsUndoEntry(sheet, startColumn, numberOfColumns, targetColumn))
+    const version = this.operations.moveColumns(sheet, startColumn, numberOfColumns, targetColumn)
+    this.undoRedo.saveOperation(new MoveColumnsUndoEntry(sheet, startColumn, numberOfColumns, targetColumn, version))
   }
 
   public cut(sourceLeftCorner: SimpleCellAddress, width: number, height: number): void {

--- a/src/DependencyGraph/DependencyGraph.ts
+++ b/src/DependencyGraph/DependencyGraph.ts
@@ -457,11 +457,9 @@ export class DependencyGraph {
           this.addressMapping.removeCell(targetAddress)
         }
         for (const adjacentNode of this.graph.adjacentNodes(targetVertex)) {
-          if (adjacentNode !== sourceVertex) {
-            sourceVertex = sourceVertex || this.fetchCellOrCreateEmpty(targetAddress)
-            this.graph.addEdge(sourceVertex, adjacentNode)
-            this.graph.markNodeAsSpecialRecentlyChanged(sourceVertex)
-          }
+          sourceVertex = sourceVertex || this.fetchCellOrCreateEmpty(targetAddress)
+          this.graph.addEdge(sourceVertex, adjacentNode)
+          this.graph.markNodeAsSpecialRecentlyChanged(sourceVertex)
         }
         this.removeVertex(targetVertex)
       }
@@ -853,7 +851,7 @@ export class DependencyGraph {
   }
 
   private truncateRanges(span: Span, coordinate: (address: SimpleCellAddress) => number) {
-    const { verticesToRemove, verticesToMerge } = this.rangeMapping.truncateRanges(span, coordinate)
+    const {verticesToRemove, verticesToMerge} = this.rangeMapping.truncateRanges(span, coordinate)
     for (const [existingVertex, mergedVertex] of verticesToMerge) {
       this.mergeRangeVertices(existingVertex, mergedVertex)
     }

--- a/src/DependencyGraph/DependencyGraph.ts
+++ b/src/DependencyGraph/DependencyGraph.ts
@@ -755,6 +755,7 @@ export class DependencyGraph {
 
     const deps = collectDependencies(formula!, this.functionRegistry)
     const absoluteDeps = absolutizeDependencies(deps, address)
+
     return new Set(absoluteDeps.map((dep: CellDependency) => {
       if (dep instanceof AbsoluteCellRange) {
         return this.rangeMapping.fetchRange(dep.start, dep.end)

--- a/src/DependencyGraph/FormulaCellVertex.ts
+++ b/src/DependencyGraph/FormulaCellVertex.ts
@@ -75,6 +75,10 @@ export class FormulaCellVertex {
     }
   }
 
+  public maybeValue(): InternalCellValue | null {
+    return this.cachedCellValue
+  }
+
   public isComputed() {
     return (this.cachedCellValue !== null)
   }

--- a/src/Evaluator.ts
+++ b/src/Evaluator.ts
@@ -92,6 +92,8 @@ export class Evaluator {
           if (vertex instanceof RangeVertex) {
             vertex.clearCache()
           } else if (vertex instanceof FormulaCellVertex) {
+            const address = vertex.getAddress(this.dependencyGraph.lazilyTransformingAstService)
+            this.columnSearch.remove(vertex.maybeValue(), address)
             const error = new CellError(ErrorType.CYCLE)
             vertex.setCellValue(error)
             changes.addChange(error, vertex.address)

--- a/src/Operations.ts
+++ b/src/Operations.ts
@@ -233,7 +233,7 @@ export class Operations {
     return this.sheetMapping.renameSheet(sheetId, newName)
   }
 
-  public moveRows(sheet: number, startRow: number, numberOfRows: number, targetRow: number): void {
+  public moveRows(sheet: number, startRow: number, numberOfRows: number, targetRow: number): number {
     const rowsToAdd = RowsSpan.fromNumberOfRows(sheet, targetRow, numberOfRows)
     this.doAddRows(rowsToAdd)
 
@@ -243,12 +243,13 @@ export class Operations {
 
     const startAddress = simpleCellAddress(sheet, 0, startRow)
     const targetAddress = simpleCellAddress(sheet, 0, targetRow)
-    this.moveCells(startAddress, Number.POSITIVE_INFINITY, numberOfRows, targetAddress)
+    const { version } = this.moveCells(startAddress, Number.POSITIVE_INFINITY, numberOfRows, targetAddress)
     const rowsToRemove = RowsSpan.fromNumberOfRows(sheet, startRow, numberOfRows)
     this.doRemoveRows(rowsToRemove)
+    return version
   }
 
-  public moveColumns(sheet: number, startColumn: number, numberOfColumns: number, targetColumn: number): void {
+  public moveColumns(sheet: number, startColumn: number, numberOfColumns: number, targetColumn: number): number {
     const columnsToAdd = ColumnsSpan.fromNumberOfColumns(sheet, targetColumn, numberOfColumns)
     this.doAddColumns(columnsToAdd)
 
@@ -258,9 +259,10 @@ export class Operations {
 
     const startAddress = simpleCellAddress(sheet, startColumn, 0)
     const targetAddress = simpleCellAddress(sheet, targetColumn, 0)
-    this.moveCells(startAddress, numberOfColumns, Number.POSITIVE_INFINITY, targetAddress)
+    const { version } = this.moveCells(startAddress, numberOfColumns, Number.POSITIVE_INFINITY, targetAddress)
     const columnsToRemove = ColumnsSpan.fromNumberOfColumns(sheet, startColumn, numberOfColumns)
     this.doRemoveColumns(columnsToRemove)
+    return version
   }
 
   public moveCells(sourceLeftCorner: SimpleCellAddress, width: number, height: number, destinationLeftCorner: SimpleCellAddress): MoveCellsResult {

--- a/src/Operations.ts
+++ b/src/Operations.ts
@@ -235,6 +235,8 @@ export class Operations {
 
   public moveRows(sheet: number, startRow: number, numberOfRows: number, targetRow: number): number {
     const rowsToAdd = RowsSpan.fromNumberOfRows(sheet, targetRow, numberOfRows)
+    this.lazilyTransformingAstService.beginCombinedMode(sheet)
+
     this.doAddRows(rowsToAdd)
 
     if (targetRow < startRow) {
@@ -243,14 +245,17 @@ export class Operations {
 
     const startAddress = simpleCellAddress(sheet, 0, startRow)
     const targetAddress = simpleCellAddress(sheet, 0, targetRow)
-    const { version } = this.moveCells(startAddress, Number.POSITIVE_INFINITY, numberOfRows, targetAddress)
+    this.moveCells(startAddress, Number.POSITIVE_INFINITY, numberOfRows, targetAddress)
     const rowsToRemove = RowsSpan.fromNumberOfRows(sheet, startRow, numberOfRows)
     this.doRemoveRows(rowsToRemove)
-    return version
+
+    return this.lazilyTransformingAstService.commitCombinedMode()
   }
 
   public moveColumns(sheet: number, startColumn: number, numberOfColumns: number, targetColumn: number): number {
     const columnsToAdd = ColumnsSpan.fromNumberOfColumns(sheet, targetColumn, numberOfColumns)
+    this.lazilyTransformingAstService.beginCombinedMode(sheet)
+
     this.doAddColumns(columnsToAdd)
 
     if (targetColumn < startColumn) {
@@ -259,10 +264,11 @@ export class Operations {
 
     const startAddress = simpleCellAddress(sheet, startColumn, 0)
     const targetAddress = simpleCellAddress(sheet, targetColumn, 0)
-    const { version } = this.moveCells(startAddress, numberOfColumns, Number.POSITIVE_INFINITY, targetAddress)
+    this.moveCells(startAddress, numberOfColumns, Number.POSITIVE_INFINITY, targetAddress)
     const columnsToRemove = ColumnsSpan.fromNumberOfColumns(sheet, startColumn, numberOfColumns)
     this.doRemoveColumns(columnsToRemove)
-    return version
+
+    return this.lazilyTransformingAstService.commitCombinedMode()
   }
 
   public moveCells(sourceLeftCorner: SimpleCellAddress, width: number, height: number, destinationLeftCorner: SimpleCellAddress): MoveCellsResult {

--- a/src/UndoRedo.ts
+++ b/src/UndoRedo.ts
@@ -56,6 +56,9 @@ export class SetSheetContentUndoEntry {
 }
 
 export class MoveRowsUndoEntry {
+  public readonly undoStart: number
+  public readonly undoEnd: number
+
   constructor(
     public readonly sheet: number,
     public readonly startRow: number,
@@ -63,10 +66,15 @@ export class MoveRowsUndoEntry {
     public readonly targetRow: number,
     public readonly version: number,
   ) {
+    this.undoStart = this.startRow < this.targetRow ? this.targetRow - this.numberOfRows : this.targetRow
+    this.undoEnd = this.startRow > this.targetRow ? this.startRow + this.numberOfRows : this.startRow
   }
 }
 
 export class MoveColumnsUndoEntry {
+  public readonly undoStart: number
+  public readonly undoEnd: number
+
   constructor(
     public readonly sheet: number,
     public readonly startColumn: number,
@@ -74,6 +82,8 @@ export class MoveColumnsUndoEntry {
     public readonly targetColumn: number,
     public readonly version: number,
   ) {
+    this.undoStart = this.startColumn < this.targetColumn ? this.targetColumn - this.numberOfColumns : this.targetColumn
+    this.undoEnd = this.startColumn > this.targetColumn ? this.startColumn + this.numberOfColumns : this.startColumn
   }
 }
 
@@ -399,13 +409,13 @@ export class UndoRedo {
 
   private undoMoveRows(operation: MoveRowsUndoEntry) {
     const {sheet} = operation
-    this.operations.moveRows(sheet, operation.targetRow - operation.numberOfRows, operation.numberOfRows, operation.startRow)
+    this.operations.moveRows(sheet, operation.undoStart, operation.numberOfRows, operation.undoEnd)
     this.restoreOldDataFromVersion(operation.version - 1)
   }
 
   private undoMoveColumns(operation: MoveColumnsUndoEntry) {
     const {sheet} = operation
-    this.operations.moveColumns(sheet, operation.targetColumn - operation.numberOfColumns, operation.numberOfColumns, operation.startColumn)
+    this.operations.moveColumns(sheet, operation.undoStart, operation.numberOfColumns, operation.undoEnd)
     this.restoreOldDataFromVersion(operation.version - 1)
   }
 

--- a/src/UndoRedo.ts
+++ b/src/UndoRedo.ts
@@ -61,6 +61,7 @@ export class MoveRowsUndoEntry {
     public readonly startRow: number,
     public readonly numberOfRows: number,
     public readonly targetRow: number,
+    public readonly version: number,
   ) {
   }
 }
@@ -71,6 +72,7 @@ export class MoveColumnsUndoEntry {
     public readonly startColumn: number,
     public readonly numberOfColumns: number,
     public readonly targetColumn: number,
+    public readonly version: number,
   ) {
   }
 }
@@ -398,11 +400,13 @@ export class UndoRedo {
   private undoMoveRows(operation: MoveRowsUndoEntry) {
     const {sheet} = operation
     this.operations.moveRows(sheet, operation.targetRow - operation.numberOfRows, operation.numberOfRows, operation.startRow)
+    this.restoreOldDataFromVersion(operation.version - 1)
   }
 
   private undoMoveColumns(operation: MoveColumnsUndoEntry) {
     const {sheet} = operation
     this.operations.moveColumns(sheet, operation.targetColumn - operation.numberOfColumns, operation.numberOfColumns, operation.startColumn)
+    this.restoreOldDataFromVersion(operation.version - 1)
   }
 
   public undoMoveCells(operation: MoveCellsUndoEntry): void {

--- a/src/dependencyTransformers/CombinedTransformer.ts
+++ b/src/dependencyTransformers/CombinedTransformer.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright (c) 2020 Handsoncode. All rights reserved.
+ */
+
+import {FormulaTransformer} from './Transformer'
+import {SimpleCellAddress} from '../Cell'
+import {DependencyGraph} from '../DependencyGraph'
+import {Ast, ParserWithCaching} from '../parser'
+
+export class CombinedTransformer implements FormulaTransformer {
+  private readonly transformations: FormulaTransformer[] = []
+
+  constructor(
+    public readonly sheet: number
+  ) {
+  }
+
+  public add(transformation: FormulaTransformer): void {
+    this.transformations.push(transformation)
+  }
+
+  public performEagerTransformations(graph: DependencyGraph, parser: ParserWithCaching): void {
+    this.transformations.forEach(transformation => transformation.performEagerTransformations(graph, parser))
+  }
+
+  public transformSingleAst(ast: Ast, address: SimpleCellAddress): [Ast, SimpleCellAddress] {
+    let [transformedAst, transformedAddress] = [ast, address]
+    this.transformations.forEach(transformation => {
+      [transformedAst, transformedAddress] = transformation.transformSingleAst(transformedAst, transformedAddress)
+    })
+    return [transformedAst, transformedAddress]
+  }
+
+  public isIrreversible() {
+    return true
+  }
+}

--- a/src/dependencyTransformers/MoveCellsTransformer.ts
+++ b/src/dependencyTransformers/MoveCellsTransformer.ts
@@ -59,34 +59,38 @@ export class MoveCellsTransformer extends Transformer {
     return this.transformRange(start, end, formulaAddress)
   }
 
-  private transformAddress<T extends CellAddress | RowAddress | ColumnAddress>(dependencyAddress: T, formulaAddress: SimpleCellAddress): ErrorType.REF | false | T {
+  private transformAddress<T extends CellAddress | RowAddress | ColumnAddress>(dependencyAddress: T, formulaAddress: SimpleCellAddress): T {
     const sourceRange = this.sourceRange
-    const targetRange = sourceRange.shifted(this.toRight, this.toBottom)
 
     if (dependencyAddress instanceof CellAddress) {
       const absoluteDependencyAddress = dependencyAddress.toSimpleCellAddress(formulaAddress)
       if (sourceRange.addressInRange(absoluteDependencyAddress)) { // If dependency is internal, move only absolute dimensions
         return dependencyAddress.shiftAbsoluteDimensions(this.toRight, this.toBottom) as T
-
-      } else if (targetRange.addressInRange(absoluteDependencyAddress)) {  // If dependency is external and moved range overrides it return REF
-        return ErrorType.REF
       }
     }
 
     return dependencyAddress.shiftRelativeDimensions(-this.toRight, -this.toBottom) as T
   }
 
+  private transformRange<T extends CellAddress | RowAddress | ColumnAddress>(start: T,  end: T, formulaAddress: SimpleCellAddress): [T, T] {
+    const sourceRange = this.sourceRange
 
-  private transformRange<T extends CellAddress | RowAddress | ColumnAddress>(start: T,  end: T, formulaAddress: SimpleCellAddress): [T, T] | ErrorType.REF | false {
-    const newStart = this.transformAddress(start, formulaAddress)
-    const newEnd = this.transformAddress(end, formulaAddress)
-    if (newStart === ErrorType.REF || newEnd === ErrorType.REF) {
-      return ErrorType.REF
-    } else if (newStart || newEnd) {
-      return [newStart || start, newEnd || end]
-    } else {
-      return false
+    if (start instanceof CellAddress && end instanceof CellAddress) {
+      const absoluteStart = start.toSimpleCellAddress(formulaAddress)
+      const absoluteEnd = end.toSimpleCellAddress(formulaAddress)
+
+      if (sourceRange.addressInRange(absoluteStart) && sourceRange.addressInRange(absoluteEnd)) {
+        return [
+          start.shiftAbsoluteDimensions(this.toRight, this.toBottom) as T,
+          end.shiftAbsoluteDimensions(this.toRight, this.toBottom) as T
+        ]
+      }
     }
+
+    return [
+      start.shiftRelativeDimensions(-this.toRight, -this.toBottom) as T,
+      end.shiftRelativeDimensions(-this.toRight, -this.toBottom) as T
+    ]
   }
 }
 

--- a/test/cruds/move-columns.spec.ts
+++ b/test/cruds/move-columns.spec.ts
@@ -7,9 +7,10 @@ import {
   colStart,
   detailedError,
   extractColumnRange,
-  extractRange,
   extractReference,
-  extractRowRange, rowEnd, rowStart
+  extractRowRange,
+  rowEnd,
+  rowStart
 } from '../testUtils'
 
 describe('Ensure it is possible to move columns', () => {
@@ -176,27 +177,25 @@ describe('Move columns', () => {
   it('should adjust range', () => {
     const engine = HyperFormula.buildFromArray([
       ['1', '2'],
-      ['',  '=COUNTBLANK(A1:B1)'],
+      ['', '=COUNTBLANK(A1:B1)'],
     ])
 
     engine.moveColumns(0, 1, 1, 3)
-    const range = extractRange(engine, adr('C2'))
 
-    expect(range.start.col).toEqual(0)
-    expect(range.end.col).toEqual(2)
-    expect(engine.getCellValue(adr('C2'))).toEqual(1)
+    expect(engine.getCellFormula(adr('C2'))).toEqual('=COUNTBLANK(A1:A1)')
+    expect(engine.getCellValue(adr('C2'))).toEqual(0)
   })
 
   it('should return changes', () => {
     const engine = HyperFormula.buildFromArray([
-      ['1', '2'],
-      ['',  '=COUNTBLANK(A1:B1)'],
+      ['1', null],
+      ['', '=COUNTBLANK(A1:B1)'],
     ])
 
     const changes = engine.moveColumns(0, 1, 1, 3)
 
     expect(changes.length).toEqual(1)
-    expect(changes).toContainEqual(new ExportedCellChange(simpleCellAddress( 0, 2, 1), 1 ))
+    expect(changes).toContainEqual(new ExportedCellChange(simpleCellAddress(0, 2, 1), 0))
   })
 
   it('should return #CYCLE when moving formula onto referred range', () => {

--- a/test/cruds/move-columns.spec.ts
+++ b/test/cruds/move-columns.spec.ts
@@ -229,6 +229,16 @@ describe('Move columns', () => {
     expect(engine.getCellValue(adr('B1'))).toEqual(detailedError(ErrorType.CYCLE))
     expect(engine.getCellFormula(adr('B1'))).toEqual('=SUM(A1:C1)')
   })
+
+  it('should produce only one history entry', () => {
+    const engine = HyperFormula.buildFromArray([[0, 1, 2, 3]])
+
+    const version = engine.lazilyTransformingAstService.version()
+
+    engine.moveColumns(0, 1, 1, 3)
+
+    expect(engine.lazilyTransformingAstService.version()).toEqual(version + 1)
+  })
 })
 
 describe('Move columns - column ranges', () => {

--- a/test/cruds/move-rows.spec.ts
+++ b/test/cruds/move-rows.spec.ts
@@ -227,6 +227,16 @@ describe('Move rows', () => {
     expect(engine.getCellValue(adr('A2'))).toEqual(detailedError(ErrorType.CYCLE))
     expect(engine.getCellValue(adr('A5'))).toEqual(detailedError(ErrorType.CYCLE))
   })
+
+  it('should produce only one history entry', () => {
+    const engine = HyperFormula.buildFromArray([[0], [1], [2], [3]])
+
+    const version = engine.lazilyTransformingAstService.version()
+
+    engine.moveRows(0, 1, 1, 3)
+
+    expect(engine.lazilyTransformingAstService.version()).toEqual(version + 1)
+  })
 })
 
 describe('Move rows - row ranges', () => {

--- a/test/cruds/move-rows.spec.ts
+++ b/test/cruds/move-rows.spec.ts
@@ -2,10 +2,11 @@ import {ExportedCellChange, HyperFormula, InvalidArgumentsError} from '../../src
 import {ErrorType, simpleCellAddress} from '../../src/Cell'
 import {CellAddress} from '../../src/parser'
 import {
-  adr, colEnd,
+  adr,
+  colEnd,
   colStart,
-  detailedError, extractColumnRange,
-  extractRange,
+  detailedError,
+  extractColumnRange,
   extractReference,
   extractRowRange,
   rowEnd,
@@ -195,23 +196,21 @@ describe('Move rows', () => {
     ])
 
     engine.moveRows(0, 1, 1, 3)
-    const range = extractRange(engine, adr('B3'))
 
-    expect(range.start.row).toEqual(0)
-    expect(range.end.row).toEqual(2)
-    expect(engine.getCellValue(adr('B3'))).toEqual(1)
+    expect(engine.getCellFormula(adr('B3'))).toEqual('=COUNTBLANK(A1:A1)')
+    expect(engine.getCellValue(adr('B3'))).toEqual(0)
   })
 
   it('should return changes', () => {
     const engine = HyperFormula.buildFromArray([
       ['1'],
-      ['2', '=COUNTBLANK(A1:A2)'],
+      [null, '=COUNTBLANK(A1:A2)'],
     ])
 
     const changes = engine.moveRows(0, 1, 1, 3)
 
     expect(changes.length).toEqual(1)
-    expect(changes).toContainEqual(new ExportedCellChange(simpleCellAddress( 0, 1, 2), 1 ))
+    expect(changes).toContainEqual(new ExportedCellChange(simpleCellAddress(0, 1, 2), 0))
   })
 
   it('should return #CYCLE when moving formula onto referred range', () => {

--- a/test/undo-redo.spec.ts
+++ b/test/undo-redo.spec.ts
@@ -171,6 +171,18 @@ describe('Undo - moving rows', () => {
 
     expectEngineToBeTheSameAs(engine, HyperFormula.buildFromArray(sheet))
   })
+
+  it('should restore range', () => {
+    const engine = HyperFormula.buildFromArray([
+      [1, null],
+      [2, '=SUM(A1:A2)'],
+    ])
+    engine.moveRows(0, 1, 1, 3)
+
+    engine.undo()
+
+    expect(engine.getCellFormula(adr('B2'))).toEqual('=SUM(A1:A2)')
+  })
 })
 
 describe('Undo - moving columns', () => {
@@ -184,6 +196,18 @@ describe('Undo - moving columns', () => {
     engine.undo()
 
     expectEngineToBeTheSameAs(engine, HyperFormula.buildFromArray(sheet))
+  })
+
+  it('should restore range', () => {
+    const engine = HyperFormula.buildFromArray([
+      [1, 2],
+      [null, '=SUM(A1:B1)'],
+    ])
+    engine.moveColumns(0, 1, 1, 3)
+
+    engine.undo()
+
+    expect(engine.getCellFormula(adr('B2'))).toEqual('=SUM(A1:B1)')
   })
 })
 

--- a/test/undo-redo.spec.ts
+++ b/test/undo-redo.spec.ts
@@ -160,13 +160,21 @@ describe('Undo - adding rows', () => {
 describe('Undo - moving rows', () => {
   it('works', () => {
     const sheet = [
-      ['1'],
-      ['2'],
-      ['3'], // move first row before this one
+      [0], [1], [2], [3], [4], [5], [6], [7],
     ]
     const engine = HyperFormula.buildFromArray(sheet)
-    engine.moveRows(0, 0, 1, 2)
+    engine.moveRows(0, 1, 3, 7)
+    engine.undo()
 
+    expectEngineToBeTheSameAs(engine, HyperFormula.buildFromArray(sheet))
+  })
+
+  it('works in both directions', () => {
+    const sheet = [
+      [0], [1], [2], [3], [4], [5], [6], [7],
+    ]
+    const engine = HyperFormula.buildFromArray(sheet)
+    engine.moveRows(0, 4, 3, 2)
     engine.undo()
 
     expectEngineToBeTheSameAs(engine, HyperFormula.buildFromArray(sheet))
@@ -178,7 +186,18 @@ describe('Undo - moving rows', () => {
       [2, '=SUM(A1:A2)'],
     ])
     engine.moveRows(0, 1, 1, 3)
+    engine.undo()
 
+    expect(engine.getCellFormula(adr('B2'))).toEqual('=SUM(A1:A2)')
+  })
+
+  it('should restore range when moving other way', () => {
+    const engine = HyperFormula.buildFromArray([
+      [1, null],
+      [2, '=SUM(A1:A2)'],
+    ])
+
+    engine.moveRows(0, 2, 1, 1)
     engine.undo()
 
     expect(engine.getCellFormula(adr('B2'))).toEqual('=SUM(A1:A2)')
@@ -188,11 +207,21 @@ describe('Undo - moving rows', () => {
 describe('Undo - moving columns', () => {
   it('works', () => {
     const sheet = [
-      ['1', '2', '3'],
+      [0, 1, 2, 3, 4, 5, 6, 7],
     ]
     const engine = HyperFormula.buildFromArray(sheet)
-    engine.moveColumns(0, 0, 1, 2)
+    engine.moveColumns(0, 1, 3, 7)
+    engine.undo()
 
+    expectEngineToBeTheSameAs(engine, HyperFormula.buildFromArray(sheet))
+  })
+
+  it('works in both directions', () => {
+    const sheet = [
+      [0, 1, 2, 3, 4, 5, 6, 7],
+    ]
+    const engine = HyperFormula.buildFromArray(sheet)
+    engine.moveColumns(0, 4, 3, 2)
     engine.undo()
 
     expectEngineToBeTheSameAs(engine, HyperFormula.buildFromArray(sheet))
@@ -204,7 +233,18 @@ describe('Undo - moving columns', () => {
       [null, '=SUM(A1:B1)'],
     ])
     engine.moveColumns(0, 1, 1, 3)
+    engine.undo()
 
+    expect(engine.getCellFormula(adr('B2'))).toEqual('=SUM(A1:B1)')
+  })
+
+  it('should restore range when moving to left', () => {
+    const engine = HyperFormula.buildFromArray([
+      [1, 2],
+      [null, '=SUM(A1:B1)'],
+    ])
+
+    engine.moveColumns(0, 2, 1, 1)
     engine.undo()
 
     expect(engine.getCellFormula(adr('B2'))).toEqual('=SUM(A1:B1)')


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Fixes several bugs caused by inconsistent behavior of `moveCells` operation.

- Moving cells with part of a range caused inconsistent state and runtime exception
- Moving rows/columns were also affected as this operations consist of three others (`addRows`, `moveCells`, `removeRows`)
- Undoing `moveCells`/`moveRows` sometimes caused wrong engine state

Circular dependencies that may occur after moving cells are now handled without loosing original formula.

```typescript
const engine = HyperFormula.buildFromArray([
      ['=B1', '1'],
])
engine.moveCells(adr('A1'), 1, 1, adr('B1'))

const formula = engine.getCellFormula(adr('B1')) // '=B1',     before: '=#REF!'
const value = engine.getCellValue(adr('B1'))     // '#CYCLE!', before: '#REF!'
```

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation,
- [x] I described the modification in the CHANGELOG.md file.