### PR TITLE
Docs: Adding HyperFormula 2.0.0 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,31 +12,31 @@ For more information on this release, see:
 - [Migration guide](https://handsontable.github.io/hyperformula/guide/migration-from-1.0-to-2.0.html)
 
 ### Added
-- Added support for reversed ranges. (#834)
-- Added a new configuration option, `ignoreWhiteSpace`, which allows for parsing formulas that contain whitespace characters of any kind. (#898)
+- Added support for reversed ranges. [#834](https://github.com/handsontable/hyperformula/issues/834)
+- Added a new configuration option, `ignoreWhiteSpace`, which allows for parsing formulas that contain whitespace characters of any kind. [#898](https://github.com/handsontable/hyperformula/issues/898)
 
 ### Changed
-- **Breaking change**: Removed the `gpu.js` dependency and its use, to speed up the installation time. (#812)
-- **Breaking change**: Removed the deprecated `gpujs` and `gpuMode` configuration options. (#812)
+- **Breaking change**: Removed the `gpu.js` dependency and its use, to speed up the installation time. [#812](https://github.com/handsontable/hyperformula/issues/812)
+- **Breaking change**: Removed the deprecated `gpujs` and `gpuMode` configuration options. [#812](https://github.com/handsontable/hyperformula/issues/812)
 
 ### Fixed
-- Fixed an issue where the RATE function didn't converge for some inputs. (#905)
+- Fixed an issue where the RATE function didn't converge for some inputs. [#905](https://github.com/handsontable/hyperformula/issues/905)
 
 ## [1.3.1] - 2022-01-11
 
 ### Fixed
-- Fixed an issue where warnings about deprecated configuration options were getting duplicated. (#882)
+- Fixed an issue where warnings about deprecated configuration options were getting duplicated. [#882](https://github.com/handsontable/hyperformula/issues/882)
 
 ## [1.3.0] - 2021-10-20
 
 ### Added
-- Added a new static property: `defaultConfig`. (#822)
-- The `getFillRangeData()` method can now use one sheet for its source and another sheet for its target. (#836)
+- Added a new static property: `defaultConfig`. [#822](https://github.com/handsontable/hyperformula/issues/822)
+- The `getFillRangeData()` method can now use one sheet for its source and another sheet for its target. [#836](https://github.com/handsontable/hyperformula/issues/836)
 
 ### Fixed
-- Fixed the handling of Unicode characters and non-letter characters in the `PROPER` function. (#811)
-- Fixed unnecessary warnings caused by deprecated configuration options. (#830)
-- Fixed the `SUMPRODUCT` function. (#810)
+- Fixed the handling of Unicode characters and non-letter characters in the `PROPER` function. [#811](https://github.com/handsontable/hyperformula/issues/811)
+- Fixed unnecessary warnings caused by deprecated configuration options. [#830](https://github.com/handsontable/hyperformula/issues/830)
+- Fixed the `SUMPRODUCT` function. [#810](https://github.com/handsontable/hyperformula/issues/810)
 
 ## [1.2.0] - 2021-09-23
 
@@ -46,45 +46,45 @@ For more information on this release, see:
 ## [1.1.0] - 2021-08-12
 
 ### Changed
-- Deprecated the `binarySearchThreshold` configuration option, as every search of sorted data always uses binary search. (#791)
+- Deprecated the `binarySearchThreshold` configuration option, as every search of sorted data always uses binary search. [#791](https://github.com/handsontable/hyperformula/issues/791)
 
 ### Added
-- Added support for the array arithmetic mode in the `calculateFormula()` method. (#782)
-- Added a new `CellType` returned by `getCellType`: `CellType.ARRAYFORMULA`. It's assigned to the top-left corner of an array, and is recognized by the `isCellPartOfArray()` and `doesCellHaveFormula()` methods. (#781)
+- Added support for the array arithmetic mode in the `calculateFormula()` method. [#782](https://github.com/handsontable/hyperformula/issues/782)
+- Added a new `CellType` returned by `getCellType`: `CellType.ARRAYFORMULA`. It's assigned to the top-left corner of an array, and is recognized by the `isCellPartOfArray()` and `doesCellHaveFormula()` methods. [#781](https://github.com/handsontable/hyperformula/issues/781)
 
 ### Fixed
-- Fixed an issue with searching sorted data. (#787)
-- Fixed the `destroy` method to properly destroy HyperFormula instances. (#788)
+- Fixed an issue with searching sorted data. [#787](https://github.com/handsontable/hyperformula/issues/787)
+- Fixed the `destroy` method to properly destroy HyperFormula instances. [#788](https://github.com/handsontable/hyperformula/issues/788)
 
 
 ## [1.0.0] - 2021-07-15
 
 ### Changed
-- **Breaking change**: Changed API of many sheet-related methods to take sheetId instead of sheetName as an argument. (#645)
-- **Breaking change**: Removed support for matrix formulas (`{=FORMULA}`) notation. Engine now supports formulas returning array of values (instead of only scalars). (#652)
-- **Breaking change**: Removed numeric matrix detection along with matrixDetection and matrixDetectionThreshold config options. (#669)
-- **Breaking change**: Changed API of the following methods to take `SimpleCellRange` type argument: `copy`,  `cut`, `getCellDependents`, `getCellPrecedents`, `getFillRangeData`, `getRangeFormulas`,  `getRangeSerialized`, `getRangeValues`, `isItPossibleToMoveCells`, `isItPossibleToSetCellContents`, `moveCells`. (#687)
+- **Breaking change**: Changed API of many sheet-related methods to take sheetId instead of sheetName as an argument. [#645](https://github.com/handsontable/hyperformula/issues/645)
+- **Breaking change**: Removed support for matrix formulas (`{=FORMULA}`) notation. Engine now supports formulas returning array of values (instead of only scalars). [#652](https://github.com/handsontable/hyperformula/issues/652)
+- **Breaking change**: Removed numeric matrix detection along with matrixDetection and matrixDetectionThreshold config options. [#669](https://github.com/handsontable/hyperformula/issues/669)
+- **Breaking change**: Changed API of the following methods to take `SimpleCellRange` type argument: `copy`,  `cut`, `getCellDependents`, `getCellPrecedents`, `getFillRangeData`, `getRangeFormulas`,  `getRangeSerialized`, `getRangeValues`, `isItPossibleToMoveCells`, `isItPossibleToSetCellContents`, `moveCells`. [#687](https://github.com/handsontable/hyperformula/issues/687)
 - **Breaking change**: Changed the AGPLv3 license to GPLv3.
 - **Breaking change**: Removed the free non-commercial license.
-- **Breaking change**: Changed behaviour of `setCellContents` so that it is possible to override space occupied by spilled array. (#708)
-- **Breaking change**: Changed behaviour of `addRows/removeRows` so that it is possible to add/remove rows across spilled array without changing array size. (#708)
-- **Breaking change**: Changed behaviour of `addColumns/removeColumns` so that it is possible to add/remove columns across spilled array without changing array size. (#732)
-- **Breaking change**: Changed config options (#747):
+- **Breaking change**: Changed behaviour of `setCellContents` so that it is possible to override space occupied by spilled array. [#708](https://github.com/handsontable/hyperformula/issues/708)
+- **Breaking change**: Changed behaviour of `addRows/removeRows` so that it is possible to add/remove rows across spilled array without changing array size. [#708](https://github.com/handsontable/hyperformula/issues/708)
+- **Breaking change**: Changed behaviour of `addColumns/removeColumns` so that it is possible to add/remove columns across spilled array without changing array size. [#732](https://github.com/handsontable/hyperformula/issues/732)
+- **Breaking change**: Changed config options [#747](https://github.com/handsontable/hyperformula/issues/747):
 
 | before                | after                |
 |-----------------------|----------------------|
 | matrixColumnSeparator | arrayColumnSeparator |
 | matrixRowSeparator    | arrayRowSeparator    |
 
-- **Breaking change**: Changed CellType.MATRIX to CellType.ARRAY (#747)
-- **Breaking change**: Changed API methods (#747):
+- **Breaking change**: Changed CellType.MATRIX to CellType.ARRAY [#747](https://github.com/handsontable/hyperformula/issues/747)
+- **Breaking change**: Changed API methods [#747](https://github.com/handsontable/hyperformula/issues/747):
 
 | before             | after             |
 |--------------------|-------------------|
 | matrixMapping      | arrrayMapping     |
 | isCellPartOfMatrix | isCellPartOfArray |
 
-- **Breaking change**: Changed Exceptions (#747):
+- **Breaking change**: Changed Exceptions [#747](https://github.com/handsontable/hyperformula/issues/747):
 
 | before                       | after                       |
 |------------------------------|-----------------------------|
@@ -92,176 +92,176 @@ For more information on this release, see:
 | TargetLocationHasMatrixError | TargetLocationHasArrayError |
 
 - Changed SWITCH function, so it takes array as its first argument.
-- Changed TRANSPOSE function, so it works with data of any type. (#708)
-- Changed the way how we include `gpu.js` making it even more optional (#753)
+- Changed TRANSPOSE function, so it works with data of any type. [#708](https://github.com/handsontable/hyperformula/issues/708)
+- Changed the way how we include `gpu.js` making it even more optional [#753](https://github.com/handsontable/hyperformula/issues/753)
 
 ### Added
-- Added support for array arithmetic. (#628)
-- Added performance improvements for array handling. (#629)
-- Added ARRAYFORMULA function. (#630)
-- Added FILTER function. (#668)
-- Added ARRAY_CONSTRAIN function. (#661)
-- Added casting to scalars from non-range arrays. (#663)
-- Added support for range interpolation. (#665)
-- Added parsing of arrays in formulas (together with respective config options for separators). (#671)
-- Added support for vectorization of scalar functions. (#673)
-- Added support for time in JS `Date()` objects on the input. (#648)
-- Added validation of API argument types for simple types. (#654)
-- Added named expression handling to engine factories. (#680)
-- Added `getAllNamedExpressionsSerialized` method. (#680)
-- Added parsing of arrays in formulas (together with respective config options for separators). (#671)
-- Added utility function for filling ranges with source from other range. (#678)
-- Added pretty print for detailedCellError. (#712)
-- Added `simpleCellRangeFromString` and `simpleCellRangeToString` helpers. (#720)
-- Added `CellError` to exports. (#736)
-- Added mapping policies to the exports:   `AlwaysDense`, `AlwaysSparse`, `DenseSparseChooseBasedOnThreshold`. (#747)
-- Added `#SPILL!` error type. (#708)
-- Added large tests for CRUD interactions. (#755)
-- Added support for array arithmetic in plugins. (#766)
-- Added a flag to `getFillRangeData` to support different types of offsetting. (#767)
+- Added support for array arithmetic. [#628](https://github.com/handsontable/hyperformula/issues/628)
+- Added performance improvements for array handling. [#629](https://github.com/handsontable/hyperformula/issues/629)
+- Added ARRAYFORMULA function. [#630](https://github.com/handsontable/hyperformula/issues/630)
+- Added FILTER function. [#668](https://github.com/handsontable/hyperformula/issues/668)
+- Added ARRAY_CONSTRAIN function. [#661](https://github.com/handsontable/hyperformula/issues/661)
+- Added casting to scalars from non-range arrays. [#663](https://github.com/handsontable/hyperformula/issues/663)
+- Added support for range interpolation. [#665](https://github.com/handsontable/hyperformula/issues/665)
+- Added parsing of arrays in formulas (together with respective config options for separators). [#671](https://github.com/handsontable/hyperformula/issues/671)
+- Added support for vectorization of scalar functions. [#673](https://github.com/handsontable/hyperformula/issues/673)
+- Added support for time in JS `Date()` objects on the input. [#648](https://github.com/handsontable/hyperformula/issues/648)
+- Added validation of API argument types for simple types. [#654](https://github.com/handsontable/hyperformula/issues/654)
+- Added named expression handling to engine factories. [#680](https://github.com/handsontable/hyperformula/issues/680)
+- Added `getAllNamedExpressionsSerialized` method. [#680](https://github.com/handsontable/hyperformula/issues/680)
+- Added parsing of arrays in formulas (together with respective config options for separators). [#671](https://github.com/handsontable/hyperformula/issues/671)
+- Added utility function for filling ranges with source from other range. [#678](https://github.com/handsontable/hyperformula/issues/678)
+- Added pretty print for detailedCellError. [#712](https://github.com/handsontable/hyperformula/issues/712)
+- Added `simpleCellRangeFromString` and `simpleCellRangeToString` helpers. [#720](https://github.com/handsontable/hyperformula/issues/720)
+- Added `CellError` to exports. [#736](https://github.com/handsontable/hyperformula/issues/736)
+- Added mapping policies to the exports:   `AlwaysDense`, `AlwaysSparse`, `DenseSparseChooseBasedOnThreshold`. [#747](https://github.com/handsontable/hyperformula/issues/747)
+- Added `#SPILL!` error type. [#708](https://github.com/handsontable/hyperformula/issues/708)
+- Added large tests for CRUD interactions. [#755](https://github.com/handsontable/hyperformula/issues/755)
+- Added support for array arithmetic in plugins. [#766](https://github.com/handsontable/hyperformula/issues/766)
+- Added a flag to `getFillRangeData` to support different types of offsetting. [#767](https://github.com/handsontable/hyperformula/issues/767)
 
 ### Fixed
-- Fixed an issue with arrays and cruds. (#651)
-- Fixed handling of arrays for ROWS/COLUMNS functions. (#677)
-- Fixed an issue with nested namedexpressions. (#679)
-- Fixed an issue with matrixDetection + number parsing. (#686)
-- Fixed an issue with NOW and TODAY functions. (#709)
-- Fixed an issue with MIN/MAX function caches. (#711)
-- Fixed an issue with caching and order of evaluation. (#735)
+- Fixed an issue with arrays and cruds. [#651](https://github.com/handsontable/hyperformula/issues/651)
+- Fixed handling of arrays for ROWS/COLUMNS functions. [#677](https://github.com/handsontable/hyperformula/issues/677)
+- Fixed an issue with nested named expressions. [#679](https://github.com/handsontable/hyperformula/issues/679)
+- Fixed an issue with matrixDetection + number parsing. [#686](https://github.com/handsontable/hyperformula/issues/686)
+- Fixed an issue with NOW and TODAY functions. [#709](https://github.com/handsontable/hyperformula/issues/709)
+- Fixed an issue with MIN/MAX function caches. [#711](https://github.com/handsontable/hyperformula/issues/711)
+- Fixed an issue with caching and order of evaluation. [#735](https://github.com/handsontable/hyperformula/issues/735)
 
 ## [0.6.2] - 2021-05-26
 
 ### Changed
-- Modified a private field in one of the classes to ensure broader compatibility with older TypeScript versions. (#681)
+- Modified a private field in one of the classes to ensure broader compatibility with older TypeScript versions. [#681](https://github.com/handsontable/hyperformula/issues/681)
 
 ## [0.6.1] - 2021-05-24
 
 ### Changed
-- Remove redundant `'assert'` dependency from the code. (#672)
+- Remove redundant `'assert'` dependency from the code. [#672](https://github.com/handsontable/hyperformula/issues/672)
 
 ### Fixed
-- Fixed library support for IE11. The `unorm` package is added to the dependencies. (#675)
+- Fixed library support for IE11. The `unorm` package is added to the dependencies. [#675](https://github.com/handsontable/hyperformula/issues/675)
 
 ## [0.6.0] - 2021-04-27
 
 ### Changed
-- **Breaking change**: Moved `GPU.js` from `dependencies` to `devDependencies` and `optionalDependencies`. (#642)
+- **Breaking change**: Moved `GPU.js` from `dependencies` to `devDependencies` and `optionalDependencies`. [#642](https://github.com/handsontable/hyperformula/issues/642)
 
 ### Added
-- Added two new fired events, for suspending and resuming execution. (#637)
-- Added listing in scopes to `listNamedExpressions` method. (#638)
+- Added two new fired events, for suspending and resuming execution. [#637](https://github.com/handsontable/hyperformula/issues/637)
+- Added listing in scopes to `listNamedExpressions` method. [#638](https://github.com/handsontable/hyperformula/issues/638)
 
 ### Fixed
-- Fixed issues with scoped named expression. (#646, #641)
-- Fixed an issue with losing formating info about DateTime numbers. (#626)
+- Fixed issues with scoped named expression. [#646](https://github.com/handsontable/hyperformula/issues/646) [#641](https://github.com/handsontable/hyperformula/issues/641)
+- Fixed an issue with losing formating info about DateTime numbers. [#626](https://github.com/handsontable/hyperformula/issues/626)
 
 ## [0.5.0] - 2021-04-15
 
 ### Changed
-- **Breaking change**: A change to the type of value returned via serialization methods. (#617)
-- An input value should be preserved through serialization more precisely. (#617)
-- GPU.js constructor needs to be provided directly to engine configuration. (#355)
-- A deprecated config option vlookupThreshold has been removed. (#620)
+- **Breaking change**: A change to the type of value returned via serialization methods. [#617](https://github.com/handsontable/hyperformula/issues/617)
+- An input value should be preserved through serialization more precisely. [#617](https://github.com/handsontable/hyperformula/issues/617)
+- GPU.js constructor needs to be provided directly to engine configuration. [#355](https://github.com/handsontable/hyperformula/issues/355)
+- A deprecated config option vlookupThreshold has been removed. [#620](https://github.com/handsontable/hyperformula/issues/620)
 
 ### Added
-- Added support for row and column reordering. (#343)
-- Added type inferrence for subtypes for number. (#313)
-- Added parsing of number literals containing '%' or currency symbol (default '$'). (#590)
-- Added ability to fallback to plain CPU implementation for functions that uses GPU.js (#355)
+- Added support for row and column reordering. [#343](https://github.com/handsontable/hyperformula/issues/343)
+- Added type inferrence for subtypes for number. [#313](https://github.com/handsontable/hyperformula/issues/313)
+- Added parsing of number literals containing '%' or currency symbol (default '$'). [#590](https://github.com/handsontable/hyperformula/issues/590)
+- Added ability to fallback to plain CPU implementation for functions that uses GPU.js [#355](https://github.com/handsontable/hyperformula/issues/355)
 
 ### Fixed
-- Fixed minor issue. (#631)
-- Fixed a bug with serialization of some addresses after CRUDs. (#587)
-- Fixed a bug with MEDIAN function implementation. (#601)
-- Fixed a bug with copy-paste operation that could cause out of scope references (#591)
-- Fixed a bug with date parsing. (#614)
-- Fixed a bug where accent/case sensitivity was ignored for LOOKUPs. (#621)
-- Fixed a bug with handling of no time format/no date format scenarios. (#616)
+- Fixed minor issue. [#631](https://github.com/handsontable/hyperformula/issues/631)
+- Fixed a bug with serialization of some addresses after CRUDs. [#587](https://github.com/handsontable/hyperformula/issues/587)
+- Fixed a bug with MEDIAN function implementation. [#601](https://github.com/handsontable/hyperformula/issues/601)
+- Fixed a bug with copy-paste operation that could cause out of scope references [#591](https://github.com/handsontable/hyperformula/issues/591)
+- Fixed a bug with date parsing. [#614](https://github.com/handsontable/hyperformula/issues/614)
+- Fixed a bug where accent/case sensitivity was ignored for LOOKUPs. [#621](https://github.com/handsontable/hyperformula/issues/621)
+- Fixed a bug with handling of no time format/no date format scenarios. [#616](https://github.com/handsontable/hyperformula/issues/616)
 
 ## [0.4.0] - 2020-12-17
 
 ### Changed
-- A **breaking change**: CEILING function implementation to be consistent with existing implementations. (#582)
+- A **breaking change**: CEILING function implementation to be consistent with existing implementations. [#582](https://github.com/handsontable/hyperformula/issues/582)
 
 ### Added
-- Added 50 mathematical functions: ROMAN, ARABIC, FACT, FACTDOUBLE, COMBIN, COMBINA, GCD, LCM, MROUND, MULTINOMIAL, QUOTIENT, RANDBETWEEN, SERIESSUM, SIGN, SQRTPI, SUMX2MY2, SUMX2PY2, SUMXMY2, CEILING.MATH, FLOOR.MATH, FLOOR, CEILING.PRECISE, FLOOR.PRECISE, ISO.CEILING, COMPLEX, IMABS, IMAGINARY, IMARGUMENT, IMCONJUGATE, IMCOS, IMCOSH, IMCOT, IMCSC, IMCSCH, IMDIV, IMEXP, IMLN, IMLOG10, IMLOG2, IMPOWER, IMPRODUCT, IMREAL, IMSEC, IMSECH, IMSIN, IMSINH, IMSQRT, IMSUB,  IMSUM, IMTAN. (#537, #582, #281, #581)
-- Added 106 statistical functions: EXPON.DIST, EXPONDIST, FISHER, FISHERINV, GAMMA, GAMMA.DIST, GAMMADIST, GAMMALN, GAMMALN.PRECISE, GAMMA.INV, GAMMAINV, GAUSS, BETA.DIST, BETADIST, BETA.INV, BETAINV, BINOM.DIST, BINOMDIST, BINOM.INV, BESSELI, BESSELJ, BESSELK, BESSELY, CHISQ.DIST, CHISQ.DIST.RT, CHISQ.INV, CHISQ.INV.RT, CHIDIST, CHIINV, F.DIST, F.DIST.RT, F.INV, F.INV.RT, FDIST, FINV, WEIBULL, WEIBULL.DIST, HYPGEOMDIST, HYPGEOM.DIST, T.DIST, T.DIST.2T, T.DIST.RT, T.INV, T.INV.2T, TDIST, TINV, LOGNORM.DIST, LOGNORMDIST, LOGNORM.INV, LOGINV, NORM.DIST, NORMDIST, NORM.S.DIST, NORMSDIST, NORM.INV, NORMINV, NORM.S.INV, NORMSINV, PHI, NEGBINOM.DIST, NEGBINOMDIST, POISSON, POISSON.DIST, LARGE, SMALL, AVEDEV, CONFIDENCE, CONFIDENCE.NORM, CONFIDENCE.T, DEVSQ, GEOMEAN, HARMEAN, CRITBINOM, COVAR, COVARIANCE.P, COVARIANCE.S, PEARSON, RSQ, STANDARDIZE, Z.TEST, ZTEST, F.TEST, FTEST, STEYX, SLOPE, CHITEST, CHISQ.TEST, T.TEST, TTEST, SKEW.P, SKEW, WEIBULLDIST, VARS, TINV2T, TDISTRT, TDIST2T, STDEVS, FINVRT, FDISTRT, CHIDISTRT, CHIINVRT, COVARIANCEP, COVARIANCES, LOGNORMINV, POISSONDIST, SKEWP. (#152, #154, #160)
-- Added function aliases mechanism. (PR #569)
-- Added support for scientific notation. (#579)
-- Added support for complex numbers. (#281)
+- Added 50 mathematical functions: ROMAN, ARABIC, FACT, FACTDOUBLE, COMBIN, COMBINA, GCD, LCM, MROUND, MULTINOMIAL, QUOTIENT, RANDBETWEEN, SERIESSUM, SIGN, SQRTPI, SUMX2MY2, SUMX2PY2, SUMXMY2, CEILING.MATH, FLOOR.MATH, FLOOR, CEILING.PRECISE, FLOOR.PRECISE, ISO.CEILING, COMPLEX, IMABS, IMAGINARY, IMARGUMENT, IMCONJUGATE, IMCOS, IMCOSH, IMCOT, IMCSC, IMCSCH, IMDIV, IMEXP, IMLN, IMLOG10, IMLOG2, IMPOWER, IMPRODUCT, IMREAL, IMSEC, IMSECH, IMSIN, IMSINH, IMSQRT, IMSUB,  IMSUM, IMTAN. [#537](https://github.com/handsontable/hyperformula/issues/537) [#582](https://github.com/handsontable/hyperformula/issues/582) [#281](https://github.com/handsontable/hyperformula/issues/281) [#581](https://github.com/handsontable/hyperformula/issues/581)
+- Added 106 statistical functions: EXPON.DIST, EXPONDIST, FISHER, FISHERINV, GAMMA, GAMMA.DIST, GAMMADIST, GAMMALN, GAMMALN.PRECISE, GAMMA.INV, GAMMAINV, GAUSS, BETA.DIST, BETADIST, BETA.INV, BETAINV, BINOM.DIST, BINOMDIST, BINOM.INV, BESSELI, BESSELJ, BESSELK, BESSELY, CHISQ.DIST, CHISQ.DIST.RT, CHISQ.INV, CHISQ.INV.RT, CHIDIST, CHIINV, F.DIST, F.DIST.RT, F.INV, F.INV.RT, FDIST, FINV, WEIBULL, WEIBULL.DIST, HYPGEOMDIST, HYPGEOM.DIST, T.DIST, T.DIST.2T, T.DIST.RT, T.INV, T.INV.2T, TDIST, TINV, LOGNORM.DIST, LOGNORMDIST, LOGNORM.INV, LOGINV, NORM.DIST, NORMDIST, NORM.S.DIST, NORMSDIST, NORM.INV, NORMINV, NORM.S.INV, NORMSINV, PHI, NEGBINOM.DIST, NEGBINOMDIST, POISSON, POISSON.DIST, LARGE, SMALL, AVEDEV, CONFIDENCE, CONFIDENCE.NORM, CONFIDENCE.T, DEVSQ, GEOMEAN, HARMEAN, CRITBINOM, COVAR, COVARIANCE.P, COVARIANCE.S, PEARSON, RSQ, STANDARDIZE, Z.TEST, ZTEST, F.TEST, FTEST, STEYX, SLOPE, CHITEST, CHISQ.TEST, T.TEST, TTEST, SKEW.P, SKEW, WEIBULLDIST, VARS, TINV2T, TDISTRT, TDIST2T, STDEVS, FINVRT, FDISTRT, CHIDISTRT, CHIINVRT, COVARIANCEP, COVARIANCES, LOGNORMINV, POISSONDIST, SKEWP. [#152](https://github.com/handsontable/hyperformula/issues/152) [#154](https://github.com/handsontable/hyperformula/issues/154) [#160](https://github.com/handsontable/hyperformula/issues/160)
+- Added function aliases mechanism. [#569](https://github.com/handsontable/hyperformula/issues/569)
+- Added support for scientific notation. [#579](https://github.com/handsontable/hyperformula/issues/579)
+- Added support for complex numbers. [#281](https://github.com/handsontable/hyperformula/issues/281)
 
 ### Fixed
-- Fixed a problem with dependencies not collected for specific functions. (#550, #549)
-- Fixed a minor problem with dependencies under nested parenthesis. (#549, #558)
-- Fixed a problem with HLOOKUP/VLOOKUP getting stuck in binary search. (#559, #562)
-- Fixed a problem with the logic of dependency resolving. (#561, #563)
-- Fixed a minor bug with ATAN2 function. (#581)
+- Fixed a problem with dependencies not collected for specific functions. [#550](https://github.com/handsontable/hyperformula/issues/550) [#549](https://github.com/handsontable/hyperformula/issues/549)
+- Fixed a minor problem with dependencies under nested parenthesis. [#549](https://github.com/handsontable/hyperformula/issues/549) [#558](https://github.com/handsontable/hyperformula/issues/558)
+- Fixed a problem with HLOOKUP/VLOOKUP getting stuck in binary search. [#559](https://github.com/handsontable/hyperformula/issues/559) [#562](https://github.com/handsontable/hyperformula/issues/562)
+- Fixed a problem with the logic of dependency resolving. [#561](https://github.com/handsontable/hyperformula/issues/561) [#563](https://github.com/handsontable/hyperformula/issues/563)
+- Fixed a minor bug with ATAN2 function. [#581](https://github.com/handsontable/hyperformula/issues/581)
 
 ## [0.3.0] - 2020-10-22
 
 ### Added
-- Added 9 text functions EXACT, LOWER, UPPER, MID, T, SUBSTITUTE, REPLACE, UNICODE, UNICHAR. (#159)
-- Added 5 datetime functions: INTERVAL, NETWORKDAYS, NETWORKDAYS.INTL, WORKDAY, WORKDAY.INTL. (#153)
-- Added 3 information functions HLOOKUP, ROW, COLUMN. (PR #520)
-- Added 5 financial functions FVSCHEDULE, NPV, MIRR, PDURATION, XNPV. (PR #542)
-- Added 12 statistical functions VAR.P, VAR.S, VARA, VARPA, STDEV.P, STDEV.S, STDEVA, STDEVPA, VARP, VAR, STDEVP, STDEV. (PR #536)
-- Added 2 mathematical functions SUBTOTAL, PRODUCT. (PR #536)
-- Added 15 operator functions HF.ADD, HF.CONCAT, HF.DIVIDE, HF.EQ, HF.GT, HF.GTE, HF.LT, HF.LTE, HF.MINUS, HF.MULTIPLY, HF.NE, HF.POW, HF.UMINUS, HF.UNARY_PERCENT, HF.UPLUS (PR #543).
+- Added 9 text functions EXACT, LOWER, UPPER, MID, T, SUBSTITUTE, REPLACE, UNICODE, UNICHAR. [#159](https://github.com/handsontable/hyperformula/issues/159)
+- Added 5 datetime functions: INTERVAL, NETWORKDAYS, NETWORKDAYS.INTL, WORKDAY, WORKDAY.INTL. [#153](https://github.com/handsontable/hyperformula/issues/153)
+- Added 3 information functions HLOOKUP, ROW, COLUMN. [#520](https://github.com/handsontable/hyperformula/issues/520)
+- Added 5 financial functions FVSCHEDULE, NPV, MIRR, PDURATION, XNPV. [#542](https://github.com/handsontable/hyperformula/issues/542)
+- Added 12 statistical functions VAR.P, VAR.S, VARA, VARPA, STDEV.P, STDEV.S, STDEVA, STDEVPA, VARP, VAR, STDEVP, STDEV. [#536](https://github.com/handsontable/hyperformula/issues/536)
+- Added 2 mathematical functions SUBTOTAL, PRODUCT. [#536](https://github.com/handsontable/hyperformula/issues/536)
+- Added 15 operator functions HF.ADD, HF.CONCAT, HF.DIVIDE, HF.EQ, HF.GT, HF.GTE, HF.LT, HF.LTE, HF.MINUS, HF.MULTIPLY, HF.NE, HF.POW, HF.UMINUS, HF.UNARY_PERCENT, HF.UPLUS. [#543](https://github.com/handsontable/hyperformula/issues/543)
 
 ### Fixed
-- Fixed multiple issues with VLOOKUP function. (#526, #528)
-- Fixed MATCH and INDEX functions compatiblity. (PR #520)
-- Fixed issue with config update that does not preserve named expressions. (#527)
-- Fixed minor issue with arithmetic operations error messages. (#532)
+- Fixed multiple issues with VLOOKUP function. [#526](https://github.com/handsontable/hyperformula/issues/526) [#528](https://github.com/handsontable/hyperformula/issues/528)
+- Fixed MATCH and INDEX functions compatiblity. [#520](https://github.com/handsontable/hyperformula/issues/520)
+- Fixed issue with config update that does not preserve named expressions. [#527](https://github.com/handsontable/hyperformula/issues/527)
+- Fixed minor issue with arithmetic operations error messages. [#532](https://github.com/handsontable/hyperformula/issues/532)
 
 ## [0.2.0] - 2020-09-22
 
 ### Added
-- Added 9 text functions LEN, TRIM, PROPER, CLEAN, REPT, RIGHT, LEFT, SEARCH, FIND. (#221)
-- Added helper methods for keeping track of cell/range dependencies: `getCellPrecedents` and `getCellDependents`. (#441)
-- Added 22 financial functions FV, PMT, PPMT, IPMT, CUMIPMT, CUMPRINC, DB, DDB, DOLLARDE, DOLLARFR, EFFECT, ISPMT, NOMINAL, NPER, RATE, PV, RRI, SLN, SYD, TBILLEQ, TBILLPRICE, TBILLYIELD. (#494)
-- Added FORMULATEXT function. (PR #422)
-- Added 8 information functions ISERR, ISNA, ISREF, NA, SHEET, SHEETS, ISBINARY, ISFORMULA. (#481)
-- Added 15 date functions: WEEKDAY, DATEVALUE, HOUR, MINUTE, SECOND, TIME, TIMEVALUE, NOW, TODAY, EDATE, WEEKNUM, ISOWEEKNUM, DATEDIF, DAYS360, YEARFRAC. (#483)
-- Added 13 trigonometry functions: SEC, CSC, SINH, COSH, TANH, COTH, SECH, CSCH, ACOT, ASINH, ACOSH, ATANH, ACOTH. (#485)
-- Added 6 engineering functions: OCT2BIN, OCT2DEC, OCT2HEX, HEX2BIN, HEX2OCT, HEX2DEC. (#497)
-- Added a configuration option to evaluate reference to an empty cells as a zero. (#476)
-- Added new error type: missing licence. (#306)
-- Added detailed error messages for error values. (#506)
-- Added ability to handle more characters in quoted sheet names. (#509)
-- Added support for escaping apostrophe character in quoted sheet names. (#64)
+- Added 9 text functions LEN, TRIM, PROPER, CLEAN, REPT, RIGHT, LEFT, SEARCH, FIND. [#221](https://github.com/handsontable/hyperformula/issues/221)
+- Added helper methods for keeping track of cell/range dependencies: `getCellPrecedents` and `getCellDependents`. [#441](https://github.com/handsontable/hyperformula/issues/441)
+- Added 22 financial functions FV, PMT, PPMT, IPMT, CUMIPMT, CUMPRINC, DB, DDB, DOLLARDE, DOLLARFR, EFFECT, ISPMT, NOMINAL, NPER, RATE, PV, RRI, SLN, SYD, TBILLEQ, TBILLPRICE, TBILLYIELD. [#494](https://github.com/handsontable/hyperformula/issues/494)
+- Added FORMULATEXT function. [#422](https://github.com/handsontable/hyperformula/issues/422)
+- Added 8 information functions ISERR, ISNA, ISREF, NA, SHEET, SHEETS, ISBINARY, ISFORMULA. [#481](https://github.com/handsontable/hyperformula/issues/481)
+- Added 15 date functions: WEEKDAY, DATEVALUE, HOUR, MINUTE, SECOND, TIME, TIMEVALUE, NOW, TODAY, EDATE, WEEKNUM, ISOWEEKNUM, DATEDIF, DAYS360, YEARFRAC. [#483](https://github.com/handsontable/hyperformula/issues/483)
+- Added 13 trigonometry functions: SEC, CSC, SINH, COSH, TANH, COTH, SECH, CSCH, ACOT, ASINH, ACOSH, ATANH, ACOTH. [#485](https://github.com/handsontable/hyperformula/issues/485)
+- Added 6 engineering functions: OCT2BIN, OCT2DEC, OCT2HEX, HEX2BIN, HEX2OCT, HEX2DEC. [#497](https://github.com/handsontable/hyperformula/issues/497)
+- Added a configuration option to evaluate reference to an empty cells as a zero. [#476](https://github.com/handsontable/hyperformula/issues/476)
+- Added new error type: missing licence. [#306](https://github.com/handsontable/hyperformula/issues/306)
+- Added detailed error messages for error values. [#506](https://github.com/handsontable/hyperformula/issues/506)
+- Added ability to handle more characters in quoted sheet names. [#509](https://github.com/handsontable/hyperformula/issues/509)
+- Added support for escaping apostrophe character in quoted sheet names. [#64](https://github.com/handsontable/hyperformula/issues/64)
 
 ### Changed
-- Operation `moveCells` creating cyclic dependencies does not cause losing original formula. (#479)
-- Simplified adding new function modules, reworked (simplified) implementations of existing modules. (#480)
+- Operation `moveCells` creating cyclic dependencies does not cause losing original formula. [#479](https://github.com/handsontable/hyperformula/issues/479)
+- Simplified adding new function modules, reworked (simplified) implementations of existing modules. [#480](https://github.com/handsontable/hyperformula/issues/480)
 
 ### Fixed
-- Fixed hardcoding of languages in i18n tests. (#471)
-- Fixed many compilation warnings based on LGTM analysis. (#473)
-- Fixed `moveCells` behaviour when moving part of a range. (#479)
-- Fixed `moveColumns`/`moveRows` inconsistent behaviour. (#479)
-- Fixed undo of `moveColumns`/`moveRows` operations. (#479)
-- Fixed name-collision issue in translations. (#486)
-- Fixed bug in concatenation + `nullValue`. (#495)
-- Fixed bug when undoing irreversible operation. (#502)
-- Fixed minor issue with CHAR function logic. (#510)
-- Fixed `simpleCellAddressToString` behaviour when converting quoted sheet names. (#514)
-- Fixed issues with numeric aggregation functions. (#515)
+- Fixed hardcoding of languages in i18n tests. [#471](https://github.com/handsontable/hyperformula/issues/471)
+- Fixed many compilation warnings based on LGTM analysis. [#473](https://github.com/handsontable/hyperformula/issues/473)
+- Fixed `moveCells` behaviour when moving part of a range. [#479](https://github.com/handsontable/hyperformula/issues/479)
+- Fixed `moveColumns`/`moveRows` inconsistent behaviour. [#479](https://github.com/handsontable/hyperformula/issues/479)
+- Fixed undo of `moveColumns`/`moveRows` operations. [#479](https://github.com/handsontable/hyperformula/issues/479)
+- Fixed name-collision issue in translations. [#486](https://github.com/handsontable/hyperformula/issues/486)
+- Fixed bug in concatenation + `nullValue`. [#495](https://github.com/handsontable/hyperformula/issues/495)
+- Fixed bug when undoing irreversible operation. [#502](https://github.com/handsontable/hyperformula/issues/502)
+- Fixed minor issue with CHAR function logic. [#510](https://github.com/handsontable/hyperformula/issues/510)
+- Fixed `simpleCellAddressToString` behaviour when converting quoted sheet names. [#514](https://github.com/handsontable/hyperformula/issues/514)
+- Fixed issues with numeric aggregation functions. [#515](https://github.com/handsontable/hyperformula/issues/515)
 
 ## [0.1.3] - 2020-07-21
 
 ### Fixed
-- Fixed a bug in coercion of empty string to boolean value. (#453)
+- Fixed a bug in coercion of empty string to boolean value. [#453](https://github.com/handsontable/hyperformula/issues/453)
 
 ## [0.1.2] - 2020-07-13
 
 ### Fixed
-- Fixed a bug in topological ordering module. (#442)
+- Fixed a bug in topological ordering module. [#442](https://github.com/handsontable/hyperformula/issues/442)
 
 ## [0.1.1] - 2020-07-01
 
 ### Fixed
-- Fixed a typo in a config option from `useRegularExpresssions` to `useRegularExpressions`. (#437)
+- Fixed a typo in a config option from `useRegularExpresssions` to `useRegularExpressions`. [#437](https://github.com/handsontable/hyperformula/issues/437)
 
 ## [0.1.0] - 2020-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ For more information on this release, see:
 
 ### Added
 - Added support for reversed ranges. (#834)
-- Added a new configuration option, `ignoreWhiteSpace`, which allows for parsing formulas that contain whitespace characters of any type. (#898)
+- Added a new configuration option, `ignoreWhiteSpace`, which allows for parsing formulas that contain whitespace characters of any kind. (#898)
 
 ### Changed
 - **Breaking change**: Removed the `gpu.js` dependency and its use, to speed up the installation time. (#812)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For more information on this release, see:
 - [Migration guide](https://handsontable.github.io/hyperformula/guide/migration-from-1.0-to-2.0.html)
 
 ### Added
-- Added support for reverse ranges. (#834)
+- Added support for reversed ranges. (#834)
 - Added a new configuration option, `ignoreWhiteSpace`, which allows for parsing formulas that contain whitespace characters of any type. (#898)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2022-04-14
+
+For more information on this release, see:
+- [Release notes](https://handsontable.github.io/hyperformula/guide/release-notes.html)
+- [Blog post](https://handsontable.com/blog/articles/2022/04/whats-new-in-hyperformula-2.0.0)
+- [Migration guide](https://handsontable.github.io/hyperformula/guide/migration-from-1.0-to-2.0.html)
 
 ### Added
-- Added support for reversed ranges (#834 & #938)
-- Added support for parsing formulas with all whitespace characters (controlled by config param `ignoreWhiteSpace`). (#898)
+- Added support for reverse ranges. (#834)
+- Added a new configuration option, `ignoreWhiteSpace`, which allows for parsing formulas that contain whitespace characters of any type. (#898)
 
 ### Changed
-- **Breaking change**: Removed `gpu.js` dependency and its use. (#812)
+- **Breaking change**: Removed the `gpu.js` dependency and its use, to speed up the installation time. (#812)
+- **Breaking change**: Removed the deprecated `gpujs` and `gpuMode` configuration options. (#812)
 
 ### Fixed
-- Fixed RATE function not converging for some inputs. (#905)
+- Fixed an issue where the RATE function didn't converge for some inputs. (#905)
 
 ## [1.3.1] - 2022-01-11
 

--- a/docs/guide/cell-references.md
+++ b/docs/guide/cell-references.md
@@ -192,7 +192,7 @@ You can reference ranges:
 ### Range restraints
 
 The following restraints apply:
-- You can't mix two different types of ranges together (=A1:B).
+- You can't mix two different types of range references together (=A1:B).
 - Range expressions can't contain [named expressions](/guide/named-expressions.md).
 - At the moment, HyperFormula doesn't support multi-cell range references (=A1:B2:C3).
 

--- a/docs/guide/cell-references.md
+++ b/docs/guide/cell-references.md
@@ -192,7 +192,7 @@ You can reference ranges:
 ### Range restraints
 
 The following restraints apply:
-- You can't mix two different types of range references together (=A1:B).
+- You can't mix two different types of ranges together (=A1:B).
 - Range expressions can't contain [named expressions](/guide/named-expressions.md).
 - At the moment, HyperFormula doesn't support multi-cell range references (=A1:B2:C3).
 

--- a/docs/guide/cell-references.md
+++ b/docs/guide/cell-references.md
@@ -179,8 +179,8 @@ HyperFormula features the following types of ranges:
 | Range type   | Description                         | Example                                       |
 | ------------ | ----------------------------------- | --------------------------------------------- |
 | Cell range   | Has the shape of a finite rectangle | =A1:B2<br>or =A2:B1<br>or =B1:A2<br>or =B2:A1 |
-| Column range | Contains whole columns              | =A:B<br>or =B:A                               |
-| Row range    | Contains whole rows                 | =1:2<br>or =2:1                               |
+| Column range | Contains entire columns             | =A:B<br>or =B:A                               |
+| Row range    | Contains entire rows                | =1:2<br>or =2:1                               |
 
 ### Referencing ranges
 

--- a/docs/guide/known-limitations.md
+++ b/docs/guide/known-limitations.md
@@ -32,7 +32,7 @@ you can't compare the arguments in a formula like this:
 * SUBTOTAL function does not ignore nested subtotals.
 * CHISQ.INV, CHISQ.INV.RT, CHISQ.DIST.RT, CHIDIST, CHIINV and CHISQ.DIST (CHISQ.DIST in CDF mode): Running time grows linearly with the value of the second parameter, degrees_of_freedom (slow for values>1e7).
 * GAMMA.DIST, GAMMA.INV, GAMMADIST, GAMMAINV (GAMMA.DIST and GAMMADIST in CDF mode): Running time grows linearly with the value of the second parameter, alpha (slow for values>1e7). 
-* For certain inputs, the RATE function might have no solutions, or have multiple solutions. In case of multiple solutions, our implementation uses an iterative algorithm (Newton's method) to find an approximation for one of the solutions to within `1e-7`. If the approximation is not found after 50 iterations, the RATE function returns the `#NUM!` error.
+* For certain inputs, the RATE function might have no solutions, or have multiple solutions. Our implementation uses an iterative algorithm (Newton's method) to find an approximation for one of the solutions to within `1e-7`. If the approximation is not found after 50 iterations, the RATE function returns the `#NUM!` error.
 
 ## Google Sheets and Microsoft Excel
 

--- a/docs/guide/known-limitations.md
+++ b/docs/guide/known-limitations.md
@@ -32,7 +32,7 @@ you can't compare the arguments in a formula like this:
 * SUBTOTAL function does not ignore nested subtotals.
 * CHISQ.INV, CHISQ.INV.RT, CHISQ.DIST.RT, CHIDIST, CHIINV and CHISQ.DIST (CHISQ.DIST in CDF mode): Running time grows linearly with the value of the second parameter, degrees_of_freedom (slow for values>1e7).
 * GAMMA.DIST, GAMMA.INV, GAMMADIST, GAMMAINV (GAMMA.DIST and GAMMADIST in CDF mode): Running time grows linearly with the value of the second parameter, alpha (slow for values>1e7). 
-* RATE function might have no solutions (depending on the inputs). Sometimes it has multiple solutions. Our implementation uses an iterative algorithm (Newton's Method) for finding an approximation for one of them to within `1e-7`. If it is not found after `50` iterations function returns the `#NUM!` error.
+* For certain inputs, the RATE function might have no solutions, or have multiple solutions. In case of multiple solutions, our implementation uses an iterative algorithm (Newton's method) to find an approximation for one of the solutions to within `1e-7`. If the approximation is not found after 50 iterations, the RATE function returns the `#NUM!` error.
 
 ## Google Sheets and Microsoft Excel
 

--- a/docs/guide/migration-from-1.0-to-2.0.md
+++ b/docs/guide/migration-from-1.0-to-2.0.md
@@ -1,25 +1,27 @@
-# Migrating from 1.x.x to 2.0
+# Migrating from 1.x to 2.0
 
 To upgrade your HyperFormula version from 1.x.x to 2.0.0, follow this guide.
 
-## Step 1: Remove GPU-related config parameters
+## Drop the `gpujs` and `gpuMode` options
 
-GPU support has been removed. You need to remove all the usages of config parameters:
-- `gpujs`
-- `gpuMode`
+Remove the `gpujs` and `gpuMode` options from your HyperFormula configuration.
 
 Before:
 ```js
-const engine = HyperFormula.buildFromArray(
-    [[]],
-    { gpujs: true, gpuMode: 'cpu', licenseKey: 'gpl-v3' },
-)
+const engine = HyperFormula.buildFromArray([[]], {
+    gpujs: true,
+    gpuMode: 'cpu',
+    licenseKey: 'gpl-v3',
+});
 ```
 
 After:
 ```js
-const engine = HyperFormula.buildFromArray(
-    [[]],
-    { licenseKey: 'gpl-v3' },
-)
+const engine = HyperFormula.buildFromArray([[]], {
+    licenseKey: 'gpl-v3',
+});
 ```
+
+::: tip
+Functions that used GPU acceleration before (MMULT, MAXPOOL, MEDIANPOOL, and TRANSPOSE), still work. Their performance remains largely the same, except for very large data sets.
+:::

--- a/docs/guide/release-notes.md
+++ b/docs/guide/release-notes.md
@@ -9,7 +9,7 @@ HyperFormula adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 - Added support for reversed ranges. [#834](https://github.com/handsontable/hyperformula/issues/834)
-- Added a new configuration option, [`ignoreWhiteSpace`](/api/interfaces/configparams.md#ignorewhitespace), which allows for parsing formulas that contain whitespace characters of any type. [#898](https://github.com/handsontable/hyperformula/issues/898)
+- Added a new configuration option, [`ignoreWhiteSpace`](/api/interfaces/configparams.md#ignorewhitespace), which allows for parsing formulas that contain whitespace characters of any kind. [#898](https://github.com/handsontable/hyperformula/issues/898)
 
 ### Changed
 - **Breaking change**: Removed the `gpu.js` dependency and its use, to speed up the installation time. [#812](https://github.com/handsontable/hyperformula/issues/812)

--- a/docs/guide/release-notes.md
+++ b/docs/guide/release-notes.md
@@ -4,6 +4,20 @@ This page lists HyperFormula release notes. The format is based on [Keep a Chang
 
 HyperFormula adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0
+**Release date: April 14, 2022**
+
+### Added
+- Added support for reverse ranges. [#834](https://github.com/handsontable/hyperformula/issues/834)
+- Added a new configuration option, [`ignoreWhiteSpace`](/api/interfaces/configparams.md#ignorewhitespace), which allows for parsing formulas that contain whitespace characters of any type. [#898](https://github.com/handsontable/hyperformula/issues/898)
+
+### Changed
+- **Breaking change**: Removed the `gpu.js` dependency and its use, to speed up the installation time. [#812](https://github.com/handsontable/hyperformula/issues/812)
+- **Breaking change**: Removed the deprecated `gpujs` and `gpuMode` configuration options. [#812](https://github.com/handsontable/hyperformula/issues/812)
+
+### Fixed
+- Fixed an issue where the RATE function didn't converge for some inputs. [#905](https://github.com/handsontable/hyperformula/issues/905)
+
 ## 1.3.1
 **Release date: January 11, 2022**
 

--- a/docs/guide/release-notes.md
+++ b/docs/guide/release-notes.md
@@ -8,7 +8,7 @@ HyperFormula adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 **Release date: April 14, 2022**
 
 ### Added
-- Added support for reverse ranges. [#834](https://github.com/handsontable/hyperformula/issues/834)
+- Added support for reversed ranges. [#834](https://github.com/handsontable/hyperformula/issues/834)
 - Added a new configuration option, [`ignoreWhiteSpace`](/api/interfaces/configparams.md#ignorewhitespace), which allows for parsing formulas that contain whitespace characters of any type. [#898](https://github.com/handsontable/hyperformula/issues/898)
 
 ### Changed

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -343,7 +343,7 @@ export interface ConfigParams {
    */
   smartRounding: boolean,
   /**
-   * Sets a thousand separator symbol for parsing numerical literals.
+   * Sets a thousands separator symbol for parsing numerical literals.
    *
    * Can be one of the following:
    * - empty

--- a/src/parser/CellAddress.ts
+++ b/src/parser/CellAddress.ts
@@ -50,7 +50,7 @@ export class CellAddress implements AddressWithColumn, AddressWithRow {
         ? CellAddress.absoluteCol.bind(this)
         : row.isRowAbsolute()
           ? CellAddress.absoluteRow.bind(this)
-          // this is because CellAddress.relative expects arguments in different order
+          // this is because `CellAddress.relative` expects arguments in a different order
           : (col: number, row: number, sheet?: number) => CellAddress.relative(row, col, sheet)
 
     return factoryMethod(col.col, row.row, sheet)

--- a/src/parser/FormulaParser.ts
+++ b/src/parser/FormulaParser.ts
@@ -370,12 +370,12 @@ export class FormulaParser extends EmbeddedActionsParser {
     ])
   })
   /**
-   * Rule for expressions that start with OFFSET() function
+   * Rule for expressions that start with the OFFSET function.
    *
-   * OFFSET() function can occur as cell reference or part of cell range.
-   * In order to preserve LL(k) properties, expressions that start with OFFSET() functions needs to have separate rule.
+   * The OFFSET function can occur as a cell reference, or as a part of a cell range.
+   * To preserve LL(k) properties, expressions that start with the OFFSET function need a separate rule.
    *
-   * Proper {@link Ast} node type is built depending on the presence of {@link RangeSeparator}
+   * Depending on the presence of the {@link RangeSeparator}, a proper {@link Ast} node type is built.
    */
   private offsetExpression: AstRule = this.RULE('offsetExpression', () => {
     const offsetProcedure = this.SUBRULE(this.offsetProcedureExpression)


### PR DESCRIPTION
This PR:
- Edits the HyperFormula 2.0.0 changelog entries
- Adds HyperFormula 2.0.0 release notes
- Edits the HyperFormula 2.0.0 migration guide
- Makes minor editing changes related to the HyperFormula 2.0.0 release