### PR TITLE
Fix error names typos in the TSDoc

### DIFF
--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -94,7 +94,7 @@ export class HyperFormula implements TypedEmitter {
 
   /**
    * Contains all available languages to use in registerLanguage.
-   * 
+   *
    * @category Static Properties
    */
   public static languages: Record<string, RawTranslationPackage> = {}
@@ -2088,7 +2088,7 @@ export class HyperFormula implements TypedEmitter {
    *
    * // do an operation, for example remove columns
    * hfInstance.removeColumns(0, [0, 1]);
-   * 
+   *
    * // undo the operation
    * hfInstance.undo();
    *
@@ -2116,7 +2116,7 @@ export class HyperFormula implements TypedEmitter {
    *
    * // do an operation, for example remove columns
    * hfInstance.removeColumns(0, [0, 1]);
-   * 
+   *
    * // undo the operation
    * hfInstance.undo();
    *
@@ -3148,8 +3148,8 @@ export class HyperFormula implements TypedEmitter {
    * @fires [[namedExpressionAdded]] always, unless [[batch]] mode is used
    * @fires [[valuesUpdated]] if recalculation was triggered by this change
    *
-   * @throws [[NamedExpressionNameIsAlreadyTaken]] when the named expression name is not available.
-   * @throws [[NamedExpressionNameIsInvalid]] when the named expression name is not valid
+   * @throws [[NamedExpressionNameIsAlreadyTakenError]] when the named expression name is not available.
+   * @throws [[NamedExpressionNameIsInvalidError]] when the named expression name is not valid
    * @throws [[MatrixFormulasNotSupportedError]] when the named expression formula is a Matrix formula
    * @throws [[NoRelativeAddressesAllowedError]] when the named expression formula contains relative references
    * @throws [[NoSheetWithNameError]] when the given sheet name does not exists
@@ -3337,7 +3337,7 @@ export class HyperFormula implements TypedEmitter {
    *
    * @fires [[valuesUpdated]] if recalculation was triggered by this change
    *
-   * @throws [[NamedExpressionDoesNotExist]] when the given expression does not exist.
+   * @throws [[NamedExpressionDoesNotExistError]] when the given expression does not exist.
    * @throws [[NoSheetWithNameError]] when the given sheet name does not exists
    * @throws [[MatrixFormulasNotSupportedError]] when the named expression formula is a Matrix formula
    * @throws [[NoRelativeAddressesAllowedError]] when the named expression formula contains relative references
@@ -3407,7 +3407,7 @@ export class HyperFormula implements TypedEmitter {
    * @fires [[namedExpressionRemoved]] after the expression was removed
    * @fires [[valuesUpdated]] if recalculation was triggered by this change
    *
-   * @throws [[NamedExpressionDoesNotExist]] when the given expression does not exist.
+   * @throws [[NamedExpressionDoesNotExistError]] when the given expression does not exist.
    * @throws [[NoSheetWithNameError]] when the given sheet name does not exists
    *
    * @example
@@ -3659,7 +3659,7 @@ export class HyperFormula implements TypedEmitter {
    * @example
    * ```js
    * const hfInstance = HyperFormula.buildEmpty();
-   * 
+   *
    * // pass a number to be interpreted as a time
    * // should return {hours: 26, minutes: 24} for this example
    * const timeFromNumber = hfInstance.numberToTime(1.1);


### PR DESCRIPTION
### Context
https://handsontable.github.io/hyperformula/api/classes/hyperformula.html#named-expressions have few errors that are not correctly linked. They were renamed and are no longer correctly recognized. TSDoc had to be updated.

### How has this been tested?
I've built the docs and verified that the errors are linked correctly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. none
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation,
- [ ] I described the modification in the CHANGELOG.md file.