### PR TITLE
Copy paste range out of scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed a bug with serialization of some addresses after CRUDs. (#587)
 - Fixed a bug with MEDIAN function implementation. (#601)
+- Fixed a bug with copy-paste operation that could cause out of scope references (#591)
 
 ## [0.4.0] - 2020-12-17
 

--- a/src/CrudOperations.ts
+++ b/src/CrudOperations.ts
@@ -298,8 +298,8 @@ export class CrudOperations {
     this.testRowOrderForMatrices(sheetId, rowMapping)
     this.undoRedo.clearRedoStack()
     this.clipboardOperations.abortCut()
-    this.operations.setRowOrder(sheetId, rowMapping)
-    this.undoRedo.saveOperation(new SetRowOrderUndoEntry(sheetId, rowMapping))
+    const oldContent = this.operations.setRowOrder(sheetId, rowMapping)
+    this.undoRedo.saveOperation(new SetRowOrderUndoEntry(sheetId, rowMapping, oldContent))
   }
 
   public validateSwapRowIndexes(sheetId: number, rowMapping: [number, number][]): void {
@@ -326,8 +326,8 @@ export class CrudOperations {
     this.testColumnOrderForMatrices(sheetId, columnMapping)
     this.undoRedo.clearRedoStack()
     this.clipboardOperations.abortCut()
-    this.operations.setColumnOrder(sheetId, columnMapping)
-    this.undoRedo.saveOperation(new SetColumnOrderUndoEntry(sheetId, columnMapping))
+    const oldContent = this.operations.setColumnOrder(sheetId, columnMapping)
+    this.undoRedo.saveOperation(new SetColumnOrderUndoEntry(sheetId, columnMapping, oldContent))
   }
 
   public validateSwapColumnIndexes(sheetId: number, columnMapping: [number, number][]): void {

--- a/src/UndoRedo.ts
+++ b/src/UndoRedo.ts
@@ -49,7 +49,8 @@ export class AddRowsUndoEntry {
 export class SetRowOrderUndoEntry {
   constructor(
     public readonly sheetId: number,
-    public readonly rowMapping: [number, number][]
+    public readonly rowMapping: [number, number][],
+    public readonly oldContent: [SimpleCellAddress, ClipboardCell][]
   ) {
   }
 }
@@ -57,7 +58,8 @@ export class SetRowOrderUndoEntry {
 export class SetColumnOrderUndoEntry {
   constructor(
     public readonly sheetId: number,
-    public readonly columnMapping: [number, number][]
+    public readonly columnMapping: [number, number][],
+    public readonly oldContent: [SimpleCellAddress, ClipboardCell][]
   ) {
   }
 }
@@ -518,13 +520,15 @@ export class UndoRedo {
   }
 
   private undoSetRowOrder(operation: SetRowOrderUndoEntry) {
-    const reverseMap = operation.rowMapping.map(([source, target]) => [target, source] as [number, number])
-    this.operations.setRowOrder(operation.sheetId, reverseMap)
+    for (const [address, clipboardCell] of operation.oldContent) {
+      this.operations.restoreCell(address, clipboardCell)
+    }
   }
 
   private undoSetColumnOrder(operation: SetColumnOrderUndoEntry) {
-    const reverseMap = operation.columnMapping.map(([source, target]) => [target, source] as [number, number])
-    this.operations.setColumnOrder(operation.sheetId, reverseMap)
+    for (const [address, clipboardCell] of operation.oldContent) {
+      this.operations.restoreCell(address, clipboardCell)
+    }
   }
 
   public redo() {

--- a/src/UndoRedo.ts
+++ b/src/UndoRedo.ts
@@ -423,9 +423,7 @@ export class UndoRedo {
   }
 
   private undoPaste(operation: PasteUndoEntry) {
-    for (const [address, clipboardCell] of operation.oldContent) {
-      this.operations.restoreCell(address, clipboardCell)
-    }
+    this.restoreOperationOldContent(operation.oldContent)
     for (const namedExpression of operation.addedGlobalNamedExpressions) {
       this.operations.removeNamedExpression(namedExpression)
     }
@@ -447,9 +445,7 @@ export class UndoRedo {
     this.operations.forceApplyPostponedTransformations()
     this.operations.moveCells(operation.destinationLeftCorner, operation.width, operation.height, operation.sourceLeftCorner)
 
-    for (const [address, clipboardCell] of operation.overwrittenCellsData) {
-      this.operations.restoreCell(address, clipboardCell)
-    }
+    this.restoreOperationOldContent(operation.overwrittenCellsData)
 
     this.restoreOldDataFromVersion(operation.version - 1)
     for (const namedExpression of operation.addedGlobalNamedExpressions) {
@@ -520,13 +516,15 @@ export class UndoRedo {
   }
 
   private undoSetRowOrder(operation: SetRowOrderUndoEntry) {
-    for (const [address, clipboardCell] of operation.oldContent) {
-      this.operations.restoreCell(address, clipboardCell)
-    }
+    this.restoreOperationOldContent(operation.oldContent)
   }
 
   private undoSetColumnOrder(operation: SetColumnOrderUndoEntry) {
-    for (const [address, clipboardCell] of operation.oldContent) {
+    this.restoreOperationOldContent(operation.oldContent)
+  }
+
+  private restoreOperationOldContent(oldContent: [SimpleCellAddress, ClipboardCell][]) {
+    for (const [address, clipboardCell] of oldContent) {
       this.operations.restoreCell(address, clipboardCell)
     }
   }

--- a/src/absolutizeDependencies.ts
+++ b/src/absolutizeDependencies.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2020 Handsoncode. All rights reserved.
  */
 
-import {SimpleCellAddress} from './Cell'
+import {invalidSimpleCellAddress, SimpleCellAddress} from './Cell'
 import {CellDependency} from './CellDependency'
 import {NamedExpressionDependency, RelativeDependency} from './parser'
 import {AbsoluteCellRange} from './AbsoluteCellRange'
@@ -15,7 +15,7 @@ import {AbsoluteCellRange} from './AbsoluteCellRange'
  * @param baseAddress - base address with regard to which make a convertion
  */
 export const absolutizeDependencies = (deps: RelativeDependency[], baseAddress: SimpleCellAddress): CellDependency[] => {
-  return deps.map((dep) => dep.absolutize(baseAddress))
+  return deps.map(dep => dep.absolutize(baseAddress))
 }
 
 export const filterDependenciesOutOfScope = (deps: CellDependency[]) => {
@@ -24,13 +24,9 @@ export const filterDependenciesOutOfScope = (deps: CellDependency[]) => {
       return true
     }
     if (dep instanceof AbsoluteCellRange) {
-      return addressInScope(dep.start) && addressInScope(dep.end)
+      return !(invalidSimpleCellAddress(dep.start) || invalidSimpleCellAddress(dep.end))
     } else {
-      return addressInScope(dep)
+      return !invalidSimpleCellAddress(dep)
     }
   })
-}
-
-function addressInScope(address: SimpleCellAddress) {
-  return address.col >= 0 && address.row >= 0
 }

--- a/src/absolutizeDependencies.ts
+++ b/src/absolutizeDependencies.ts
@@ -5,7 +5,8 @@
 
 import {SimpleCellAddress} from './Cell'
 import {CellDependency} from './CellDependency'
-import {RelativeDependency} from './parser'
+import {NamedExpressionDependency, RelativeDependency} from './parser'
+import {AbsoluteCellRange} from './AbsoluteCellRange'
 
 /**
  * Converts dependencies from maybe relative addressing to absolute addressing.
@@ -15,4 +16,21 @@ import {RelativeDependency} from './parser'
  */
 export const absolutizeDependencies = (deps: RelativeDependency[], baseAddress: SimpleCellAddress): CellDependency[] => {
   return deps.map((dep) => dep.absolutize(baseAddress))
+}
+
+export const filterDependenciesOutOfScope = (deps: CellDependency[]) => {
+  return deps.filter(dep => {
+    if (dep instanceof NamedExpressionDependency) {
+      return true
+    }
+    if (dep instanceof AbsoluteCellRange) {
+      return addressInScope(dep.start) && addressInScope(dep.end)
+    } else {
+      return addressInScope(dep)
+    }
+  })
+}
+
+function addressInScope(address: SimpleCellAddress) {
+  return address.col >= 0 && address.row >= 0
 }

--- a/src/dependencyTransformers/CleanOutOfScopeDependenciesTransformer.ts
+++ b/src/dependencyTransformers/CleanOutOfScopeDependenciesTransformer.ts
@@ -5,8 +5,7 @@
 
 import {Transformer} from './Transformer'
 import {ErrorType, SimpleCellAddress} from '../Cell'
-import {DependencyGraph} from '../DependencyGraph'
-import {CellAddress, ParserWithCaching} from '../parser'
+import {CellAddress} from '../parser'
 import {ColumnAddress} from '../parser/ColumnAddress'
 import {RowAddress} from '../parser/RowAddress'
 
@@ -21,30 +20,23 @@ export class CleanOutOfScopeDependenciesTransformer extends Transformer {
     return true
   }
 
-  public performEagerTransformations(graph: DependencyGraph, _parser: ParserWithCaching): void {
-    for (const node of graph.matrixFormulaNodes()) {
-      const [newAst] = this.transformSingleAst(node.getFormula()!, node.getAddress())
-      node.setFormula(newAst)
-    }
-  }
-
   protected fixNodeAddress(address: SimpleCellAddress): SimpleCellAddress {
     return address
   }
 
   protected transformCellAddress<T extends CellAddress>(dependencyAddress: T, formulaAddress: SimpleCellAddress): ErrorType.REF | false | T {
-    return dependencyAddress.isInScope(formulaAddress) ? false : ErrorType.REF
+    return dependencyAddress.isInvalid(formulaAddress) ? ErrorType.REF : false
   }
 
   protected transformCellRange(start: CellAddress, end: CellAddress, formulaAddress: SimpleCellAddress): ErrorType.REF | false {
-    return start.isInScope(formulaAddress) && end.isInScope(formulaAddress) ? false : ErrorType.REF
+    return start.isInvalid(formulaAddress) || end.isInvalid(formulaAddress) ? ErrorType.REF : false
   }
 
   protected transformColumnRange(start: ColumnAddress, end: ColumnAddress, formulaAddress: SimpleCellAddress): ErrorType.REF | false {
-    return start.isInScope(formulaAddress) && end.isInScope(formulaAddress) ? false : ErrorType.REF
+    return start.isInvalid(formulaAddress) || end.isInvalid(formulaAddress) ? ErrorType.REF : false
   }
 
   protected transformRowRange(start: RowAddress, end: RowAddress, formulaAddress: SimpleCellAddress): ErrorType.REF | false {
-    return start.isInScope(formulaAddress) && end.isInScope(formulaAddress) ? false : ErrorType.REF
+    return start.isInvalid(formulaAddress) || end.isInvalid(formulaAddress) ? ErrorType.REF : false
   }
 }

--- a/src/dependencyTransformers/CleanOutOfScopeDependenciesTransformer.ts
+++ b/src/dependencyTransformers/CleanOutOfScopeDependenciesTransformer.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright (c) 2020 Handsoncode. All rights reserved.
+ */
+
+import {Transformer} from './Transformer'
+import {ErrorType, SimpleCellAddress} from '../Cell'
+import {DependencyGraph} from '../DependencyGraph'
+import {CellAddress, ParserWithCaching} from '../parser'
+import {ColumnAddress} from '../parser/ColumnAddress'
+import {RowAddress} from '../parser/RowAddress'
+
+export class CleanOutOfScopeDependenciesTransformer extends Transformer {
+  constructor(
+    public readonly sheet: number
+  ) {
+    super()
+  }
+
+  public isIrreversible() {
+    return true
+  }
+
+  public performEagerTransformations(graph: DependencyGraph, _parser: ParserWithCaching): void {
+    for (const node of graph.matrixFormulaNodes()) {
+      const [newAst] = this.transformSingleAst(node.getFormula()!, node.getAddress())
+      node.setFormula(newAst)
+    }
+  }
+
+  protected fixNodeAddress(address: SimpleCellAddress): SimpleCellAddress {
+    return address
+  }
+
+  protected transformCellAddress<T extends CellAddress>(dependencyAddress: T, formulaAddress: SimpleCellAddress): ErrorType.REF | false | T {
+    return dependencyAddress.isInScope(formulaAddress) ? false : ErrorType.REF
+  }
+
+  protected transformCellRange(start: CellAddress, end: CellAddress, formulaAddress: SimpleCellAddress): ErrorType.REF | false {
+    return start.isInScope(formulaAddress) && end.isInScope(formulaAddress) ? false : ErrorType.REF
+  }
+
+  protected transformColumnRange(start: ColumnAddress, end: ColumnAddress, formulaAddress: SimpleCellAddress): ErrorType.REF | false {
+    return start.isInScope(formulaAddress) && end.isInScope(formulaAddress) ? false : ErrorType.REF
+  }
+
+  protected transformRowRange(start: RowAddress, end: RowAddress, formulaAddress: SimpleCellAddress): ErrorType.REF | false {
+    return start.isInScope(formulaAddress) && end.isInScope(formulaAddress) ? false : ErrorType.REF
+  }
+}

--- a/src/dependencyTransformers/Transformer.ts
+++ b/src/dependencyTransformers/Transformer.ts
@@ -17,7 +17,6 @@ import {
 import {ColumnRangeAst, RowRangeAst} from '../parser/Ast'
 import {ColumnAddress} from '../parser/ColumnAddress'
 import {RowAddress} from '../parser/RowAddress'
-import {ErrorMessage} from '../error-message'
 
 export interface FormulaTransformer {
   sheet: number,

--- a/src/dependencyTransformers/Transformer.ts
+++ b/src/dependencyTransformers/Transformer.ts
@@ -17,6 +17,7 @@ import {
 import {ColumnRangeAst, RowRangeAst} from '../parser/Ast'
 import {ColumnAddress} from '../parser/ColumnAddress'
 import {RowAddress} from '../parser/RowAddress'
+import {ErrorMessage} from '../error-message'
 
 export interface FormulaTransformer {
   sheet: number,

--- a/src/parser/CellAddress.ts
+++ b/src/parser/CellAddress.ts
@@ -130,6 +130,11 @@ export class CellAddress implements AddressWithColumn, AddressWithRow {
     return new CellAddress(sheet, this.col, this.row, this.type)
   }
 
+  public isInScope(baseAddress: SimpleCellAddress): boolean {
+    const absolute = this.toSimpleCellAddress(baseAddress)
+    return absolute.row >= 0 && absolute.col >= 0
+  }
+
   public shiftRelativeDimensions(toRight: number, toBottom: number): CellAddress {
     const col = this.isColumnAbsolute() ? this.col : this.col + toRight
     const row = this.isRowAbsolute() ? this.row : this.row + toBottom

--- a/src/parser/CellAddress.ts
+++ b/src/parser/CellAddress.ts
@@ -130,9 +130,8 @@ export class CellAddress implements AddressWithColumn, AddressWithRow {
     return new CellAddress(sheet, this.col, this.row, this.type)
   }
 
-  public isInScope(baseAddress: SimpleCellAddress): boolean {
-    const absolute = this.toSimpleCellAddress(baseAddress)
-    return absolute.row >= 0 && absolute.col >= 0
+  public isInvalid(baseAddress: SimpleCellAddress): boolean {
+    return invalidSimpleCellAddress(this.toSimpleCellAddress(baseAddress))
   }
 
   public shiftRelativeDimensions(toRight: number, toBottom: number): CellAddress {

--- a/src/parser/ColumnAddress.ts
+++ b/src/parser/ColumnAddress.ts
@@ -78,8 +78,8 @@ export class ColumnAddress implements AddressWithColumn {
     return new ColumnAddress(sheet, this.col, this.type)
   }
 
-  public isInScope(baseAddress: SimpleCellAddress): boolean {
-    return this.toSimpleColumnAddress(baseAddress).col >= 0
+  public isInvalid(baseAddress: SimpleCellAddress): boolean {
+    return this.toSimpleColumnAddress(baseAddress).col < 0
   }
 
   public hash(withSheet: boolean): string {

--- a/src/parser/ColumnAddress.ts
+++ b/src/parser/ColumnAddress.ts
@@ -78,6 +78,10 @@ export class ColumnAddress implements AddressWithColumn {
     return new ColumnAddress(sheet, this.col, this.type)
   }
 
+  public isInScope(baseAddress: SimpleCellAddress): boolean {
+    return this.toSimpleColumnAddress(baseAddress).col >= 0
+  }
+
   public hash(withSheet: boolean): string {
     const sheetPart = withSheet && this.sheet !== null ? `#${this.sheet}` : ''
     switch (this.type) {

--- a/src/parser/RowAddress.ts
+++ b/src/parser/RowAddress.ts
@@ -73,8 +73,8 @@ export class RowAddress implements AddressWithRow {
     return new RowAddress(sheet, this.row, this.type)
   }
 
-  public isInScope(baseAddress: SimpleCellAddress): boolean {
-    return this.toSimpleRowAddress(baseAddress).row >= 0
+  public isInvalid(baseAddress: SimpleCellAddress): boolean {
+    return this.toSimpleRowAddress(baseAddress).row < 0
   }
 
   public hash(withSheet: boolean): string {

--- a/src/parser/RowAddress.ts
+++ b/src/parser/RowAddress.ts
@@ -73,6 +73,10 @@ export class RowAddress implements AddressWithRow {
     return new RowAddress(sheet, this.row, this.type)
   }
 
+  public isInScope(baseAddress: SimpleCellAddress): boolean {
+    return this.toSimpleRowAddress(baseAddress).row >= 0
+  }
+
   public hash(withSheet: boolean): string {
     const sheetPart = withSheet && this.sheet !== null ? `#${this.sheet}` : ''
     switch (this.type) {

--- a/test/cruds/copy-paste.spec.ts
+++ b/test/cruds/copy-paste.spec.ts
@@ -190,7 +190,7 @@ describe('Copy - paste integration', () => {
     engine.copy(adr('B2'), 1, 1)
     engine.paste(adr('A1'))
 
-    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.REF, ErrorMessage.BadRef))
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.REF))
     expect(engine.getCellSerialized(adr('A1'))).toEqual('=#REF!')
   })
 
@@ -203,7 +203,7 @@ describe('Copy - paste integration', () => {
     engine.copy(adr('B2'), 1, 1)
     engine.paste(adr('A1'))
 
-    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.REF, ErrorMessage.BadRef))
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.REF))
     expect(engine.getCellSerialized(adr('A1'))).toEqual('=#REF!')
   })
 
@@ -217,8 +217,8 @@ describe('Copy - paste integration', () => {
     engine.copy(adr('C3'), 1, 1)
     engine.paste(adr('B2'))
 
-    expect(engine.getCellValue(adr('B2'))).toEqualError(detailedError(ErrorType.REF, ErrorMessage.BadRef))
-    expect(engine.getCellSerialized(adr('B2'))).toEqual('=#REF!')
+    expect(engine.getCellValue(adr('B2'))).toEqualError(detailedError(ErrorType.REF))
+    expect(engine.getCellSerialized(adr('B2'))).toEqual('=SUM(#REF!)')
   })
 
   it('should return ref when pasted column range is out of scope', () => {
@@ -230,7 +230,7 @@ describe('Copy - paste integration', () => {
     engine.copy(adr('B2'), 1, 1)
     engine.paste(adr('A1'))
 
-    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.REF, ErrorMessage.BadRef))
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.REF))
     expect(engine.getCellSerialized(adr('A1'))).toEqual('=#REF!')
   })
 
@@ -243,7 +243,7 @@ describe('Copy - paste integration', () => {
     engine.copy(adr('B2'), 1, 1)
     engine.paste(adr('A1'))
 
-    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.REF, ErrorMessage.BadRef))
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.REF))
     expect(engine.getCellSerialized(adr('A1'))).toEqual('=#REF!')
   })
 

--- a/test/cruds/copy-paste.spec.ts
+++ b/test/cruds/copy-paste.spec.ts
@@ -203,7 +203,22 @@ describe('Copy - paste integration', () => {
     engine.copy(adr('B2'), 1, 1)
     engine.paste(adr('A1'))
 
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.REF, ErrorMessage.BadRef))
     expect(engine.getCellSerialized(adr('A1'))).toEqual('=#REF!')
+  })
+
+  it('should return ref when pasted range is out of scope 2', () => {
+    const engine = HyperFormula.buildFromArray([
+      [null, null, null],
+      [null, null, null],
+      [null, null, '=SUM(A1:B2)'],
+    ])
+
+    engine.copy(adr('C3'), 1, 1)
+    engine.paste(adr('B2'))
+
+    expect(engine.getCellValue(adr('B2'))).toEqualError(detailedError(ErrorType.REF, ErrorMessage.BadRef))
+    expect(engine.getCellSerialized(adr('B2'))).toEqual('=#REF!')
   })
 
   it('should return ref when pasted column range is out of scope', () => {
@@ -215,6 +230,7 @@ describe('Copy - paste integration', () => {
     engine.copy(adr('B2'), 1, 1)
     engine.paste(adr('A1'))
 
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.REF, ErrorMessage.BadRef))
     expect(engine.getCellSerialized(adr('A1'))).toEqual('=#REF!')
   })
 
@@ -227,6 +243,7 @@ describe('Copy - paste integration', () => {
     engine.copy(adr('B2'), 1, 1)
     engine.paste(adr('A1'))
 
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.REF, ErrorMessage.BadRef))
     expect(engine.getCellSerialized(adr('A1'))).toEqual('=#REF!')
   })
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #591

In order to preserve correctness of undo/redo, functions `setRowOrder` / `setColumnOrder` had to be adjusted in such a way that old content is remebered in the history.


### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #591
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation,
- [x] I described the modification in the CHANGELOG.md file.