### PR TITLE
Change the hash declaration of a private member to a local weakMap.

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -27,6 +27,7 @@ import {ParserConfig} from './parser/ParserConfig'
 type GPUMode = 'gpu' | 'cpu' | 'dev'
 
 const PossibleGPUModeString: GPUMode[] = ['gpu', 'cpu', 'dev']
+const privatePool: WeakMap<Config, {licenseKeyValidityState: LicenseKeyValidityState}> = new WeakMap()
 
 export interface ConfigParams {
   /**
@@ -494,12 +495,7 @@ export class Config implements ConfigParams, ParserConfig {
   public readonly useRegularExpressions: boolean
   public readonly useWildcards: boolean
   public readonly matchWholeCell: boolean
-  /**
-   * Set automatically based on licenseKey checking result.
-   *
-   * @internal
-   */
-  #licenseKeyValidityState: LicenseKeyValidityState
+
   /**
    * Proxied property to its private counterpart. This makes the property
    * as accessible as the other Config options but without ability to change the value.
@@ -507,7 +503,7 @@ export class Config implements ConfigParams, ParserConfig {
    * @internal
    */
   public get licenseKeyValidityState() {
-    return this.#licenseKeyValidityState
+    return privatePool.get(this)!.licenseKeyValidityState
   }
 
   constructor(
@@ -563,7 +559,6 @@ export class Config implements ConfigParams, ParserConfig {
     this.decimalSeparator = configValueFromParam(decimalSeparator, ['.', ','], 'decimalSeparator')
     this.language = configValueFromParam(language, 'string', 'language')
     this.licenseKey = configValueFromParam(licenseKey, 'string', 'licenseKey')
-    this.#licenseKeyValidityState = checkLicenseKeyValidity(this.licenseKey)
     this.thousandSeparator = configValueFromParam(thousandSeparator, ['', ',', ' ', '.'], 'thousandSeparator')
     this.localeLang = configValueFromParam(localeLang, 'string', 'localeLang')
     this.functionPlugins = functionPlugins ?? Config.defaultConfig.functionPlugins
@@ -607,6 +602,10 @@ export class Config implements ConfigParams, ParserConfig {
       }
     })
     validateNumberToBeAtLeast(this.maxColumns, 'maxColumns', 1)
+
+    privatePool.set(this, {
+      licenseKeyValidityState: checkLicenseKeyValidity(this.licenseKey)
+    })
 
     configCheckIfParametersNotInConflict(
       {value: this.decimalSeparator, name: 'decimalSeparator'},


### PR DESCRIPTION
### Context
Because of https://github.com/handsontable/handsontable/issues/8099 I tried to move the `#licenseKeyValidityState` declaration of https://github.com/handsontable/hyperformula/blob/master/src/Config.ts#L514 to a `WeakMap`, so it wouldn't produce the `#private` entry in the declaration file.

@wojciechczerniak please review

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/8099 
