### PR TITLE
Docs: adding data sorting tutorial (#746)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [ '14' ]
+        node-version: [ '15' ]
         os: [ 'ubuntu-latest' ]
     name: AUDIT
     runs-on: ${{ matrix.os }}

--- a/docs/guide/basic-operations.md
+++ b/docs/guide/basic-operations.md
@@ -226,7 +226,7 @@ this operation, together with their absolute addresses and new values.
 
 ```javascript
 // column 0 and column 2 swap places
-const changes = hfInstance.setRowOrder(0, [2, 1, 0]);
+const changes = hfInstance.setColumnOrder(0, [2, 1, 0]);
 ```
 
 ## Cells

--- a/docs/guide/basic-operations.md
+++ b/docs/guide/basic-operations.md
@@ -142,12 +142,26 @@ to pass the following parameters:
 * Target row
 
 This method returns a list of cells whose values were affected by
-this operation together with their absolute addresses and new values.
+this operation, together with their absolute addresses and new values.
 
 ```javascript
 // track the changes triggered by moving
 // the first row in the first sheet into row 2
 const changes = hfInstance.moveRows(0, 0, 1, 2);
+```
+
+### Reordering rows
+
+You can change the order of rows by using the `setRowOrder` method. You need to pass the following parameters:
+* Sheet ID
+* New row order
+
+This method returns a list of cells whose values were affected by
+this operation, together with their absolute addresses and new values.
+
+```javascript
+// row 0 and row 2 swap places
+const changes = hfInstance.setRowOrder(0, [2, 1, 0]);
 ```
 
 ## Columns
@@ -199,6 +213,20 @@ this operation together with their absolute addresses and new values.
 // track the changes triggered by moving
 // the first column in the first sheet into column 2 
 const changes = hfInstance.moveColumns(0, 0, 1, 2);
+```
+
+### Reordering columns
+
+You can change the order of columns by using the `setColumnOrder` method. You need to pass the following parameters:
+* Sheet ID
+* New column order
+
+This method returns a list of cells whose values were affected by
+this operation, together with their absolute addresses and new values.
+
+```javascript
+// column 0 and column 2 swap places
+const changes = hfInstance.setRowOrder(0, [2, 1, 0]);
 ```
 
 ## Cells

--- a/docs/guide/sorting-data.md
+++ b/docs/guide/sorting-data.md
@@ -4,10 +4,9 @@ In HyperFormula, you can sort data by reordering rows and columns.
 
 ## Sorting data in HyperFormula
 
-Sorting data in HyperFormula works similarly to Google Sheets and Microsoft Excel:
+To sort data in HyperFormula, you reorder rows (or columns), by providing your preferred permutation of row (or column) indexes.
 
-1. First, HyperFormula sorts formulas by their results (calculated values).
-2. When the sorting is done, each formula is recalculated with regard to its new position.
+You can implement any sorting algorithm that returns an array of row or column indexes.
 
 ## Sorting rows
 

--- a/docs/guide/sorting-data.md
+++ b/docs/guide/sorting-data.md
@@ -1,17 +1,202 @@
 # Sorting data
 
+In HyperFormula, you can sort data by reordering rows and columns.
+
+## Sorting data in HyperFormula
+
+Sorting data in HyperFormula works similarly to Google Sheets and Microsoft Excel:
+
+1. First, HyperFormula sorts formulas by their results (calculated values).
+2. When the sorting is done, each formula is recalculated with regard to its new position.
+
+## Sorting rows
+
+To sort rows, use the [`isItPossibleToSetRowOrder`](../api/classes/hyperformula.md#isitpossibletosetroworder) and [`setRowOrder`](../api/classes/hyperformula.md#setroworder) methods.
+
+### Step 1: Choose a new row order
+Choose your required permutation of row numbers.
+
+For example, if you want to swap the first row with the third row, set the order to `[2, 1, 0]` instead of `[0, 1, 2]`:
+
+```js
+// a HyperFormula instance with example data
+const hfInstance = HyperFormula.buildFromArray([
+ [1],
+ [2],
+ [4, 5],
+]);
+
+// we'll set the row order to [2, 1, 0] in the next steps
+```
+
 ::: tip
-HyperFormula does not support sorting natively.
+The [`setRowOrder`](../api/classes/hyperformula.md#setroworder) method accepts an array of numbers, so you can implement any function that returns an array with your required row order.
 :::
 
-However, a similar result can be achieved by doing multiple **move**
-operations for columns. It works in a similar way to spreadsheet
-software like Excel or Google Sheets. That means HyperFormula first
-sorts the formulas by their results (values). Then, when the sorting
-is done, the formulas are re-calculated with regard to their new
-position.
+### Step 2: Check if the new row order can be applied
 
-## Demo
+Before you change the row order, check if your specified row number permutation can actually be applied.
+
+Thanks to the [`isItPossibleTo*` methods](basic-operations.md#isitpossibleto-methods), you can check if an operation is allowed, and display an error message if it's not.
+
+Ue the [`isItPossibleToSetRowOrder`](../api/classes/hyperformula.md#isitpossibletosetroworder) method:
+
+```js
+const hfInstance = HyperFormula.buildFromArray([
+ [1],
+ [2],
+ [4, 5],
+]);
+
+// a variable to carry the user message
+let messageUsedInUI;
+
+// check if your permutation can be applied
+const isRowOrderOk = hfInstance.isItPossibleToSetRowOrder(0, [2, 1, 0]);
+
+// display an error message
+if (!isRowOrderOk) {
+  messageUsedInUI = 'Sorry, you cannot sort rows like that.'
+}
+```
+
+### Step 3: Set the new row order
+
+If your specified row number permutation is valid, change the row order:
+
+```js
+const hfInstance = HyperFormula.buildFromArray([
+ [1],
+ [2],
+ [4, 5],
+]);
+
+let messageUsedInUI;
+
+const isRowOrderOk = hfInstance.isItPossibleToSetRowOrder(0, [2, 1, 0]);
+
+if (!isRowOrderOk) {
+  messageUsedInUI = 'Sorry, you cannot sort rows like that.'
+} else {
+  // change the row order
+  setRowOrder(0, [2, 1, 0]);
+}
+// rows 0 and 2 swap places
+
+// returns:
+// [{
+//   address: { sheet: 0, col: 0, row: 2 },
+//   newValue: 1,
+// },
+// {
+//   address: { sheet: 0, col: 1, row: 2 },
+//   newValue: null,
+// },
+// {
+//   address: { sheet: 0, col: 0, row: 0 },
+//   newValue: 4,
+// },
+// {
+//   address: { sheet: 0, col: 1, row: 0 },
+//   newValue: 5,
+// }]
+```
+
+## Sorting columns
+
+To sort columns, use the [`isItPossibleToSetColumnOrder`](../api/classes/hyperformula.md#isitpossibletosetcolumnorder) and [`setColumnOrder`](../api/classes/hyperformula.md#setcolumnorder) methods.
+
+### Step 1: Choose a new column order
+Choose your required permutation of column numbers.
+
+For example, if you want to swap the first column with the third column, set the order to `[2, 1, 0]` instead of `[0, 1, 2]`:
+
+```js
+// a HyperFormula instance with example data
+const hfInstance = HyperFormula.buildFromArray([
+ [1, 2, 4],
+ [5]
+]);
+
+// we'll set the column order to [2, 1, 0] in the next steps
+```
+
+::: tip
+The [`setColumnOrder`](../api/classes/hyperformula.md#setcolumnorder) method accepts an array of numbers, so you can implement any function that returns an array with your required column order.
+:::
+
+### Step 2: Check if the new column order can be applied
+
+Before you change the column order, check if your specified column number permutation can actually be applied.
+
+Thanks to the [`isItPossibleTo*` methods](basic-operations.md#isitpossibleto-methods), you can check if an operation is allowed, and display an error message if it's not.
+
+Ue the [`isItPossibleToSetColumnOrder`](../api/classes/hyperformula.md#isitpossibletosetcolumnorder) method:
+
+```js
+const hfInstance = HyperFormula.buildFromArray([
+ [1, 2, 4],
+ [5]
+]);
+
+// a variable to carry the user message
+let messageUsedInUI;
+
+// check if your permutation can be applied
+const isColumnOrderOk = hfInstance.isItPossibleToSetColumnOrder(0, [2, 1, 0]);
+
+// display an error message
+if (!isColumnOrderOk) {
+  messageUsedInUI = 'Sorry, you cannot sort columns like that.'
+}
+```
+
+### Step 3: Set the new column order
+
+If your specified column number permutation is valid, change the column order:
+
+```js
+const hfInstance = HyperFormula.buildFromArray([
+ [1, 2, 4],
+ [5]
+]);
+
+let messageUsedInUI;
+
+const isColumnOrderOk = hfInstance.isItPossibleToSetColumnOrder(0, [2, 1, 0]);
+
+if (!isColumnOrderOk) {
+  messageUsedInUI = 'Sorry, you cannot sort columns like that.'
+} else {
+  // change the column order
+  setColumnOrder(0, [2, 1, 0]);
+}
+// columns 0 and 2 swap places
+
+//returns:
+// [{
+//   address: { sheet: 0, col: 2, row: 0 },
+//   newValue: 1,
+// },
+// {
+//   address: { sheet: 0, col: 2, row: 1 },
+//   newValue: 5,
+// },
+// {
+//   address: { sheet: 0, col: 0, row: 0 },
+//   newValue: 4,
+// },
+// {
+//   address: { sheet: 0, col: 0, row: 1 },
+//   newValue: null,
+// }]
+```
+
+## Data sorting demo
+
+The demo below shows how to sort rows in ascending and descending order, based on the results (calculated values) of the cells in the second column.
+
+To see the code, select "Open Sandbox" in the frame's bottom right corner.
 
 <iframe
      src="https://codesandbox.io/embed/github/handsontable/hyperformula-demos/tree/0.6.x/sorting?autoresize=1&fontsize=11&hidenavigation=1&theme=light&view=preview"

--- a/docs/guide/sorting-data.md
+++ b/docs/guide/sorting-data.md
@@ -39,7 +39,7 @@ Before you change the row order, check if your specified row number permutation 
 
 Thanks to the [`isItPossibleTo*` methods](basic-operations.md#isitpossibleto-methods), you can check if an operation is allowed, and display an error message if it's not.
 
-Ue the [`isItPossibleToSetRowOrder`](../api/classes/hyperformula.md#isitpossibletosetroworder) method:
+Use the [`isItPossibleToSetRowOrder`](../api/classes/hyperformula.md#isitpossibletosetroworder) method:
 
 ```js
 const hfInstance = HyperFormula.buildFromArray([
@@ -56,7 +56,7 @@ const isRowOrderOk = hfInstance.isItPossibleToSetRowOrder(0, [2, 1, 0]);
 
 // display an error message
 if (!isRowOrderOk) {
-  messageUsedInUI = 'Sorry, you cannot sort rows like that.'
+  messageUsedInUI = 'Sorry, you cannot sort rows in this way.'
 }
 ```
 
@@ -76,9 +76,9 @@ let messageUsedInUI;
 const isRowOrderOk = hfInstance.isItPossibleToSetRowOrder(0, [2, 1, 0]);
 
 if (!isRowOrderOk) {
-  messageUsedInUI = 'Sorry, you cannot sort rows like that.'
+  messageUsedInUI = 'Sorry, you cannot sort rows in this way.'
 } else {
-  // change the row order
+  // set the new row order
   setRowOrder(0, [2, 1, 0]);
 }
 // rows 0 and 2 swap places
@@ -131,7 +131,7 @@ Before you change the column order, check if your specified column number permut
 
 Thanks to the [`isItPossibleTo*` methods](basic-operations.md#isitpossibleto-methods), you can check if an operation is allowed, and display an error message if it's not.
 
-Ue the [`isItPossibleToSetColumnOrder`](../api/classes/hyperformula.md#isitpossibletosetcolumnorder) method:
+Use the [`isItPossibleToSetColumnOrder`](../api/classes/hyperformula.md#isitpossibletosetcolumnorder) method:
 
 ```js
 const hfInstance = HyperFormula.buildFromArray([
@@ -147,7 +147,7 @@ const isColumnOrderOk = hfInstance.isItPossibleToSetColumnOrder(0, [2, 1, 0]);
 
 // display an error message
 if (!isColumnOrderOk) {
-  messageUsedInUI = 'Sorry, you cannot sort columns like that.'
+  messageUsedInUI = 'Sorry, you cannot sort columns in this way.'
 }
 ```
 
@@ -166,9 +166,9 @@ let messageUsedInUI;
 const isColumnOrderOk = hfInstance.isItPossibleToSetColumnOrder(0, [2, 1, 0]);
 
 if (!isColumnOrderOk) {
-  messageUsedInUI = 'Sorry, you cannot sort columns like that.'
+  messageUsedInUI = 'Sorry, you cannot sort columns in this way.'
 } else {
-  // change the column order
+  // set the new column order
   setColumnOrder(0, [2, 1, 0]);
 }
 // columns 0 and 2 swap places

--- a/docs/guide/sorting-data.md
+++ b/docs/guide/sorting-data.md
@@ -14,7 +14,7 @@ Sorting data in HyperFormula works similarly to Google Sheets and Microsoft Exce
 To sort rows, use the [`isItPossibleToSetRowOrder`](../api/classes/hyperformula.md#isitpossibletosetroworder) and [`setRowOrder`](../api/classes/hyperformula.md#setroworder) methods.
 
 ### Step 1: Choose a new row order
-Choose your required permutation of row numbers.
+Choose your required permutation of row indexes.
 
 For example, if you want to swap the first row with the third row, set the order to `[2, 1, 0]` instead of `[0, 1, 2]`:
 
@@ -107,7 +107,7 @@ if (!isRowOrderOk) {
 To sort columns, use the [`isItPossibleToSetColumnOrder`](../api/classes/hyperformula.md#isitpossibletosetcolumnorder) and [`setColumnOrder`](../api/classes/hyperformula.md#setcolumnorder) methods.
 
 ### Step 1: Choose a new column order
-Choose your required permutation of column numbers.
+Choose your required permutation of column indexes.
 
 For example, if you want to swap the first column with the third column, set the order to `[2, 1, 0]` instead of `[0, 1, 2]`:
 

--- a/docs/guide/sorting-data.md
+++ b/docs/guide/sorting-data.md
@@ -13,7 +13,7 @@ You can implement any sorting algorithm that returns an array of row or column i
 To sort rows, use the [`isItPossibleToSetRowOrder`](../api/classes/hyperformula.md#isitpossibletosetroworder) and [`setRowOrder`](../api/classes/hyperformula.md#setroworder) methods.
 
 ### Step 1: Choose a new row order
-Choose your required permutation of row indexes.
+Choose your required permutation of row indexes. 
 
 For example, if you want to swap the first row with the third row, set the order to `[2, 1, 0]` instead of `[0, 1, 2]`:
 

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -1299,8 +1299,9 @@ export class HyperFormula implements TypedEmitter {
    *  [2],
    *  [4, 5],
    * ]);
-   *
-   * // should set swap rows 0 and 2 in place, returns:
+   * // rows 0 and 2 swap places
+   * 
+   * // returns:
    * // [{
    * //   address: { sheet: 0, col: 0, row: 2 },
    * //   newValue: 1,
@@ -1469,8 +1470,9 @@ export class HyperFormula implements TypedEmitter {
    *  [1, 2, 4],
    *  [5]
    * ]);
-   *
-   * // should set swap columns 0 and 2 in place, returns:
+   * // columns 0 and 2 swap places
+   * 
+   * // returns:
    * // [{
    * //   address: { sheet: 0, col: 2, row: 0 },
    * //   newValue: 1,


### PR DESCRIPTION
From what I gather, there's no native sorting as such, but now, instead of `moveRows` you can use `setRowOrder` and `setColumnOrder`.

@izulin @wojciechczerniak - can I ask for your help with updating the data sorting demo?

- [x] Updated a few comments in the `setRowOrder` and `setColumnOrder` API ref
- [x] Added "Reordering rows" and "Reordering columns" sections to the "Basic operations" page
- [x] Rewrote the "Sorting data" page

Any repetitions are purposeful (each procedure section should make sense on its own).