### PR TITLE
Optional gpujs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- GPU.js constructor needs to be provided directly to engine configuration. (#355)
+
 ### Added
 - Added support for row and column reordering. (#343)
 - Added ability to fallback to plain CPU implementation for functions that uses GPU.js (#355)

--- a/docs/guide/enabling-gpu-acceleration.md
+++ b/docs/guide/enabling-gpu-acceleration.md
@@ -1,0 +1,19 @@
+# Enabling GPU acceleration.
+
+Currently, GPU.js uses ES6 features and does not provide proper ES5 package. 
+Therefore, to allow the engine to run on browsers like Internet Explorer, it is not bundled with the engine.
+
+In order to take advantage of the GPU acceleration, the GPU.js constructor has to be passed to the engine configuration 
+(supported version of GPU.js is 2.3.0):
+
+```javascript
+import GPU from 'gpu.js'
+
+// define options 
+const options = {
+    gpujs: GPU.GPU ?? GPU
+};
+
+// call the static method to build a new instance
+const hfInstance = HyperFormula.buildEmpty(options);
+```

--- a/docs/guide/known-limitations.md
+++ b/docs/guide/known-limitations.md
@@ -10,8 +10,8 @@ market (~450 functions on average).
 culture-insensitive strings. HyperFormula requires the full
 International Components for Unicode (ICU) to be supported.
 [Learn more](https://nodejs.org/api/intl.html#intl_embed_the_entire_icu_full_icu)
-* GPU acceleration is used only by matrix functions: MMULT,
-TRANSPOSE, MEDIANPOOL, MAXPOOL.
+* GPU acceleration is used only by matrix functions: MMULT, MEDIANPOOL, MAXPOOL.
+* GPU.js works only in browsers that support ES6. [Learn more](enabling-gpu-acceleration.md)
 * Sorting and filtering are not natively supported. However,
 we simulate sorting using the move operations.
 * Multiple workbooks are not supported. One instance of HyperFormula

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -89,6 +89,8 @@ the bigger the performance gain.
 **For small data sets, the difference between the CPU and GPU is
 non-significant.**
 
+[See how to enable GPU acceleration &#8594;](enabling-gpu-acceleration.md)
+
 ## Benchmarks
 
 HyperFormula's performance has been tested on different devices,

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "ts-node": "^8.0.1",
     "typedoc": "^0.17.3",
     "typedoc-plugin-markdown": "^2.2.17",
-    "typescript": "^3.2",
+    "typescript": "^3.8",
     "vuepress": "^1.3.1",
     "vuepress-plugin-clean-urls": "^1.1.1",
     "weak-napi": "^2.0.2",

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -20,11 +20,11 @@ import {Maybe} from './Maybe'
 import {ParserConfig} from './parser/ParserConfig'
 import {checkLicenseKeyValidity, LicenseKeyValidityState} from './helpers/licenseKeyValidator'
 import {FunctionPluginDefinition} from './interpreter'
-import GPU from 'gpu.js'
+import type { GPU } from 'gpu.js'
 
-type GPUMode = 'gpu' | 'cpu' | 'dev' | 'fallback'
+type GPUMode = 'gpu' | 'cpu' | 'dev'
 
-const PossibleGPUModeString: GPUMode[] = ['gpu', 'cpu', 'dev', 'fallback']
+const PossibleGPUModeString: GPUMode[] = ['gpu', 'cpu', 'dev']
 
 export interface ConfigParams {
   /**
@@ -145,6 +145,10 @@ export interface ConfigParams {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   functionPlugins: any[],
+  /**
+   * TODO
+   */
+  gpujs?: typeof GPU,
   /**
    * Allows to set GPU or CPU for use in matrix calculations.
    * When set to 'gpu' it will try to use GPU for matrix calculations. Setting it to 'cpu' will force CPU usage.
@@ -390,6 +394,7 @@ export class Config implements ConfigParams, ParserConfig {
     language: 'enGB',
     licenseKey: '',
     functionPlugins: [],
+    gpujs: undefined,
     gpuMode: 'gpu',
     leapYear1900: false,
     smartRounding: true,
@@ -441,6 +446,8 @@ export class Config implements ConfigParams, ParserConfig {
   /** @inheritDoc */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public readonly functionPlugins: FunctionPluginDefinition[]
+  /** @inheritDoc */
+  public readonly gpujs?: typeof GPU
   /** @inheritDoc */
   public readonly gpuMode: GPUMode
   /** @inheritDoc */
@@ -530,6 +537,7 @@ export class Config implements ConfigParams, ParserConfig {
       language,
       licenseKey,
       functionPlugins,
+      gpujs,
       gpuMode,
       ignorePunctuation,
       leapYear1900,
@@ -572,6 +580,7 @@ export class Config implements ConfigParams, ParserConfig {
     this.thousandSeparator = this.valueFromParam(thousandSeparator, ['', ',', ' ', '.'], 'thousandSeparator')
     this.localeLang = this.valueFromParam(localeLang, 'string', 'localeLang')
     this.functionPlugins = functionPlugins ?? Config.defaultConfig.functionPlugins
+    this.gpujs = gpujs ?? Config.defaultConfig.gpujs
     this.gpuMode = this.valueFromParam(gpuMode, PossibleGPUModeString, 'gpuMode')
     this.smartRounding = this.valueFromParam(smartRounding, 'boolean', 'smartRounding')
     this.matrixDetection = this.valueFromParam(matrixDetection, 'boolean', 'matrixDetection')
@@ -615,10 +624,6 @@ export class Config implements ConfigParams, ParserConfig {
       {value: this.functionArgSeparator, name: 'functionArgSeparator'},
       {value: this.thousandSeparator, name: 'thousandSeparator'}
     )
-
-    if (GPU === undefined) {
-      this.gpuMode = 'fallback'
-    }
   }
 
   public getConfig(): ConfigParams { //TODO: avoid pollution

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -146,7 +146,11 @@ export interface ConfigParams {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   functionPlugins: any[],
   /**
-   * TODO
+   * A GPU.js constructor used by matrix functions. When not provided, plain cpu implementation will be used.
+   *
+   * @default undefined
+   *
+   * @category Engine
    */
   gpujs?: typeof GPU,
   /**

--- a/src/interpreter/plugin/MatrixPlugin.ts
+++ b/src/interpreter/plugin/MatrixPlugin.ts
@@ -62,7 +62,7 @@ export class MatrixPlugin extends FunctionPlugin {
 
   constructor(interpreter: Interpreter) {
     super(interpreter)
-    if (this.config.gpuMode === 'fallback') {
+    if (this.config.gpujs === undefined) {
       this.createKernel = this.createCpuKernel
     } else {
       this.createKernel = this.createGpuJsKernel

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -96,7 +96,7 @@ describe('Config', () => {
     expect(() => new Config({dateFormats: {}})).toThrowError('Expected value of type: array for config parameter: dateFormats')
     // eslint-disable-next-line
     // @ts-ignore
-    expect(() => new Config({gpuMode: 'abcd'})).toThrowError('Expected one of \'gpu\' \'cpu\' \'dev\' \'fallback\' for config parameter: gpuMode')
+    expect(() => new Config({gpuMode: 'abcd'})).toThrowError('Expected one of \'gpu\' \'cpu\' \'dev\' for config parameter: gpuMode')
     // eslint-disable-next-line
     // @ts-ignore
     expect(() => new Config({caseFirst: 'abcd'})).toThrowError('Expected one of \'upper\' \'lower\' \'false\' for config parameter: caseFirst')

--- a/test/interpreter/matrix-plugin.spec.ts
+++ b/test/interpreter/matrix-plugin.spec.ts
@@ -4,6 +4,7 @@ import {ErrorMessage} from '../../src/error-message'
 import {MatrixPlugin} from '../../src/interpreter/plugin/MatrixPlugin'
 import {adr, detailedError} from '../testUtils'
 import {ConfigParams} from '../../src/Config'
+import GPU from 'gpu.js'
 
 describe('Matrix plugin', () => {
   beforeAll(() => {
@@ -210,9 +211,9 @@ describe('Matrix plugin', () => {
     })
   }
 
-  describe('GPU.js', () => sharedExamples({gpuMode: 'cpu'}))
+  describe('GPU.js', () => sharedExamples({gpujs: GPU.GPU ?? GPU, gpuMode: 'cpu'}))
 
-  describe('CPU fallback', () => sharedExamples({gpuMode: 'fallback'}))
+  describe('CPU fallback', () => sharedExamples({}))
 })
 
 describe('Function TRANSPOSE', () => {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Import only `gpu.js` types in order to not include it in bundles.
Constructor of `gpu.js` needs to be passed to engine config in order to use gpu acceleration.

Also: removed `TRANSPOSE` from list of functions that take advantage of gpu.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #355 
2. #330
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation,
- [x] I described the modification in the CHANGELOG.md file.