### PR TITLE
Added support for infering return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added support for inferring return types based on their values in custom function plugins.
+- Added support for inferring return types based on their values in custom function plugins. (#875)
 
 ## [1.3.0] - 2021-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added support for inferring return types based on their values in custom function plugins.
+
 ## [1.3.0] - 2021-10-20
 
 ### Added

--- a/src/BuildEngineFactory.ts
+++ b/src/BuildEngineFactory.ts
@@ -112,7 +112,7 @@ export class BuildEngineFactory {
     const exporter = new Exporter(config, namedExpressions, sheetMapping.fetchDisplayName, lazilyTransformingAstService)
     const serialization = new Serialization(dependencyGraph, unparser, exporter)
 
-    const interpreter = new Interpreter(config, dependencyGraph, columnSearch, stats, arithmeticHelper, functionRegistry, namedExpressions, serialization, arraySizePredictor, dateTimeHelper)
+    const interpreter = new Interpreter(config, dependencyGraph, columnSearch, stats, arithmeticHelper, functionRegistry, namedExpressions, serialization, arraySizePredictor, dateTimeHelper, cellContentParser)
 
     stats.measure(StatType.GRAPH_BUILD, () => {
       const graphBuilder = new GraphBuilder(dependencyGraph, columnSearch, parser, cellContentParser, stats, arraySizePredictor)

--- a/src/CellContentParser.ts
+++ b/src/CellContentParser.ts
@@ -3,187 +3,216 @@
  * Copyright (c) 2021 Handsoncode. All rights reserved.
  */
 
-import {CellError, ErrorType} from './Cell'
-import {Config} from './Config'
-import {DateTimeHelper, timeToNumber} from './DateTimeHelper'
-import {ErrorMessage} from './error-message'
-import {UnableToParseError} from './errors'
-import {fixNegativeZero, isNumberOverflow} from './interpreter/ArithmeticHelper'
-import {
-  cloneNumber,
-  CurrencyNumber,
-  DateNumber,
-  DateTimeNumber,
-  ExtendedNumber,
-  getRawValue,
-  PercentNumber,
-  TimeNumber
-} from './interpreter/InterpreterValue'
-import {Maybe} from './Maybe'
-import {NumberLiteralHelper} from './NumberLiteralHelper'
-
-export type RawCellContent = Date | string | number | boolean | null | undefined
-
-export namespace CellContent {
-  export class Number {
-    constructor(public readonly value: ExtendedNumber) {
-      this.value = cloneNumber(this.value, fixNegativeZero(getRawValue(this.value)))
-    }
-  }
-
-  export class String {
-    constructor(public readonly value: string) {
-    }
-  }
-
-  export class Boolean {
-    constructor(public readonly value: boolean) {
-    }
-  }
-
-  export class Empty {
-
-    private static instance: Empty
-
-    public static getSingletonInstance() {
-      if (!Empty.instance) {
-        Empty.instance = new Empty()
-      }
-      return Empty.instance
-    }
-  }
-
-  export class Formula {
-    constructor(public readonly formula: string) {
-    }
-  }
-
-  export class Error {
-    public readonly value: CellError
-
-    constructor(errorType: ErrorType, message?: string) {
-      this.value = new CellError(errorType, message)
-    }
-  }
-
-  export type Type = Number | String | Boolean | Empty | Formula | Error
-}
-
-/**
- * Checks whether string looks like formula or not.
- *
- * @param text - formula
- */
-export function isFormula(text: string): boolean {
-  return text.startsWith('=')
-}
-
-export function isBoolean(text: string): boolean {
-  const tl = text.toLowerCase()
-  return tl === 'true' || tl === 'false'
-}
-
-export function isError(text: string, errorMapping: Record<string, ErrorType>): boolean {
-  const upperCased = text.toUpperCase()
-  const errorRegex = /#[A-Za-z0-9\/]+[?!]?/
-  return errorRegex.test(upperCased) && Object.prototype.hasOwnProperty.call(errorMapping, upperCased)
-}
-
-export class CellContentParser {
-  constructor(
-    private readonly config: Config,
-    private readonly dateHelper: DateTimeHelper,
-    private readonly numberLiteralsHelper: NumberLiteralHelper) {
-  }
-
-  public parse(content: RawCellContent): CellContent.Type {
-    if (content === undefined || content === null) {
-      return CellContent.Empty.getSingletonInstance()
-    } else if (typeof content === 'number') {
-      if (isNumberOverflow(content)) {
-        return new CellContent.Error(ErrorType.NUM, ErrorMessage.ValueLarge)
-      } else {
-        return new CellContent.Number(content)
-      }
-    } else if (typeof content === 'boolean') {
-      return new CellContent.Boolean(content)
-    } else if (content instanceof Date) {
-      const dateVal = this.dateHelper.dateToNumber({
-        day: content.getDate(),
-        month: content.getMonth() + 1,
-        year: content.getFullYear()
-      })
-      const timeVal = timeToNumber({
-        hours: content.getHours(),
-        minutes: content.getMinutes(),
-        seconds: content.getSeconds() + content.getMilliseconds() / 1000
-      })
-      const val = dateVal + timeVal
-      if (val < 0) {
-        return new CellContent.Error(ErrorType.NUM, ErrorMessage.DateBounds)
-      }
-      if (val % 1 === 0) {
-        return new CellContent.Number(new DateNumber(val, 'Date()'))
-      } else if (val < 1) {
-        return new CellContent.Number(new TimeNumber(val, 'Date()'))
-      } else {
-        return new CellContent.Number(new DateTimeNumber(val, 'Date()'))
-      }
-    } else if (typeof content === 'string') {
-      if (isBoolean(content)) {
-        return new CellContent.Boolean(content.toLowerCase() === 'true')
-      } else if (isFormula(content)) {
-        return new CellContent.Formula(content)
-      } else if (isError(content, this.config.errorMapping)) {
-        return new CellContent.Error(this.config.errorMapping[content.toUpperCase()])
-      } else {
+ import {CellError, ErrorType} from './Cell'
+ import {Config} from './Config'
+ import {DateTimeHelper, timeToNumber} from './DateTimeHelper'
+ import {ErrorMessage} from './error-message'
+ import {UnableToParseError} from './errors'
+ import {fixNegativeZero, isNumberOverflow} from './interpreter/ArithmeticHelper'
+ import {
+   cloneNumber,
+   CurrencyNumber,
+   DateNumber,
+   DateTimeNumber,
+   ExtendedNumber,
+   getRawValue,
+   PercentNumber,
+   TimeNumber
+ } from './interpreter/InterpreterValue'
+ import {Maybe} from './Maybe'
+ import {NumberLiteralHelper} from './NumberLiteralHelper'
+ 
+ export type RawCellContent = Date | string | number | boolean | null | undefined
+ 
+ export namespace CellContent {
+   export class Number {
+     constructor(public readonly value: ExtendedNumber) {
+       this.value = cloneNumber(this.value, fixNegativeZero(getRawValue(this.value)))
+     }
+   }
+ 
+   export class String {
+     constructor(public readonly value: string) {
+     }
+   }
+ 
+   export class Boolean {
+     constructor(public readonly value: boolean) {
+     }
+   }
+ 
+   export class Empty {
+ 
+     private static instance: Empty
+ 
+     public static getSingletonInstance() {
+       if (!Empty.instance) {
+         Empty.instance = new Empty()
+       }
+       return Empty.instance
+     }
+   }
+ 
+   export class Formula {
+     constructor(public readonly formula: string) {
+     }
+   }
+ 
+   export class Error {
+     public readonly value: CellError
+ 
+     constructor(errorType: ErrorType, message?: string) {
+       this.value = new CellError(errorType, message)
+     }
+   }
+ 
+   export type Type = Number | String | Boolean | Empty | Formula | Error
+ }
+ 
+ /**
+  * Checks whether string looks like formula or not.
+  *
+  * @param text - formula
+  */
+ export function isFormula(text: string): boolean {
+   return text.startsWith('=')
+ }
+ 
+ export function isBoolean(text: string): boolean {
+   const tl = text.toLowerCase()
+   return tl === 'true' || tl === 'false'
+ }
+ 
+ export function isPercent(text: string): boolean {
+   const trimmedContent = text.trim()
+ 
+   return trimmedContent.endsWith('%')
+ }
+ 
+ export function isError(text: string, errorMapping: Record<string, ErrorType>): boolean {
+   const upperCased = text.toUpperCase()
+   const errorRegex = /#[A-Za-z0-9\/]+[?!]?/
+   return errorRegex.test(upperCased) && Object.prototype.hasOwnProperty.call(errorMapping, upperCased)
+ }
+ 
+ export class CellContentParser {
+   constructor(
+     private readonly config: Config,
+     private readonly dateHelper: DateTimeHelper,
+     private readonly numberLiteralsHelper: NumberLiteralHelper) {
+   }
+ 
+   public parse(content: RawCellContent): CellContent.Type {
+     if (content === undefined || content === null) {
+       return CellContent.Empty.getSingletonInstance()
+     } else if (typeof content === 'number') {
+       if (isNumberOverflow(content)) {
+         return new CellContent.Error(ErrorType.NUM, ErrorMessage.ValueLarge)
+       } else {
+         return new CellContent.Number(content)
+       }
+     } else if (typeof content === 'boolean') {
+       return new CellContent.Boolean(content)
+     } else if (content instanceof Date) {
+       const dateVal = this.dateHelper.dateToNumber({
+         day: content.getDate(),
+         month: content.getMonth() + 1,
+         year: content.getFullYear()
+       })
+       const timeVal = timeToNumber({
+         hours: content.getHours(),
+         minutes: content.getMinutes(),
+         seconds: content.getSeconds() + content.getMilliseconds() / 1000
+       })
+       const val = dateVal + timeVal
+       if (val < 0) {
+         return new CellContent.Error(ErrorType.NUM, ErrorMessage.DateBounds)
+       }
+       if (val % 1 === 0) {
+         return new CellContent.Number(new DateNumber(val, 'Date()'))
+       } else if (val < 1) {
+         return new CellContent.Number(new TimeNumber(val, 'Date()'))
+       } else {
+         return new CellContent.Number(new DateTimeNumber(val, 'Date()'))
+       }
+     } else if (typeof content === 'string') {
+       if (isBoolean(content)) {
+         return new CellContent.Boolean(content.toLowerCase() === 'true')
+       } else if (isFormula(content)) {
+         return new CellContent.Formula(content)
+       } else if (isError(content, this.config.errorMapping)) {
+         return new CellContent.Error(this.config.errorMapping[content.toUpperCase()])
+       } else if (isPercent(content)) {
         let trimmedContent = content.trim()
-        let mode = 0
-        let currency
-        if (trimmedContent.endsWith('%')) {
-          mode = 1
-          trimmedContent = trimmedContent.slice(0, trimmedContent.length - 1)
-        } else {
-          const res = this.currencyMatcher(trimmedContent)
-          if (res !== undefined) {
-            mode = 2;
-            [currency, trimmedContent] = res
-          }
-        }
-
+ 
+        trimmedContent = trimmedContent.slice(0, trimmedContent.length - 1)
+    
         const val = this.numberLiteralsHelper.numericStringToMaybeNumber(trimmedContent)
+    
         if (val !== undefined) {
-          let parseAsNum
-          if (mode === 1) {
-            parseAsNum = new PercentNumber(val / 100)
-          } else if (mode === 2) {
-            parseAsNum = new CurrencyNumber(val, currency as string)
-          } else {
-            parseAsNum = val
-          }
+          const parseAsNum = new PercentNumber(val / 100)
+    
+          return new CellContent.Number(parseAsNum)  
+        }
+    
+        return new CellContent.String(this.getSlicedContentString(content))
+       } else if(this.isCurrency(content)) {
+         let trimmedContent = content.trim()
+ 
+         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+         const res = this.currencyMatcher(trimmedContent)!
+         const currency = res[0]
+ 
+         trimmedContent = res[1]
+ 
+         const val = this.numberLiteralsHelper.numericStringToMaybeNumber(trimmedContent)
+ 
+         if (val !== undefined) {
+          const parseAsNum = new CurrencyNumber(val, currency)
+  
           return new CellContent.Number(parseAsNum)
-        }
-        const parsedDateNumber = this.dateHelper.dateStringToDateNumber(trimmedContent)
-        if (parsedDateNumber !== undefined) {
-          return new CellContent.Number(parsedDateNumber)
-        } else {
-          return new CellContent.String(content.startsWith('\'') ? content.slice(1) : content)
-        }
-      }
-    } else {
-      throw new UnableToParseError(content)
-    }
-  }
+         }
+         return new CellContent.String(this.getSlicedContentString(content))
+       } else {
+         const trimmedContent = content.trim()
+         const val = this.numberLiteralsHelper.numericStringToMaybeNumber(trimmedContent)
+         
+         if (val !== undefined) {
+           return new CellContent.Number(val)
+         }
+         const parsedDateNumber = this.dateHelper.dateStringToDateNumber(trimmedContent)
+         if (parsedDateNumber !== undefined) {
+           return new CellContent.Number(parsedDateNumber)
+         } else {
+           return new CellContent.String(this.getSlicedContentString(content))
+         }
+       }
+     } else {
+       throw new UnableToParseError(content)
+     }
+   }
 
-  private currencyMatcher(token: string): Maybe<[string, string]> {
-    for (const currency of this.config.currencySymbol) {
-      if (token.startsWith(currency)) {
-        return [currency, token.slice(currency.length)]
-      }
-      if (token.endsWith(currency)) {
-        return [currency, token.slice(0, token.length - currency.length)]
-      }
-    }
-    return undefined
+   public isCurrency(text: string): boolean {
+     const trimmedContent = text.trim()
+ 
+     return !!this.currencyMatcher(trimmedContent)
+   }
+
+
+  private getSlicedContentString(content: string): string {
+    return content.startsWith('\'') ? content.slice(1) : content
   }
-}
+ 
+   private currencyMatcher(token: string): Maybe<[string, string]> {
+     for (const currency of this.config.currencySymbol) {
+       if (token.startsWith(currency)) {
+         return [currency, token.slice(currency.length)]
+       }
+       if (token.endsWith(currency)) {
+         return [currency, token.slice(0, token.length - currency.length)]
+       }
+     }
+     return undefined
+   }
+ }
+ 

--- a/src/interpreter/FunctionRegistry.ts
+++ b/src/interpreter/FunctionRegistry.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 Handsoncode. All rights reserved.
  */
 
+import {CellContentParser} from '../CellContentParser'
 import {Config} from '../Config'
 import {AliasAlreadyExisting, FunctionPluginValidationError, ProtectedFunctionError} from '../errors'
 import {HyperFormula} from '../HyperFormula'
@@ -184,13 +185,13 @@ export class FunctionRegistry {
     }
   }
 
-  public initializePlugins(interpreter: Interpreter): void {
+  public initializePlugins(interpreter: Interpreter, cellContentParser: CellContentParser): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const instances: any[] = []
     for (const [functionId, plugin] of this.instancePlugins.entries()) {
       let foundPluginInstance = instances.find(pluginInstance => pluginInstance instanceof plugin)
       if (foundPluginInstance === undefined) {
-        foundPluginInstance = new plugin(interpreter)
+        foundPluginInstance = new plugin(interpreter, cellContentParser)
         instances.push(foundPluginInstance)
       }
       const metadata = validateAndReturnMetadataFromName(functionId, plugin)

--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -7,6 +7,7 @@ import {AbsoluteCellRange, AbsoluteColumnRange, AbsoluteRowRange} from '../Absol
 import {ArraySizePredictor} from '../ArraySize'
 import {ArrayValue, NotComputedArray} from '../ArrayValue'
 import {CellError, ErrorType, invalidSimpleCellAddress} from '../Cell'
+import {CellContentParser} from '../CellContentParser'
 import {Config} from '../Config'
 import {DateTimeHelper} from '../DateTimeHelper'
 import {DependencyGraph} from '../DependencyGraph'
@@ -55,9 +56,10 @@ export class Interpreter {
     private readonly namedExpressions: NamedExpressions,
     public readonly serialization: Serialization,
     public readonly arraySizePredictor: ArraySizePredictor,
-    public readonly dateTimeHelper: DateTimeHelper
+    public readonly dateTimeHelper: DateTimeHelper,
+    public readonly cellContentParser: CellContentParser
   ) {
-    this.functionRegistry.initializePlugins(this)
+    this.functionRegistry.initializePlugins(this, cellContentParser)
     this.criterionBuilder = new CriterionBuilder(config)
   }
 

--- a/src/interpreter/plugin/MatrixPlugin.ts
+++ b/src/interpreter/plugin/MatrixPlugin.ts
@@ -5,6 +5,7 @@
 
 import {ArraySize} from '../../ArraySize'
 import {CellError, ErrorType} from '../../Cell'
+import { CellContentParser } from '../../CellContentParser'
 import {ErrorMessage} from '../../error-message'
 import {AstNodeType, ProcedureAst} from '../../parser'
 import {Interpreter} from '../Interpreter'
@@ -81,8 +82,8 @@ export class MatrixPlugin extends FunctionPlugin implements FunctionPluginTypech
 
   private readonly createKernel: (kernel: KernelFunction, outputSize: ArraySize) => KernelRunShortcut
 
-  constructor(interpreter: Interpreter) {
-    super(interpreter)
+  constructor(interpreter: Interpreter, cellContentParser: CellContentParser) {
+    super(interpreter, cellContentParser)
     if (this.config.gpujs === undefined) {
       this.createKernel = this.createCpuKernel
     } else {

--- a/test/infer-return-types.spec.ts
+++ b/test/infer-return-types.spec.ts
@@ -1,0 +1,88 @@
+import {CellValueDetailedType, HyperFormula, SimpleRangeValue} from '../src'
+import {ArraySize} from '../src/ArraySize'
+import {InterpreterState} from '../src/interpreter/InterpreterState'
+import {InterpreterValue} from '../src/interpreter/InterpreterValue'
+import {ArgumentTypes, FunctionPlugin, FunctionPluginTypecheck} from '../src/interpreter/plugin/FunctionPlugin'
+import {ProcedureAst} from '../src/parser'
+import {adr} from './testUtils'
+
+class FooPlugin extends FunctionPlugin implements FunctionPluginTypecheck<FooPlugin> {
+  public static implementedFunctions = {
+    'ARRAYINFERFOO': {
+      method: 'arrayinferfoo',
+      arraySizeMethod: 'arraysizeFoo',
+      inferReturnType: true,
+      parameters: []
+    },
+    'INFERFOO': {
+      method: 'inferfoo',
+      inferReturnType: true,
+      parameters: [
+        {argumentType: ArgumentTypes.ANY, optionalArg: true}
+      ]
+    },
+  }
+
+  public static translations = {
+    'enGB': {
+      'ARRAYINFERFOO': 'ARRAYINFERFOO',
+      'INFERFOO': 'INFERFOO'
+    },
+  }
+
+  public inferfoo(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(ast.args, state, this.metadata('INFERFOO'), (arg) => {
+      if (arg === 0) {
+        return '2%'
+      }
+      return '$2'  
+    })
+  }
+
+  public arrayinferfoo(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(ast.args, state, this.metadata('ARRAYINFERFOO'), () => {
+      return SimpleRangeValue.onlyValues([['$2', '2%'], [2, '"2%"']])
+    })
+  }
+
+  public arraysizeFoo(_ast: ProcedureAst, _state: InterpreterState): ArraySize {
+    return new ArraySize(2, 2)
+  }
+}
+
+describe('infer return types', () => {
+  beforeEach(() => {
+    HyperFormula.registerFunctionPlugin(FooPlugin, FooPlugin.translations)
+  })
+
+  afterEach(() => {
+    HyperFormula.unregisterFunctionPlugin(FooPlugin)
+  })
+
+  it('numbers', () => {
+    const engine = HyperFormula.buildFromArray([['=INFERFOO()', '=INFERFOO(0)']])
+
+    expect(engine.getCellValue(adr('A1'))).toEqual(2)
+    expect(engine.getCellValueDetailedType(adr('A1'))).toBe(CellValueDetailedType.NUMBER_CURRENCY)
+    
+    expect(engine.getCellValue(adr('B1'))).toEqual(.02)
+    expect(engine.getCellValueDetailedType(adr('B1'))).toBe(CellValueDetailedType.NUMBER_PERCENT)
+  })
+
+  it.only('arrays', () => {
+    const engine = HyperFormula.buildFromArray([['=ARRAYINFERFOO()']])
+
+    expect(engine.getCellValue(adr('A1'))).toEqual(2)
+    expect(engine.getCellValueDetailedType(adr('A1'))).toBe(CellValueDetailedType.NUMBER_CURRENCY)
+    
+    expect(engine.getCellValue(adr('B1'))).toEqual(.02)
+    expect(engine.getCellValueDetailedType(adr('B1'))).toBe(CellValueDetailedType.NUMBER_PERCENT)
+  
+    expect(engine.getCellValue(adr('A2'))).toEqual(2)
+    expect(engine.getCellValueDetailedType(adr('A2'))).toBe(CellValueDetailedType.NUMBER_RAW)
+    
+    expect(engine.getCellValue(adr('B2'))).toEqual('\"2%\"')
+    expect(engine.getCellValueDetailedType(adr('B2'))).toBe(CellValueDetailedType.STRING)
+
+  })
+})


### PR DESCRIPTION
### Context
Consider any formula that you do not know the exact return type of or the return type is too large and can change based on parameters :

`=GET_FINANCIALS("AMZN", "revenue")`, this would return a currency value.

`=GET_FINANCIALS("AMZN", "operatingMargin")`, this would return a percentage value.

`=GET_FINANCIALS("AMZN", "balanceSheet")`, this would return an object of currencies & percentages.

Hyperformula currently has this for custom plugins: `returnNumberType`. This isn't sufficient for functions who's return types can change dynamically.

The percentages should be automatically formatted as percentages. The currencies as currencies.

Currently this is not possible in HF and this causes bugs where other formulas don't work if you put the above as parameters because the cell types are wrong.

However we should not apply it to all functions automatically because some functions such as `=TEXT()` want to format stuff as strings specifically.

My PR currently only infers if `runFunction*` is called. When https://github.com/handsontable/hyperformula/issues/765 is done it should be done automatically regardless if the user has `inferReturnTypes` enabled.

### How has this been tested?
See the .spec file. It isn't fully tested yet for all scenario's.

I need approval that this feature is needed first before I spend time on tests.

### Types of changes
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. N/A

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation,
- [x] I described the modification in the CHANGELOG.md file.