### PR TITLE
CellValue inconsistency (#467)

### DIFF
--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -1095,7 +1095,7 @@ export class HyperFormula implements TypedEmitter {
    * ```js
    * hfInstance.undo();
    *
-   * // when there is an action to redo, this will return 'true'
+   * // when there is an action to redo, this returns 'true'
    * const isSomethingToRedo = hfInstance.isThereSomethingToRedo();
    * ```
    *

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -666,7 +666,7 @@ export class HyperFormula implements TypedEmitter {
   }
 
   /**
-   * Returns [[CellValue]] which a serialized content of the cell of a given address either a cell formula, an explicit value, or an error.
+   * Returns [[RawCellContent]] with a serialized content of the cell of a given address: either a cell formula, an explicit value, or an error.
    *
    * @param {SimpleCellAddress} cellAddress - cell coordinates
    *
@@ -760,7 +760,7 @@ export class HyperFormula implements TypedEmitter {
   }
 
   /**
-   * Returns an array of arrays of [[NoErrorCellValue]] with serialized content of cells from [[Sheet]], either a cell formula or an explicit value.
+   * Returns an array of arrays of [[RawCellContent]] with serialized content of cells from [[Sheet]], either a cell formula or an explicit value.
    *
    * @param {SimpleCellAddress} sheetId - sheet ID number
    *
@@ -891,7 +891,7 @@ export class HyperFormula implements TypedEmitter {
   }
 
   /**
-   * Returns formulas or values of all sheets in a form of an object which property keys are strings and values are arrays of arrays of [[CellValue]].
+   * Returns formulas or values of all sheets in a form of an object which property keys are strings and values are arrays of arrays of [[RawCellContent]].
    *
    * @throws [[EvaluationSuspendedError]] when the evaluation is suspended
    *


### PR DESCRIPTION
@wojciechczerniak the screenshot in #467 seems outdated, but I looked through the whole API ref for similar inconsitencies, and found three:
- https://handsontable.github.io/hyperformula/api/classes/hyperformula.html#getsheetserialized
- https://handsontable.github.io/hyperformula/api/classes/hyperformula.html#getallsheetsserialized
- https://handsontable.github.io/hyperformula/api/classes/hyperformula.html#getcellserialized

I changed `CellValue` to `RawCellContent` in three methods' descriptions, to match the TypeScript-generated content.