### PR TITLE
Add CHANGELOG.md file to publish allow list

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@
 !typings/**/*
 !github-hf-logo-blue.svg
 !gpl-3.0.txt
+!CHANGELOG.md


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds the CHANGELOG.md file to publish allow list. Without that, on the latest Node (16.4.0) I've got an error from the `verify:publish-package` script that this file is missing.

![image](https://user-images.githubusercontent.com/571316/125267901-80cb1080-e307-11eb-92bc-8ea59fcb2254.png)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Run `npm run verify:publish-package`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation,
- [ ] I described the modification in the CHANGELOG.md file.