### PR TITLE
Remove gpu.js from optional dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed `gpu.js` from optional dependencies and marked config options `gpujs` and `gpuMode` as deprecated.
+
 ## [1.1.0] - 2021-08-12
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "hyperformula",
       "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
@@ -72,9 +73,6 @@
         "webpack": "^4.41.6",
         "webpack-cli": "^3.3.11",
         "webpackbar": "^4.0.0"
-      },
-      "optionalDependencies": {
-        "gpu.js": "2.3.0"
       }
     },
     "node_modules/@babel/cli": {

--- a/package.json
+++ b/package.json
@@ -147,8 +147,5 @@
     "regenerator-runtime": "^0.13.3",
     "tiny-emitter": "^2.1.0",
     "unorm": "^1.6.0"
-  },
-  "optionalDependencies": {
-    "gpu.js": "2.3.0"
   }
 }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -691,7 +691,9 @@ export class Config implements ConfigParams, ParserConfig {
     validateNumberToBeAtLeast(this.maxColumns, 'maxColumns', 1)
     this.warnDeprecatedIfUsed(binarySearchThreshold, 'binarySearchThreshold', '1.1')
     this.warnDeprecatedIfUsed(gpujs, 'gpujs', '1.2')
-    this.warnDeprecatedIfUsed(gpuMode, 'gpuMode', '1.2')
+    if (gpuMode !== Config.defaultConfig.gpuMode) {
+      this.warnDeprecatedIfUsed(gpuMode, 'gpuMode', '1.2')
+    }
 
     privatePool.set(this, {
       licenseKeyValidityState: checkLicenseKeyValidity(this.licenseKey)
@@ -731,7 +733,7 @@ export class Config implements ConfigParams, ParserConfig {
 
   private warnDeprecatedIfUsed(inputValue: any, paramName: string, fromVersion: string, replacementName?: string) {
     if (inputValue !== undefined) {
-      if(replacementName === undefined) {
+      if (replacementName === undefined) {
         console.warn(`${paramName} option is deprecated since ${fromVersion}`)
       } else {
         console.warn(`${paramName} option is deprecated since ${fromVersion}, please use ${replacementName}`)

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -155,6 +155,8 @@ export interface ConfigParams {
    * 
    * When not provided, the plain CPU implementation is used.
    *
+   * @deprecated since version 1.2.
+   * 
    * @default undefined
    *
    * @category Engine
@@ -171,6 +173,8 @@ export interface ConfigParams {
    * 
    * For more information, see the [GPU.js documentation](https://github.com/gpujs/gpu.js/#readme).
    *
+   * @deprecated since version 1.2 
+   * 
    * @default 'gpu'
    *
    * @category Engine
@@ -686,6 +690,8 @@ export class Config implements ConfigParams, ParserConfig {
     })
     validateNumberToBeAtLeast(this.maxColumns, 'maxColumns', 1)
     this.warnDeprecatedIfUsed(binarySearchThreshold, 'binarySearchThreshold', '1.1')
+    this.warnDeprecatedIfUsed(gpujs, 'gpujs', '1.2')
+    this.warnDeprecatedIfUsed(gpuMode, 'gpuMode', '1.2')
 
     privatePool.set(this, {
       licenseKeyValidityState: checkLicenseKeyValidity(this.licenseKey)


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR removes `gpu.js` from optional dependencies and annotates appropriate config options as deprecated.
There is no reasonable way to check `gpu.js` version from within the engine code.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #812  
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation,
- [x] I described the modification in the CHANGELOG.md file.