### PR TITLE
Docs: Updating event descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking change**: Removed support for matrix formulas (`{=FORMULA}`) notation. Engine now supports formulas returning array of values (instead of only scalars). (#652)
 - **Breaking change**: Removed numeric matrix detection along with matrixDetection and matrixDetectionThreshold config options. (#669)
 - Changed SWITCH function so it takes array as its first argument.
+- Changed `on`, `off` and `once` event descriptions in the API reference
 
 ### Added
 - Added support for array arithmetic. (#628)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking change**: Removed support for matrix formulas (`{=FORMULA}`) notation. Engine now supports formulas returning array of values (instead of only scalars). (#652)
 - **Breaking change**: Removed numeric matrix detection along with matrixDetection and matrixDetectionThreshold config options. (#669)
 - Changed SWITCH function so it takes array as its first argument.
-- Changed `on`, `off` and `once` event descriptions in the API reference
 
 ### Added
 - Added support for array arithmetic. (#628)

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -3978,7 +3978,7 @@ export class HyperFormula implements TypedEmitter {
 
   /**
    * Subscribes to an event.
-   * To see all available events, see [[Listeners]].
+   * For the list of all available events, see [[Listeners]].
    * 
    * @param {Event} event the name of the event to subscribe to
    * @param {Listener} listener to be called when event is emitted
@@ -4003,7 +4003,7 @@ export class HyperFormula implements TypedEmitter {
 
   /**
    * Subscribes to an event once.
-   * To see all available events, see [[Listeners]].
+   * For the list of all available events, see [[Listeners]].
    *
    * @param {Event} event the name of the event to subscribe to
    * @param {Listener} listener to be called when event is emitted
@@ -4029,7 +4029,7 @@ export class HyperFormula implements TypedEmitter {
 
   /**
    * Unsubscribes from an event or from all events.
-   * To see all available events, see [[Listeners]].
+   * For the list of all available events, see [[Listeners]].
    *
    * @param {Event} event the name of the event to subscribe to
    * @param {Listener} listener to be called when event is emitted

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -3978,7 +3978,7 @@ export class HyperFormula implements TypedEmitter {
 
   /**
    * Subscribes to an event.
-   * To see available event names, press <kbd>Ctrl</kbd>+<kbd>F</kbd>/<kbd>Cmd</kbd>+<kbd>F</kbd> and search for `fires`.
+   * To see all available events, see [[Listeners]].
    * 
    * @param {Event} event the name of the event to subscribe to
    * @param {Listener} listener to be called when event is emitted
@@ -4003,7 +4003,7 @@ export class HyperFormula implements TypedEmitter {
 
   /**
    * Subscribes to an event once.
-   * To see available event names, press <kbd>Ctrl</kbd>+<kbd>F</kbd>/<kbd>Cmd</kbd>+<kbd>F</kbd> and search for `fires`.
+   * To see all available events, see [[Listeners]].
    *
    * @param {Event} event the name of the event to subscribe to
    * @param {Listener} listener to be called when event is emitted
@@ -4029,7 +4029,7 @@ export class HyperFormula implements TypedEmitter {
 
   /**
    * Unsubscribes from an event or from all events.
-   * To see available event names, press <kbd>Ctrl</kbd>+<kbd>F</kbd>/<kbd>Cmd</kbd>+<kbd>F</kbd> and search for `fires`.
+   * To see all available events, see [[Listeners]].
    *
    * @param {Event} event the name of the event to subscribe to
    * @param {Listener} listener to be called when event is emitted

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -3977,8 +3977,9 @@ export class HyperFormula implements TypedEmitter {
   }
 
   /**
-   * A method that subscribes to an event.
-   *
+   * Subscribes to an event.
+   * To see available event names, press <kbd>Ctrl</kbd>+<kbd>F</kbd>/<kbd>Cmd</kbd>+<kbd>F</kbd> and search for `fires`.
+   * 
    * @param {Event} event the name of the event to subscribe to
    * @param {Listener} listener to be called when event is emitted
    *
@@ -4001,7 +4002,8 @@ export class HyperFormula implements TypedEmitter {
   }
 
   /**
-   * A method that subscribes to an event once.
+   * Subscribes to an event once.
+   * To see available event names, press <kbd>Ctrl</kbd>+<kbd>F</kbd>/<kbd>Cmd</kbd>+<kbd>F</kbd> and search for `fires`.
    *
    * @param {Event} event the name of the event to subscribe to
    * @param {Listener} listener to be called when event is emitted
@@ -4026,7 +4028,8 @@ export class HyperFormula implements TypedEmitter {
   }
 
   /**
-   * A method that unsubscribe from an event or all events.
+   * Unsubscribes from an event or from all events.
+   * To see available event names, press <kbd>Ctrl</kbd>+<kbd>F</kbd>/<kbd>Cmd</kbd>+<kbd>F</kbd> and search for `fires`.
    *
    * @param {Event} event the name of the event to subscribe to
    * @param {Listener} listener to be called when event is emitted


### PR DESCRIPTION
API ref:
- [x] `off`: fixed grammar + added a link to the Event Types section.
- [x] `on`: reworded + added a link to the Event Types section.
- [x] `once`: reworded + added a link to the Event Types section.
#586 