### PR TITLE
Pu/minmax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed handling of arrays for ROWS/COLUMNS functions. (#677)
 - Fixed an issue with nested namedexpressions. (#679)
 - Fixed an issue with matrixDetection + number parsing. (#686)
+- Fixed an issue with MIN/MAX function caches.
 
 ## [0.6.2] - 2021-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed handling of arrays for ROWS/COLUMNS functions. (#677)
 - Fixed an issue with nested namedexpressions. (#679)
 - Fixed an issue with matrixDetection + number parsing. (#686)
-- Fixed an issue with MIN/MAX function caches.
+- Fixed an issue with MIN/MAX function caches. (#711)
 
 ## [0.6.2] - 2021-05-26
 

--- a/src/interpreter/plugin/NumericAggregationPlugin.ts
+++ b/src/interpreter/plugin/NumericAggregationPlugin.ts
@@ -513,7 +513,7 @@ export class NumericAggregationPlugin extends FunctionPlugin implements Function
   }
 
   private doMin(args: Ast[], state: InterpreterState): InternalScalarValue {
-    const value = this.reduce(args, state, Number.POSITIVE_INFINITY, 'MAX',
+    const value = this.reduce(args, state, Number.POSITIVE_INFINITY, 'MIN',
       (left: number, right: number) => Math.min(left, right),
       getRawValue, strictlyNumbers
     )

--- a/test/interpreter/separate-cache.spec.ts
+++ b/test/interpreter/separate-cache.spec.ts
@@ -1,0 +1,17 @@
+import {HyperFormula} from '../../src'
+import {adr} from '../testUtils'
+
+describe('numeric aggreagtion functions', () => {
+  it('should use separate caches', () => {
+    const engine = HyperFormula.buildFromArray([
+      [1, 2, 5, 10, 20],
+      ['=MIN(A1:E1)', '=MAX(A1:E1)', '=SUM(A1:E1)', '=SUMSQ(A1:E1)', '=AVERAGE(A1:E1)'],
+      ['=MIN(A1:E1)', '=MAX(A1:E1)', '=SUM(A1:E1)', '=SUMSQ(A1:E1)', '=AVERAGE(A1:E1)'],
+    ])
+    expect(engine.getCellValue(adr('A3'))).toEqual(1)
+    expect(engine.getCellValue(adr('B3'))).toEqual(20)
+    expect(engine.getCellValue(adr('C3'))).toEqual(38)
+    expect(engine.getCellValue(adr('D3'))).toEqual(530)
+    expect(engine.getCellValue(adr('E3'))).toEqual(7.6)
+  })
+})


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
MIN and MAX were using the same function cache.

```
    const engine = HyperFormula.buildFromArray([[1, 2, 3], ['=MIN(A1:C1)', '=MAX(A1:C1)']])
    expect(engine.getCellValue({col: 1, row: 1, sheet: 0})).toEqual(3) //returns 1
```

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation,
- [x] I described the modification in the CHANGELOG.md file.