### PR TITLE
Error origin respecting CRUDs.

### DIFF
--- a/src/BuildEngineFactory.ts
+++ b/src/BuildEngineFactory.ts
@@ -86,7 +86,7 @@ export class BuildEngineFactory {
     lazilyTransformingAstService.undoRedo = crudOperations.undoRedo
     lazilyTransformingAstService.parser = parser
 
-    const exporter = new Exporter(config, namedExpressions, sheetMapping.fetchDisplayName)
+    const exporter = new Exporter(config, namedExpressions, sheetMapping.fetchDisplayName, lazilyTransformingAstService)
     const serialization = new Serialization(dependencyGraph, unparser, config, exporter)
 
     const evaluator = new Evaluator(dependencyGraph, columnSearch, config, stats, dateHelper, numberLiteralHelper, functionRegistry, namedExpressions, serialization)

--- a/src/Cell.ts
+++ b/src/Cell.ts
@@ -3,7 +3,14 @@
  * Copyright (c) 2021 Handsoncode. All rights reserved.
  */
 
-import {CellVertex, FormulaCellVertex, MatrixVertex, ParsingErrorVertex, ValueCellVertex} from './DependencyGraph'
+import {
+  CellVertex,
+  FormulaCellVertex,
+  MatrixVertex,
+  ParsingErrorVertex,
+  ValueCellVertex,
+  Vertex
+} from './DependencyGraph'
 import {ErrorMessage} from './error-message'
 import {
   EmptyValue,
@@ -16,6 +23,7 @@ import {
 import {SimpleRangeValue} from './interpreter/SimpleRangeValue'
 import {CellAddress} from './parser'
 import {AddressWithSheet} from './parser/Address'
+import {FormulaVertex} from './DependencyGraph/FormulaCellVertex'
 
 /**
  * Possible errors returned by our interpreter.
@@ -140,13 +148,13 @@ export class CellError {
   constructor(
     public readonly type: ErrorType,
     public readonly message?: string,
-    public readonly address?: SimpleCellAddress
+    public readonly root?: FormulaVertex
   ) {
   }
 
-  public attachAddress(address: SimpleCellAddress): CellError {
-    if(this.address === undefined) {
-      return new CellError(this.type, this.message, address)
+  public attachRootVertex(vertex: FormulaVertex): CellError {
+    if(this.root === undefined) {
+      return new CellError(this.type, this.message, vertex)
     } else {
       return this
     }

--- a/src/Exporter.ts
+++ b/src/Exporter.ts
@@ -12,6 +12,7 @@ import {EmptyValue, getRawValue, InterpreterValue, isExtendedNumber} from './int
 import {SimpleRangeValue} from './interpreter/SimpleRangeValue'
 import {NamedExpressions} from './NamedExpressions'
 import {SheetIndexMappingFn, simpleCellAddressToString} from './parser/addressRepresentationConverters'
+import {LazilyTransformingAstService} from './LazilyTransformingAstService'
 
 export type ExportedChange = ExportedCellChange | ExportedNamedExpressionChange
 
@@ -55,6 +56,7 @@ export class Exporter implements ChangeExporter<ExportedChange> {
     private readonly config: Config,
     private readonly namedExpressions: NamedExpressions,
     private readonly sheetIndexMapping: SheetIndexMappingFn,
+    private readonly lazilyTransformingService: LazilyTransformingAstService,
   ) {
   }
 
@@ -113,7 +115,7 @@ export class Exporter implements ChangeExporter<ExportedChange> {
 
   private detailedError(error: CellError): DetailedCellError {
     let address = undefined
-    const originAddress = error.address
+    const originAddress = error.root?.getAddress(this.lazilyTransformingService)
     if (originAddress !== undefined) {
       if (originAddress.sheet === NamedExpressions.SHEET_FOR_WORKBOOK_EXPRESSIONS) {
         address = this.namedExpressions.namedExpressionInAddress(originAddress.row)?.displayName

--- a/src/interpreter/InterpreterState.ts
+++ b/src/interpreter/InterpreterState.ts
@@ -4,9 +4,14 @@
  */
 
 import {SimpleCellAddress} from '../Cell'
+import {FormulaVertex} from '../DependencyGraph/FormulaCellVertex'
 
 export class InterpreterState {
-  constructor(public formulaAddress: SimpleCellAddress, public arraysFlag: boolean) {
+  constructor(
+    public formulaAddress: SimpleCellAddress,
+    public arraysFlag: boolean,
+    public formulaVertex?: FormulaVertex,
+  ) {
   }
 }
 

--- a/test/CellValueExporter.spec.ts
+++ b/test/CellValueExporter.spec.ts
@@ -8,14 +8,17 @@ import {EmptyValue} from '../src/interpreter/InterpreterValue'
 import {NamedExpressions} from '../src/NamedExpressions'
 import {SheetIndexMappingFn} from '../src/parser/addressRepresentationConverters'
 import {detailedError} from './testUtils'
+import {LazilyTransformingAstService} from '../src/LazilyTransformingAstService'
+import {EmptyStatistics} from '../src/statistics'
 
 const namedExpressionsMock = {} as NamedExpressions
 const sheetIndexMock = {} as SheetIndexMappingFn
+const lazilyTransforminService = new LazilyTransformingAstService(new EmptyStatistics())
 
 describe( 'rounding', () => {
   it( 'no rounding', () =>{
     const config = new Config({ smartRounding : false })
-    const cellValueExporter = new Exporter(config, namedExpressionsMock, sheetIndexMock)
+    const cellValueExporter = new Exporter(config, namedExpressionsMock, sheetIndexMock, lazilyTransforminService)
     expect(cellValueExporter.exportValue(1.000000000000001)).toBe(1.000000000000001)
     expect(cellValueExporter.exportValue(-1.000000000000001)).toBe(-1.000000000000001)
     expect(cellValueExporter.exportValue(0.000000000000001)).toBe(0.000000000000001)
@@ -29,7 +32,7 @@ describe( 'rounding', () => {
 
   it( 'with rounding', () =>{
     const config = new Config()
-    const cellValueExporter = new Exporter(config, namedExpressionsMock, sheetIndexMock)
+    const cellValueExporter = new Exporter(config, namedExpressionsMock, sheetIndexMock, lazilyTransforminService)
     expect(cellValueExporter.exportValue(1.0000000000001)).toBe(1.0000000000001)
     expect(cellValueExporter.exportValue(-1.0000000000001)).toBe(-1.0000000000001)
     expect(cellValueExporter.exportValue(1.000000000000001)).toBe(1)
@@ -47,7 +50,7 @@ describe( 'rounding', () => {
 describe('detailed error', () => {
   it('should return detailed errors', () => {
     const config = new Config({ language: 'enGB' })
-    const cellValueExporter = new Exporter(config, namedExpressionsMock, sheetIndexMock)
+    const cellValueExporter = new Exporter(config, namedExpressionsMock, sheetIndexMock, lazilyTransforminService)
 
     const error = cellValueExporter.exportValue(new CellError(ErrorType.VALUE)) as DetailedCellError
     expect(error).toEqualError(detailedError(ErrorType.VALUE))
@@ -57,7 +60,7 @@ describe('detailed error', () => {
   it('should return detailed errors with translation', () => {
     HyperFormula.registerLanguage('plPL', plPL)
     const config = new Config({ language: 'plPL' })
-    const cellValueExporter = new Exporter(config, namedExpressionsMock, sheetIndexMock)
+    const cellValueExporter = new Exporter(config, namedExpressionsMock, sheetIndexMock, lazilyTransforminService)
 
     const error = cellValueExporter.exportValue(new CellError(ErrorType.VALUE)) as DetailedCellError
     expect(error).toEqualError(detailedError(ErrorType.VALUE, undefined, config))

--- a/test/_setupFiles/jest/toEqualError.ts
+++ b/test/_setupFiles/jest/toEqualError.ts
@@ -15,8 +15,8 @@ export const toEqualError: ExpectExtendMap = {
 
     if (typeof received === 'object' && typeof expected === 'object') {
       result = this.equals(
-        {...received, address: undefined},
-        {...expected, address: undefined}
+        {...received, root: undefined, address: undefined},
+        {...expected, root: undefined, address: undefined}
       )
     } else {
       result = this.equals(received, expected)

--- a/test/_setupFiles/matchers/toEqualError.ts
+++ b/test/_setupFiles/matchers/toEqualError.ts
@@ -18,8 +18,8 @@ export const toEqualErrorMatcher: CustomMatcherFactories = {
         let result
         if (typeof received === 'object' && typeof expected === 'object') {
           result = util.equals(
-            {...received, address: undefined},
-            {...expected, address: undefined}
+            {...received, root: undefined, address: undefined},
+            {...expected, root: undefined, address: undefined}
           )
         } else {
           result = util.equals(received, expected)

--- a/test/error-address-preservation.spec.ts
+++ b/test/error-address-preservation.spec.ts
@@ -1,5 +1,7 @@
 import {ErrorType, HyperFormula} from '../src'
 import {adr, detailedErrorWithOrigin} from './testUtils'
+import {EmptyValue} from '../src/interpreter/InterpreterValue'
+import {simpleCellRange} from '../src/AbsoluteCellRange'
 
 describe('Address preservation.', () => {
   it('Should work in the basic case.', () => {
@@ -66,5 +68,20 @@ describe('Address preservation.', () => {
     expect(engine.getCellValue(adr('B1'))).toEqual(detailedErrorWithOrigin(ErrorType.CYCLE, 'Sheet1!B1'))
     expect(engine.getCellValue(adr('A2'))).toEqual(detailedErrorWithOrigin(ErrorType.CYCLE, 'Sheet1!A1'))
     expect(engine.getCellValue(adr('A3'))).toEqual(detailedErrorWithOrigin(ErrorType.CYCLE, 'Sheet1!A1'))
+  })
+
+  it('Should work after simple cruds', () => {
+    const engine = HyperFormula.buildFromArray([
+      ['=NA()', '=A1']
+    ])
+
+    engine.addColumns(0, [0, 1])
+    expect(engine.getCellValue(adr('C1'))).toEqual(detailedErrorWithOrigin(ErrorType.NA, 'Sheet1!B1'))
+
+    engine.setCellContents(adr('B1'), '=1/0')
+    expect(engine.getCellValue(adr('C1'))).toEqual(detailedErrorWithOrigin(ErrorType.DIV_BY_ZERO, 'Sheet1!B1'))
+
+    engine.moveCells(simpleCellRange(adr('B1'), adr('B1')), adr('C5'))
+    expect(engine.getCellValue(adr('C1'))).toEqual(detailedErrorWithOrigin(ErrorType.DIV_BY_ZERO, 'Sheet1!C5'))
   })
 })

--- a/test/matchers.spec.ts
+++ b/test/matchers.spec.ts
@@ -1,6 +1,9 @@
 import {DetailedCellError} from '../src'
 import {CellError, ErrorType} from '../src/Cell'
 import {adr} from './testUtils'
+import {FormulaVertex} from '../src/DependencyGraph/FormulaCellVertex'
+import {buildNumberAst} from '../src/parser/Ast'
+import {MatrixSize} from '../src/MatrixSize'
 
 describe('Matchers', () => {
   it('should compare two simple values', () => {
@@ -9,23 +12,27 @@ describe('Matchers', () => {
   })
 
 
-  it('should compare two cell errors ignoring addresses', () => {
+  it('should compare two cell errors ignoring vertices', () => {
+    function dummyFormulaVertex(): FormulaVertex {
+      return FormulaVertex.fromAst(buildNumberAst(1), adr('A1'), MatrixSize.scalar(), 0)
+    }
+
     expect(
-      new CellError(ErrorType.ERROR, '', adr('A1'))
+      new CellError(ErrorType.ERROR, '', dummyFormulaVertex())
     ).toEqualError(
       new CellError(ErrorType.ERROR, '')
     )
 
     expect(
-      new CellError(ErrorType.ERROR, 'a', adr('A1'))
+      new CellError(ErrorType.ERROR, 'a', dummyFormulaVertex())
     ).not.toEqualError(
-      new CellError(ErrorType.ERROR, '', adr('A1'))
+      new CellError(ErrorType.ERROR, '', dummyFormulaVertex())
     )
 
     expect(
-      new CellError(ErrorType.NA, '', adr('A1'))
+      new CellError(ErrorType.NA, '', dummyFormulaVertex())
     ).not.toEqualError(
-      new CellError(ErrorType.ERROR, '', adr('A1'))
+      new CellError(ErrorType.ERROR, '', dummyFormulaVertex())
     )
   })
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
CellError origin was stored as simple address and was not updated during CRUDs. Right now CellError stores reference to the root error formula vertex so proper address can be exported later.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation,
- [ ] I described the modification in the CHANGELOG.md file.