### PR TITLE
Docs: adding release notes and expanding calculateFormula() description

### DIFF
--- a/docs/guide/release-notes.md
+++ b/docs/guide/release-notes.md
@@ -4,6 +4,20 @@ This page lists HyperFormula release notes. The format is based on [Keep a Chang
 
 HyperFormula adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.0
+**Release date: August 12, 2021**
+
+### Changed
+- Deprecated the `binarySearchThreshold` configuration option, as every search of sorted data always uses binary search. [#791](https://github.com/handsontable/hyperformula/pull/791)
+
+### Added
+- Added support for the array arithmetic mode in the `calculateFormula()` method. [#782](https://github.com/handsontable/hyperformula/issues/782)
+- Added a new `CellType` returned by `getCellType`: `CellType.ARRAYFORMULA`. It's assigned to the top-left corner of an array, and is recognized by the `isCellPartOfArray()` and `doesCellHaveFormula()` methods. [#781](https://github.com/handsontable/hyperformula/issues/781)
+
+### Fixed
+- Fixed an issue with searching sorted data. [#787](https://github.com/handsontable/hyperformula/issues/787)
+- Fixed the `destroy` method to properly destroy HyperFormula instances. [#788](https://github.com/handsontable/hyperformula/pull/788)
+
 ## 1.0.0
 **Release date: July 15, 2021**
 

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -3978,22 +3978,26 @@ export class HyperFormula implements TypedEmitter {
   /**
    * Calculates fire-and-forget formula, returns the calculated value.
    *
-   * @param {string} formulaString -  a formula in a proper format - it must start with "="
-   * @param {number} sheetId - an ID of the sheet in context of which we evaluate formula.
+   * @param {string} formulaString - A formula in a proper format, starting with `=`.
+   * @param {number} sheetId - The ID of a sheet in context of which the formula gets evaluated.
    *
-   * @throws [[ExpectedValueOfTypeError]] if any of its basic type argument is of wrong type
-   * @throws [[NotAFormulaError]] when the provided string is not a valid formula, i.e does not start with "="
-   * @throws [[NoSheetWithIdError]] when the given sheet ID does not exists
+   * @throws [[ExpectedValueOfTypeError]] if any of its basic type arguments is of wrong type.
+   * @throws [[NotAFormulaError]] when the provided string is not a valid formula (i.e. doesn't start with `=`).
+   * @throws [[NoSheetWithIdError]] when the provided `sheetID` doesn't exist.
    *
    * @example
    * ```js
    * const hfInstance = HyperFormula.buildFromSheets({
-   *  Sheet1: [['22']],
-   *  Sheet2: [['58']],
+   *  Sheet1: [['58']],
+   *  Sheet2: [['1', '2', '3'], ['4', '5', '6']]
    * });
    *
-   * // returns the value of calculated formula, '32' for this example
+   * // returns the calculated formula's value
+   * // for this example, returns `68`
    * const calculatedFormula = hfInstance.calculateFormula('=A1+10', 0);
+   *
+   * // for this example, returns [['11', '12', '13'], ['14', '15', '16']]
+   * const calculatedFormula = hfInstance.calculateFormula('=A1:B3+10', 1);
    * ```
    *
    * @category Helpers


### PR DESCRIPTION
This PR:
* Adds release notes for HF 1.1.0: http://localhost:8080/hyperformula/guide/release-notes.html
* Expands the `calculateFormula` example in the API ref: http://localhost:8080/hyperformula/api/classes/hyperformula.html#calculateformula