### PR TITLE
Fix undo of irreversible operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed undo of `moveColumns`/`moveRows` operations. (#479)
 - Fixed name-collision issue in translations.
 - Fixed bug in concatenation + nullValue. (#495)
+- Fixed bug when undoing irreversible operation (#502)
 
 ## [0.1.3] - 2020-07-21
 

--- a/src/LazilyTransformingAstService.ts
+++ b/src/LazilyTransformingAstService.ts
@@ -57,6 +57,7 @@ export class LazilyTransformingAstService {
       const transformation = this.transformations[v]
       if (transformation.isIrreversible()) {
         this.undoRedo!.storeDataForVersion(v, address, this.parser!.computeHashFromAst(ast))
+        this.parser!.rememberNewAst(ast)
       }
 
       const [newAst, newAddress] = transformation.transformSingleAst(ast, address)

--- a/test/undo-redo.spec.ts
+++ b/test/undo-redo.spec.ts
@@ -889,6 +889,16 @@ describe('Undo', () => {
 
     expect(engine.isThereSomethingToUndo()).toBe(true)
   })
+
+  it('restore AST after irreversible operation', () => {
+    const engine = HyperFormula.buildFromArray([])
+    engine.setCellContents(adr('E1'), '=SUM(A1:C1)')
+    engine.addColumns(0, [3, 1])
+    engine.removeColumns(0, [0, 1])
+
+    expect(() => engine.undo()).not.toThrowError()
+    expect(engine.getCellFormula(adr('F1'))).toEqual('=SUM(A1:C1)')
+  })
 })
 
 describe('UndoRedo', () => {
@@ -1289,7 +1299,6 @@ describe('Redo - renaming sheet', () => {
     expect(engine.isThereSomethingToRedo()).toBe(false)
   })
 })
-
 
 describe('Redo - clearing sheet', () => {
   it('works', () => {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

We need to remember previous version of AST before performing irreversible operations, such as removing columns, in order to undo it.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #502 
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation,
- [ ] I described the modification in the CHANGELOG.md file.