### PR TITLE
Docs: Fixing the runFunction() example

### DIFF
--- a/docs/guide/custom-functions.md
+++ b/docs/guide/custom-functions.md
@@ -294,7 +294,8 @@ export class CountHF extends FunctionPlugin {
   
   // wrap your custom function in `runFunction()`
   public hyper(ast, state) {
-    return this.runFunction(() => 'Hyperformula'.length)
+    return this.runFunction(ast, state, this.metadata('HYPER'),
+    () => 'Hyperformula'.length)
   }
 }
 ```


### PR DESCRIPTION
This PR:
- Adds missing arguments to the [runFunction() example](https://handsontable.github.io/hyperformula/guide/custom-functions.html#runfunction) (fixing #842)