### PR TITLE
Remove redundant or false throws from tsdocs

### DIFF
--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -1113,7 +1113,6 @@ export class HyperFormula implements TypedEmitter {
    *
    * @param {SimpleCellAddress | SimpleCellRange} address - single cell or block of cells to check
    *
-   * @throws [[NoSheetWithIdError]] when the given sheet ID does not exist
    * @throws [[ExpectedValueOfTypeError]] if any of its basic type argument is of wrong type
    * @throws [[SheetsNotEqual]] if range provided has distinct sheet numbers for start and end
    *
@@ -1831,7 +1830,6 @@ export class HyperFormula implements TypedEmitter {
    * @param {SimpleCellRange} source - range for a moved block
    * @param {SimpleCellAddress} destinationLeftCorner - upper left address of the target cell block
    *
-   * @throws [[NoSheetWithIdError]] when the given sheet ID does not exist
    * @throws [[ExpectedValueOfTypeError]] if destinationLeftCorner, source, or any of basic type arguments are of wrong type
    * @throws [[SheetsNotEqual]] if range provided has distinct sheet numbers for start and end
    *
@@ -2414,7 +2412,6 @@ export class HyperFormula implements TypedEmitter {
    *
    * @category Ranges
    */
-
   public getFillRangeData(source: SimpleCellRange, target: SimpleCellRange): RawCellContent[][] {
     if (!isSimpleCellRange(source)) {
       throw new ExpectedValueOfTypeError('SimpleCellRange', 'source')
@@ -2843,7 +2840,6 @@ export class HyperFormula implements TypedEmitter {
    *
    * @throws [[ExpectedValueOfTypeError]] if address is not [[SimpleCellAddress]] or [[SimpleCellRange]]
    * @throws [[SheetsNotEqual]] if range provided has distinct sheet numbers for start and end
-   *
    * @throws [[NoSheetWithIdError]] when the given sheet ID does not exist
    *
    * @example
@@ -3496,8 +3492,6 @@ export class HyperFormula implements TypedEmitter {
    * @param {number?} scope - scope definition, `sheetId` for local scope or `undefined` for global scope
    *
    * @throws [[ExpectedValueOfTypeError]] if any of its basic type argument is of wrong type
-   * @throws [[NoSheetWithIdError]] if no sheet with given sheetId exists
-   * @throws [[ExpectedValueOfTypeError]] if any of its basic type argument is of wrong type
    *
    * @example
    * ```js
@@ -3713,9 +3707,6 @@ export class HyperFormula implements TypedEmitter {
    * @param {number?} scope - scope definition, `sheetId` for local scope or `undefined` for global scope
    *
    * @throws [[ExpectedValueOfTypeError]] if any of its basic type argument is of wrong type
-   * @throws [[NoSheetWithIdError]] if no sheet with given sheetId exists
-   *
-   * @throws [[ExpectedValueOfTypeError]] if any of its basic type argument is of wrong type
    *
    * @example
    * ```js
@@ -3797,8 +3788,6 @@ export class HyperFormula implements TypedEmitter {
    * @param {string} expressionName - an expression name, case insensitive.
    * @param {number?} scope - scope definition, `sheetId` for local scope or `undefined` for global scope
    *
-   * @throws [[ExpectedValueOfTypeError]] if any of its basic type argument is of wrong type
-   * @throws [[NoSheetWithIdError]] if no sheet with given sheetId exists
    * @throws [[ExpectedValueOfTypeError]] if any of its basic type argument is of wrong type
    *
    * @example


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Functions `isItPossible*` does not throw `NoSheetWithIdError`. Instead they return false.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project,
- [ ] My change requires a change to the documentation,
- [ ] I described the modification in the CHANGELOG.md file.