### PR TITLE
Update changelog with unreleased changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added casting to scalars from non-range arrays. (#663)
 - Added support for range interpolation. (#665)
 - Accepting time in JS Date() objects on the input. (#648)
+- Validation of API arguments types for simple types. (#654)
 
 ### Fixed
 - Fixed an issue with arrays and cruds. (#651)
@@ -47,7 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added two new fired events, for suspending and resuming execution. (#637)
 - Added listing in scopes to `listNamedExpressions` method. (#638)
-- Validation of API arguments types for simple types. (#654)
 
 ### Fixed
 - Fixed issues with scoped named expression. (#646, #641)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Breaking change**: Changed API of many sheet-related methods to take sheetId instead of sheetName as an argument. (#645)
 - **Breaking change**: Removed support for matrix formulas (`{=FORMULA}`) notation. Engine now supports formulas returning array of values (instead of only scalars). (#652)
-- Changed SWITCH function so it takes array as its first argument.
 - **Breaking change**: Removed numeric matrix detection along with matrixDetection and matrixDetectionThreshold config options. (#669)
+- Changed SWITCH function so it takes array as its first argument.
 
 ### Added
 - Added support for array arithmetic. (#628)
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ARRAY_CONSTRAIN function. (#661)
 - Added casting to scalars from non-range arrays. (#663)
 - Added support for range interpolation. (#665)
-- Accepting time in JS Date() objects on the input. (#648)
-- Validation of API arguments types for simple types. (#654)
+- Added support for time in JS `Date()` objects on the input. (#648)
+- Added validation of API argument types for simple types. (#654)
 
 ### Fixed
 - Fixed an issue with arrays and cruds. (#651)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Breaking change**: Changed API of many sheet-related methods to take sheetId instead of sheetName as an argument. (#645)
+- **Breaking change**: Removed support for matrix formulas (`{=FORMULA}`) notation. Engine now supports formulas returning array of values (instead of only scalars). (#652)
+- Changed SWITCH function so it takes array as its first argument.
+- **Breaking change**: Removed numeric matrix detection along with matrixDetection and matrixDetectionThreshold config options. (#669)
+
+### Added
+- Added support for array arithmetic. (#628)
+- Added performance improvements for array handling. (#629)
+- Added ARRAYFORMULA function. (#630)
+- Added FILTER function. (#668)
+- Added ARRAY_CONSTRAIN function. (#661)
+- Added casting to scalars from non-range arrays. (#663)
+- Added support for range interpolation. (#665)
+- Accepting time in JS Date() objects on the input. (#648)
+
+### Fixed
+- Fixed an issue with arrays and cruds. (#651)
+- Fixed an issue with nested namedexpressions. (#679)
+
 ## [0.6.2] - 2021-05-26
 
 ### Changed
@@ -22,29 +42,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.0] - 2021-04-27
 
 ### Changed
-- **Breaking change**: Changed API of many sheet-related methods to take sheetId instead of sheetName as an argument. (#645)
-- **Breaking change**: Removed support for matrix formulas (`{=FORMULA}`) notation. Engine now supports formulas returning array of values (instead of only scalars). (#652)
-- Changed SWITCH function so it takes array as its first argument.
-- **Breaking change**: Removed numeric matrix detection along with matrixDetection and matrixDetectionThreshold config options. (#669)
 - **Breaking change**: Moved `GPU.js` from `dependencies` to `devDependencies` and `optionalDependencies`. (#642)
 
 ### Added
 - Added two new fired events, for suspending and resuming execution. (#637)
 - Added listing in scopes to `listNamedExpressions` method. (#638)
-- Added support for array arithmetic. (#628)
-- Added performance improvements for array handling. (#629)
-- Added ARRAYFORMULA function. (#630)
-- Added FILTER function. (#668)
-- Added ARRAY_CONSTRAIN function. (#661)
-- Added casting to scalars from non-range arrays. (#663)
-- Added support for range interpolation. (#665)
-- Accepting time in JS Date() objects on the input. (#648)
+- Validation of API arguments types for simple types. (#654)
 
 ### Fixed
 - Fixed issues with scoped named expression. (#646, #641)
 - Fixed an issue with losing formating info about DateTime numbers. (#626)
-- Fixed an issue with arrays and cruds. (#651)
-- Fixed an issue with nested namedexpressions. (#679)
 
 ## [0.5.0] - 2021-04-15
 


### PR DESCRIPTION
### Context
Because of a duplicated `0.6.0` section in `CHANGELOG.md` some entries were deleted, then retrieved under a wrong version, this PR aims to fix that.

I'm not sure about #654, as it was added to an already-published `0.6.0` section in https://github.com/handsontable/hyperformula/commit/b5115dcfcdf0d8a9fe1fadeeabc8b0f2e8176b96#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR18, and it looks as if it's still unreleased, is that correct?

### Related issue(s):
1. #675
2. #682