### PR TITLE
Docs: changing `harmonic` to `hyperbolic` for ACOSH, ACOTH, ASINH & ATANH

### DIFF
--- a/docs/guide/built-in-functions.md
+++ b/docs/guide/built-in-functions.md
@@ -244,15 +244,15 @@ Total number of functions: **{{ $page.functionsCount }}**
 | :--- | :--- | :--- |
 | ABS | Returns the absolute value of a number. | ABS(Number) |
 | ACOS | Returns the inverse trigonometric cosine of a number. | ACOS(Number) |
-| ACOSH | Returns the inverse harmonic cosine of a number. | ACOSH(Number) |
+| ACOSH | Returns the inverse hyperbolic cosine of a number. | ACOSH(Number) |
 | ACOT | Returns the inverse trigonometric cotangent of a number. | ACOT(Number) |
-| ACOTH | Returns the inverse harmonic cotangent of a number. | ACOTH(Number) |
+| ACOTH | Returns the inverse hyperbolic cotangent of a number. | ACOTH(Number) |
 | ARABIC | Converts number from roman form. | ARABIC(String) |
 | ASIN | Returns the inverse trigonometric sine of a number. | ASIN(Number) |
-| ASINH | Returns the inverse harmonic sine of a number. | ASINH(Number) |
+| ASINH | Returns the inverse hyperbolic sine of a number. | ASINH(Number) |
 | ATAN | Returns the inverse trigonometric tangent of a number. | ATAN(Number) |
 | ATAN2 | Returns the inverse trigonometric tangent of the specified x and y coordinates. | ATAN2(Numberx; Numbery) |
-| ATANH | Returns the inverse harmonic tangent of a number. | ATANH(Number) |
+| ATANH | Returns the inverse hyperbolic tangent of a number. | ATANH(Number) |
 | BASE | Converts a positive integer to a specified base into a text from the numbering system. | BASE(Number; Radix; [Minimumlength]) |
 | CEILING | Rounds a number up to the nearest multiple of Significance. | CEILING(Number; Significance) |
 | CEILING.MATH | Rounds a number up to the nearest multiple of Significance. | CEILING.MATH(Number[; Significance[; Mode]]) |


### PR DESCRIPTION
This PR:
- Changes the term "harmonic" to "hyperbolic" for the following functions: ACOSH, ACOTH, ASINTH & ATANH

Those functions use Math.js. The Math.js docs (and the MDN docs as well) use the term "hyperbolic" rather than "harmonic" in those functions' description (as pointed out by SAP):
- ACOSH: [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh), [Math.js](https://mathjs.org/docs/reference/functions/acosh.html)
- ACOTH (uses `Math.atanh`): [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atanh), [Math.js](https://mathjs.org/docs/reference/functions/atanh.html)
- ASINH: [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh), [Math.js](https://mathjs.org/docs/reference/functions/asinh.html)
- ATANH: [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atanh), [Math.js](https://mathjs.org/docs/reference/functions/atanh.html)