### PR TITLE
Docs: Removing Formula Syntax category duplicate

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -245,14 +245,14 @@ export interface ConfigParams {
    * Sets a column separator symbol for array notation.
    *
    * @default ','
-   * @category Formula syntax
+   * @category Formula Syntax
    */
   arrayColumnSeparator: ',' | ';',
   /**
    * Sets a row separator symbol for array notation.
    *
    * @default ';'
-   * @category Formula syntax
+   * @category Formula Syntax
    */
   arrayRowSeparator: ';' | '|',
   /**


### PR DESCRIPTION
This PR:
- Removes a duplicate in API ref ([Formula Syntax](https://handsontable.github.io/hyperformula/api/interfaces/configparams.html#formula-syntax) vs [Formula syntax](https://handsontable.github.io/hyperformula/api/interfaces/configparams.html#formula-syntax-2))