### PR TITLE
Changed whitespace regex -> /s+.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed lexer whitespace to match all white spaces. (#877)
+
 ## [1.3.0] - 2021-10-20
 
 ### Added

--- a/src/parser/LexerConfig.ts
+++ b/src/parser/LexerConfig.ts
@@ -95,7 +95,7 @@ export const ErrorLiteral = createToken({name: 'ErrorLiteral', pattern: /#[A-Za-
 /* skipping whitespaces */
 export const WhiteSpace = createToken({
   name: 'WhiteSpace',
-  pattern: /[ \t\n\r]+/,
+  pattern: /\s+/,
 })
 
 export interface ILexerConfig {

--- a/test/parser/white-spaces.spec.ts
+++ b/test/parser/white-spaces.spec.ts
@@ -78,6 +78,11 @@ describe('tokenizeFormula', () => {
     expect(tokens[1].tokenType).toEqual(WhiteSpace)
   })
 
+  it('should treat non-breaking space as a whitespace', () => {
+    const tokens = lexer.tokenizeFormula('=\u00A01').tokens
+    expect(tokens[1].tokenType).toEqual(WhiteSpace)
+  })
+
   it('should treat line feed (U+000A) as whitespace ', () => {
     const tokens = lexer.tokenizeFormula('=\n1').tokens
     expect(tokens[1].tokenType).toEqual(WhiteSpace)


### PR DESCRIPTION
### Context
A crazy bug I just ran into caused by this.

In our spreadsheet we use a contentEditable div. We parse the text using chevrotain's lexer to find the cells to highlight. Like so:

![image](https://user-images.githubusercontent.com/15030491/146608559-0b2ea020-0579-4c8b-9372-ca08f25de2bd.png)

When we access the content using `.textContent` it seems to replace all spaces with non-breaking spaces.

This should be fine because hyperformula should replace ANY space. However it's missing non-breaking spaces from the regex: 

`pattern: /[ \t\n\r]+/`

Hyperformula's lexer was returning `#ERROR!` due to this.

So it should be `/s+` instead.

### How has this been tested?
See the spec test.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


### Checklist:
- [x] I described the modification in the CHANGELOG.md file.