### PR TITLE
Docs: Expanding `precisionRounding` info

### DIFF
--- a/docs/api-template.md
+++ b/docs/api-template.md
@@ -29,7 +29,6 @@ An example set of options:
 ```javascript
 const options = {
   licenseKey: 'gpl-v3',
-  precisionRounding: 10,
   nullDate: { year: 1900, month: 1, day: 1 },
   functionArgSeparator: '.'
 };

--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -26,7 +26,6 @@ this:
 
 ```javascript
 const options = {
-    precisionRounding: 4,
     licenseKey: 'gpl-v3'
 };
 ```

--- a/docs/guide/configuration-options.md
+++ b/docs/guide/configuration-options.md
@@ -17,7 +17,6 @@ static method called to initiate a new instance of HyperFormula.
 // define options 
 const options = {
     licenseKey: 'gpl-v3',
-    precisionRounding: 10,
     nullDate: { year: 1900, month: 1, day: 1 },
     functionArgSeparator: '.'
 };

--- a/docs/guide/configuration-options.md
+++ b/docs/guide/configuration-options.md
@@ -17,6 +17,7 @@ static method called to initiate a new instance of HyperFormula.
 // define options 
 const options = {
     licenseKey: 'gpl-v3',
+    precisionRounding: 10,
     nullDate: { year: 1900, month: 1, day: 1 },
     functionArgSeparator: '.'
 };

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -327,7 +327,10 @@ export interface ConfigParams {
    * But when HyperFormula exports a cell's value, it rounds the output
    * to the `precisionRounding` number of significant digits.
    *
-   * We recommend setting `precisionRounding` to a value between `1` and `14`.
+   * Setting `precisionRounding` too low can cause large numbers' imprecision
+   * (for example, with `precisionRounding` set to `4`, 100005 becomes 100010).
+   *
+   * We recommend setting `precisionRounding` to a value between `10` and `14`.
    *
    * @default 14
    *

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -321,9 +321,13 @@ export interface ConfigParams {
    */
   precisionEpsilon: number,
   /**
-   * Sets calculations' precision level.
+   * Sets the precision level of calculations' output.
    *
-   * Numerical outputs are rounded to the `precisionRounding` number of digits after the decimal.
+   * Internally, all arithmetic operations are performed using JavaScript's built-in numbers.
+   * But when HyperFormula exports a cell's value, it rounds the output
+   * to the `precisionRounding` number of significant digits.
+   *
+   * We recommend setting `precisionRounding` to a value between `1` and `14`.
    *
    * @default 14
    *


### PR DESCRIPTION
This PR:
- Expands the [`precisionRounding` API ref](https://handsontable.github.io/hyperformula/api/classes/config.html#precisionrounding)
- Removes the `precisionRounding` option from examples where it's not necessary 