### PR TITLE
Docs: Adding the docs README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `getAllNamedExpressionsSerialized` method. (#680)
 - Added parsing of arrays in formulas (together with respective config options for separators). (#671)
 - Added utility function for filling ranges with source from other range. (#678)
+- Added the documentation README.md file
 
 ### Fixed
 - Fixed an issue with arrays and cruds. (#651)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `getAllNamedExpressionsSerialized` method. (#680)
 - Added parsing of arrays in formulas (together with respective config options for separators). (#671)
 - Added utility function for filling ranges with source from other range. (#678)
-- Added the documentation README.md file
 
 ### Fixed
 - Fixed an issue with arrays and cruds. (#651)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,12 @@
-# HyperFormula docs
+# HyperFormula documentation
 
 HyperFormula comes with a dedicated, regularly-updated documentation portal.
 
-View the docs' latest production version at https://handsontable.github.io/hyperformula/.
+View the documentation's latest production version at https://handsontable.github.io/hyperformula/.
 
-## About HyperFormula docs
+## About HyperFormula documentation
 
-The HyperFormula docs are built with [VuePress](https://vuepress.vuejs.org/), a Vue-powered Static Site Generator.
+The HyperFormula documentation is built with [VuePress](https://vuepress.vuejs.org/), a Vue-powered Static Site Generator.
 
 Our VuePress setup:
 
@@ -15,7 +15,7 @@ Our VuePress setup:
 * Lets us write the docs in Markdown (and use Vue inside Markdown!).
 * [COMING SOON] Versions and deploys the docs together with the software.
 
-## Getting started with HyperFormula docs
+## Getting started with HyperFormula documentation
 
 To start a local HyperFormula docs server:
 
@@ -32,7 +32,7 @@ To start a local HyperFormula docs server:
    ```
 4. In your browser, go to: http://localhost:8080/docs/.
 
-## HyperFormula docs npm scripts
+## HyperFormula documentation npm scripts
 
 From the `hyperformula` directory, you can run the following npm scripts:
 
@@ -47,7 +47,7 @@ From the `hyperformula` directory, you can run the following npm scripts:
 docs                            # All documentation files
 ├── .vuepress                   # All VuePress files
 │   ├── components              # Vue components
-│   ├── dist                    # The docs' output. The docs and the API reference are built into this folder.
+│   ├── dist                    # The docs' output. Both the docs and the API reference are built into this folder.
 │   ├── public                  # Public assets
 │   ├── styles                  # Style-related files
 │   ├── subtheme                # Subtheme files
@@ -55,9 +55,9 @@ docs                            # All documentation files
 │   ├── config.js               # VuePress configuration
 │   ├── enhanceApp.js           # VuePress app-level enhancements
 │   └── highlight.js            # Code highlight configuration
-├── api                         # API reference files, generated automatically from JsDoc. Do not edit!
+├── api                         # The API reference files, generated automatically from JsDoc. Do not edit!
 ├── guide                       # The docs' source files: Markdown content
-├── api-template.md             # API reference welcome page
-├── index.md                    # Docs portal welcome page
+├── api-template.md             # The API reference welcome page
+├── index.md                    # The docs portal welcome page
 └── README.md                   # The file you're looking at right now!
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,63 @@
+# HyperFormula docs
+
+HyperFormula comes with a dedicated, regularly-updated documentation portal.
+
+View the docs' latest production version at https://handsontable.github.io/hyperformula/.
+
+## About HyperFormula docs
+
+The HyperFormula docs are built with [VuePress](https://vuepress.vuejs.org/), a Vue-powered Static Site Generator.
+
+Our VuePress setup:
+
+* Publishes the docs as a sleek, responsive single-page application (SPA).
+* Boasts a great search engine.
+* Lets us write the docs in Markdown (and use Vue inside Markdown!).
+* [COMING SOON] Versions and deploys the docs together with the software.
+
+## Getting started with HyperFormula docs
+
+To start a local HyperFormula docs server:
+
+1. Get the right npm version:
+   * Later than 7.5
+   * Earlier than 16.0
+2. From the `hyperformula` directory, install the docs dependencies:
+    ```bash
+    npm install
+    ```
+3. From the `hyperformula` directory, start your local docs server:
+   ```bash
+   npm run docs:dev
+   ```
+4. In your browser, go to: http://localhost:8080/docs/.
+
+## HyperFormula docs npm scripts
+
+From the `hyperformula` directory, you can run the following npm scripts:
+
+* `npm run docs:dev` - Starts a local docs server at http://localhost:8080/docs/.
+* `npm run docs:api` - Generates the HyperFormula API reference into `/docs/api`.
+* `npm run docs:build` - Builds the docs output into `/docs/.vuepress/dist`.
+* `npm run docs` - Builds both the API reference and the docs output.
+
+## HyperFormula docs directory structure
+
+```bash
+docs                            # All documentation files
+├── .vuepress                   # All VuePress files
+│   ├── components              # Vue components
+│   ├── dist                    # The docs' output. The docs and the API reference are built into this folder.
+│   ├── public                  # Public assets
+│   ├── styles                  # Style-related files
+│   ├── subtheme                # Subtheme files
+│   ├── templates               # HTML templates
+│   ├── config.js               # VuePress configuration
+│   ├── enhanceApp.js           # VuePress app-level enhancements
+│   └── highlight.js            # Code highlight configuration
+├── api                         # API reference files, generated automatically from JsDoc. Do not edit!
+├── guide                       # The docs' source files: Markdown content
+├── api-template.md             # API reference welcome page
+├── index.md                    # Docs portal welcome page
+└── README.md                   # The file you're looking at right now!
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,36 +2,36 @@
 
 HyperFormula comes with a dedicated, regularly-updated documentation portal.
 
-View the documentation's latest production version at https://handsontable.github.io/hyperformula/.
+View the documentation's latest production version at https://handsontable.com/docs/hyperformula.
 
 ## About HyperFormula documentation
 
 The HyperFormula documentation is built with [VuePress](https://vuepress.vuejs.org/), a Vue-powered Static Site Generator.
 
-Our VuePress setup:
-
-* Publishes the docs as a sleek, responsive single-page application (SPA).
-* Boasts a great search engine.
-* Lets us write the docs in Markdown (and use Vue inside Markdown!).
-* Lets us quickly build the docs output onto a local server.
-* [COMING SOON] Versions and deploys the docs together with the software.
+When editing the docs, you can use features described [here](https://vuepress.vuejs.org/guide/markdown.html).
 
 ## Getting started with HyperFormula documentation
 
 To start a local HyperFormula docs server:
 
-1. Get the right npm version:
-   * Later than 7.5
-   * Earlier than 16.0
-2. From the `hyperformula` directory, install the docs dependencies:
+1. Make sure you're running [Node.js](https://nodejs.org/en/) 14+.
+2. From the main `hyperformula` directory, install the docs dependencies:
     ```bash
     npm install
     ```
-3. From the `hyperformula` directory, start your local docs server:
+3. From the main `hyperformula` directory, build HyperFormula:
+   ```bash
+   npm run bundle-all
+   ```   
+4. From the main `hyperformula` directory, generate the API reference:
+   ```bash
+   npm run docs:api
+   ```   
+5. From the main `hyperformula` directory, start your local docs server:
    ```bash
    npm run docs:dev
    ```
-4. In your browser, go to: http://localhost:8080/hyperformula/.
+6. In your browser, go to: http://localhost:8080/hyperformula/.
 
 ## HyperFormula documentation npm scripts
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Our VuePress setup:
 * Publishes the docs as a sleek, responsive single-page application (SPA).
 * Boasts a great search engine.
 * Lets us write the docs in Markdown (and use Vue inside Markdown!).
+* Lets us quickly build the docs output onto a local server.
 * [COMING SOON] Versions and deploys the docs together with the software.
 
 ## Getting started with HyperFormula documentation
@@ -30,13 +31,13 @@ To start a local HyperFormula docs server:
    ```bash
    npm run docs:dev
    ```
-4. In your browser, go to: http://localhost:8080/docs/.
+4. In your browser, go to: http://localhost:8080/hyperformula/.
 
 ## HyperFormula documentation npm scripts
 
 From the `hyperformula` directory, you can run the following npm scripts:
 
-* `npm run docs:dev` - Starts a local docs server at http://localhost:8080/docs/.
+* `npm run docs:dev` - Starts a local docs server at http://localhost:8080/hyperformula/.
 * `npm run docs:api` - Generates the HyperFormula API reference into `/docs/api`.
 * `npm run docs:build` - Builds the docs output into `/docs/.vuepress/dist`.
 * `npm run docs` - Builds both the API reference and the docs output.
@@ -47,7 +48,7 @@ From the `hyperformula` directory, you can run the following npm scripts:
 docs                            # All documentation files
 ├── .vuepress                   # All VuePress files
 │   ├── components              # Vue components
-│   ├── dist                    # The docs' output. Both the docs and the API reference are built into this folder.
+│   ├── dist                    # The docs output. Both the docs and the API reference are built into this folder.
 │   ├── public                  # Public assets
 │   ├── styles                  # Style-related files
 │   ├── subtheme                # Subtheme files
@@ -56,8 +57,8 @@ docs                            # All documentation files
 │   ├── enhanceApp.js           # VuePress app-level enhancements
 │   └── highlight.js            # Code highlight configuration
 ├── api                         # The API reference files, generated automatically from JsDoc. Do not edit!
-├── guide                       # The docs' source files: Markdown content
+├── guide                       # The docs source files: Markdown content
 ├── api-template.md             # The API reference welcome page
-├── index.md                    # The docs portal welcome page
+├── index.md                    # The main docs portal welcome page
 └── README.md                   # The file you're looking at right now!
 ```


### PR DESCRIPTION
- Added a README.md file into the /docs folder: https://github.com/handsontable/hyperformula/blob/feature/issue-695/docs/
- The content structure follows the handsontable docs README.md pattern, can be expanded later on
- Any feedback welcome!
#695 