### PR TITLE
Update GH Actions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598 # https://github.com/actions/checkout/releases/tag/v2.0.0
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@83c9f7a7df54d6b57455f7c57ac414f2ae5fb8de # https://github.com/actions/setup-node/releases/tag/v1.4.1
+        uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598 # https://github.com/actions/checkout/releases/tag/v2.0.0
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@83c9f7a7df54d6b57455f7c57ac414f2ae5fb8de # https://github.com/actions/setup-node/releases/tag/v1.4.1
+        uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598 # https://github.com/actions/checkout/releases/tag/v2.0.0
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@83c9f7a7df54d6b57455f7c57ac414f2ae5fb8de # https://github.com/actions/setup-node/releases/tag/v1.4.1
+        uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598 # https://github.com/actions/checkout/releases/tag/v2.0.0
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@83c9f7a7df54d6b57455f7c57ac414f2ae5fb8de # https://github.com/actions/setup-node/releases/tag/v1.4.1
+        uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598 # https://github.com/actions/checkout/releases/tag/v2.0.0
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@83c9f7a7df54d6b57455f7c57ac414f2ae5fb8de # https://github.com/actions/setup-node/releases/tag/v1.4.1
+        uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Due to some deprecations in GitHub Actions https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ we have to update `setup-node` action to v1.4.4 https://github.com/actions/setup-node/releases/tag/v1.4.4 that is using newer `@actions/core` package https://github.com/actions/setup-node/pull/201

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
If CI pass it's ok

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)
- [x] Chore

### Related issue(s):
1.  https://github.com/handsontable/hyperformula/pull/571/checks?check_run_id=1411526035
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation,
- [ ] I described the modification in the CHANGELOG.md file.