### PR TITLE
Docs: fixing a typo and a broken link

### DIFF
--- a/docs/guide/migration-from-0.6-to-1.0.md
+++ b/docs/guide/migration-from-0.6-to-1.0.md
@@ -4,7 +4,7 @@ To upgrade your HyperFormula version from 0.6.x to 1.0.x, follow this guide.
 
 ## Step 1: Change your license key
 
-If use the AGPLv3 license, or the free non-commercial license, you need to change your license key.
+If you use the AGPLv3 license, or the free non-commercial license, you need to change your license key.
 
 If you use a commercial license, you don't need to make any changes.
 
@@ -107,7 +107,7 @@ Before:
 ={ISEVEN(A2:A5*10)}
 ```
 
-Now, if the `useArrayArithmetic` configuration option is set to `false`, use the `ARRAYFORMULA` function to [enable the array arithmetic mode locally]((arrays.md#enabling-the-array-arithmetic-mode-locally)):
+Now, if the `useArrayArithmetic` configuration option is set to `false`, use the `ARRAYFORMULA` function to [enable the array arithmetic mode locally](arrays.md#enabling-the-array-arithmetic-mode-locally):
 ```js
 =ARRAYFORMULA(ISEVEN(A2:A5*10))
 ```


### PR DESCRIPTION
This PR:
- Fixes a typo and a broken link on the [Migrating from 0.6 to 1.0](https://handsontable.github.io/hyperformula/guide/migration-from-0.6-to-1.0.html#step-1-change-your-license-key) page