### PR TITLE
Docs: Custom functions guide rewrite (review suggestions)

### DIFF
--- a/docs/guide/custom-functions.md
+++ b/docs/guide/custom-functions.md
@@ -1,100 +1,119 @@
 # Custom functions
 
-Expand the library of functions available in your app, by implementing a custom function.
+Expand the library of functions available in your app, by creating custom functions.
 
-## Custom function example
+## Create a custom function
 
-Let's create a custom function that returns the number of letters in the word "HyperFormula".
+As an example, let's create a custom function that returns the number of letters in the word "HyperFormula".
 
-### 1. Create a plugin class
+<iframe
+  src="https://codesandbox.io/embed/github/handsontable/hyperformula-demos/tree/2.0.x/custom-functions?autoresize=1&fontsize=11&hidenavigation=1&theme=light&view=preview"
+  style="width:100%; height:300px; border:0; border-radius: 4px; overflow:hidden;"
+  title="handsontable/hyperformula-demos: custom-functions"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-autoplay allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts">
+</iframe>
 
-Import `FunctionPlugin`, and extend it with your own plugin class:
+### 1. Create a function plugin
+
+Import `FunctionPlugin`, and extend it with a new class. For example:
 
 ```javascript
 import { FunctionPlugin } from 'hyperformula';
 
-export class CountHF extends FunctionPlugin {
+export class MyFunctionPlugin extends FunctionPlugin {
   
-}
+};
 ```
 
-### 2. Define a custom function provided by your plugin
+### 2. Define your function's ID and method
 
-In your newly created class, define a static property called `implementedFunctions`.
+Inside the `implementedFunctions` property of your function plugin, define your custom function.
 
-`implementedFunctions`, defines the IDs of that your plugin's functions (e.g., `HYPER`),
-and maps 
+This is where you define an ID by which [translations](#function-translations), [aliases](#function-aliases), and other elements refer to your function. Make the ID unique among all HyperFormula [functions](built-in-functions.md#list-of-available-functions).
 
-Your newly created class should have a static `implementedFunctions`
-property that defines functions this plugin contains and maps them to their implementations.
-
-The keys are canonical function IDs which are also used to find
-corresponding translations in translation packages.
+Inside your function's object, define a `method` property, which maps your function to an implementation method (we'll define that method later on).
 
 ```javascript
-CountHF.implementedFunctions = {
+MyFunctionPlugin.implementedFunctions = {
+  // let's define the function's ID as `HYPER`
   HYPER: {
-    // we'll define this method's functionality below
+    // we'll define the `hyper` method below
     method: 'hyper',
-  }
+  };
 };
 ```
 
-### 3. Register names for your function
+::: tip
+In `implementedFunctions`, you can define more [custom function options](#custom-function-options).
+:::
 
-Define a `translations` object with the names for your function in every language you want to support.
-These names will be used to call your function inside formulas.
+### 3. Add your function's names
 
-HyperFormula doesn't enforce a naming convention of the function.
-However, all names will be normalized to upper-case, so they
-are not case-sensitive.
+Inside the `translations` property of your function plugin, define your function's names, in every language that you want to support. This is how your end users call your function inside formulas.
+
+Function names are case-insensitive, as they are all normalized to uppercase.
+
+::: tip
+If you support just one language, you still need to define the name of your function in that language.
+:::
 
 ```javascript
-CountHF.translations = {
+MyFunctionPlugin.translations = {
   enGB: {
-    HYPER: "HYPER"
-  }
+    // in English, let's set the function's name to `HYPER`
+    HYPER: 'HYPER',
+  };
 };
 ```
 
-### 4. Implement your custom function
+### 4. Implement your function's logic
 
-For the simplicity of a basic example, our custom function takes no arguments. However, this method imposes a particular structure to
-be used; there are two optional arguments, `ast` and
-`state`, and the function must return the results of
-the calculations.
-
-Optionally, you can wrap your implementation in the built-in `runFunction()` method to make use of the automatic validations:
-- It validates the function parameters according to your [optional parameter](#optional-parameters) setting.
-- It validates the function parameters according to your [argument validation options](#argument-validation-options).
-- It verifies the format of the values returned by your function.
+Inside your function plugin class, add a method that implements your function's calculations. Your method needs to:
+* Take two optional arguments: `ast` and `state`.
+* Return the results of your calculations.
 
 ```javascript
-export class CountHF extends FunctionPlugin {
-  // implement your custom function
-  // wrap your custom function in `runFunction()`
+export class MyFunctionPlugin extends FunctionPlugin {
   hyper(ast, state) {
-    return this.runFunction(ast.args, state, this.metadata('HYPER'), () => 'Hyperformula'.length)
-  }
-}
+    return 'Hyperformula'.length;
+  };
+};
 ```
 
-### 5. Register your plugin with HyperFormula
-
-Before you can use the newly created function, you need to
-register it using `registerFunctionPlugin()` method.
+To benefit from HyperFormula's automatic validations, wrap your method in the built-in `runFunction()` method, which:
+* Verifies the format of the values returned by your function.
+* Validates your function's parameters against your [custom function options](#custom-function-options).
+* Validates arguments passed to your function against your [argument validation options](#argument-validation-options).
 
 ```javascript
-HyperFormula.registerFunctionPlugin(CountHF, CountHF.translations);
+export class MyFunctionPlugin extends FunctionPlugin {
+  hyper(ast, state) {
+    return this.runFunction(ast.args, state, this.metadata('HYPER'), () => 'Hyperformula'.length);
+  };
+};
+```
+
+### 5. Register your plugin
+
+Register your function plugin (and its translations), so that HyperFormula can recognize it. 
+
+Use the `registerFunctionPlugin()` method:
+
+```javascript
+// register `MyFunctionPlugin` and its translations
+HyperFormula.registerFunctionPlugin(MyFunctionPlugin, MyFunctionPlugin.translations);
 ```
 
 ### 6. Use your custom function inside a formula
 
+Now, you can use your HYPER function inside a `=HYPER()` formula:
+
 ```javascript
-// prepare a spreadsheet data
+// prepare spreadsheet data
 const data = [['=HYPER()']];
 
-// build HF instance where you can use the function directly
+// build a HyperFormula instance where you can use your function directly
 const hfInstance = HyperFormula.buildFromArray(data);
 
 // read the value of cell A1
@@ -104,59 +123,74 @@ const result = hfInstance.getCellValue({ sheet: 0, col: 0, row: 0 });
 console.log(result);
 ```
 
-### Complete custom function implementation & demo
-
-<iframe
-  src="https://codesandbox.io/embed/github/handsontable/hyperformula-demos/tree/2.0.x/custom-functions?autoresize=1&fontsize=11&hidenavigation=1&theme=light&view=preview"
-  style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
-  title="handsontable/hyperformula-demos: custom-functions"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-  sandbox="allow-autoplay allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts">
-</iframe>
-
-## Configure the behavior of a custom function
-
-Passing optional parameters to the `implementedFunctions` object, you can configure your function to:
-* Use the [array arithmetic mode](arrays.md)
-* Treat reference or range arguments as arguments that don't create dependency
-* Inline range arguments to scalar arguments
-* Get recalculated with each sheet shape change
-* Be a [volatile](volatile-functions.md) function
-* Repeat a specified number of last arguments indefinitely
-* Never get vectorized
+### Full example
 
 ```javascript
-CountHF.implementedFunctions = {
-  HYPER: {
-    method: 'hyper',
-    // config parameters
-    arrayFunction: false,
-    doesNotNeedArgumentsToBeComputed: false,
-    expandRanges: false,
-    isDependentOnSheetStructureChange: false,
-    isVolatile: true,
-    repeatLastArgs: 4,
-  }
+import { FunctionPlugin } from 'hyperformula';
+
+export class MyFunctionPlugin extends FunctionPlugin {
+  implementedFunctions: {
+    HYPER: {
+      method: 'hyper',
+    }
+  };
+
+  translations: {
+    enGB: {
+      HYPER: 'HYPER',
+    }
+  };
+
+  hyper(ast, state) {
+    return this.runFunction(ast.args, state, this.metadata('HYPER'), () => 'Hyperformula'.length);
+  };
+};
+
+HyperFormula.registerFunctionPlugin(MyFunctionPlugin, MyFunctionPlugin.translations);
+```
+
+## Custom function options
+
+By passing optional parameters to the `implementedFunctions` object of your function plugin,
+you can configure your function to:
+* Treat reference or range arguments as arguments that don't create dependency.
+* Inline range arguments to scalar arguments.
+* Get recalculated with each sheet shape change.
+* Be a [volatile](volatile-functions.md) function.
+* Repeat a specified number of last arguments indefinitely.
+* Never get vectorized.
+
+```javascript
+MyFunctionPlugin.implementedFunctions = {
+    CUSTOM_FUNCTION: {
+      method: 'myCustomFunctionMethod',
+      arrayFunction: false,
+      doesNotNeedArgumentsToBeComputed: false,
+      expandRanges: false,
+      isDependentOnSheetStructureChange: false,
+      isVolatile: true,
+      repeatLastArgs: 4,
+  };
 };
 ```
 
-You can set the following config parameters:
+You can set the following options:
 
-| Option                              | Type    | Description                                                                                                                                                  |
-|-------------------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `arrayFunction`                     | Boolean | If set to `true`, the function enables the [array arithmetic mode](arrays.md) in its arguments and nested expressions.                                       |
-| `doesNotNeedArgumentsToBeComputed`  | Boolean | If set to `true`, the function treats reference or range arguments as arguments that don't create dependency.<br><br>Other arguments are properly evaluated. |
-| `expandRanges`                      | Boolean | If set to `true`, ranges in the function's arguments are inlined to (possibly multiple) scalar arguments.                                                    |
-| `isDependentOnSheetStructureChange` | Boolean | If set to `true`, the function gets recalculated with each sheet shape change (e.g. when adding/removing rows or columns).                                   |
-| `isVolatile`                        | Boolean | If set to `true`, the function is [volatile](volatile-functions.md).                                                                                         |
-| `repeatLastArgs`                    | Number  | For functions with a variable number of arguments: sets how many last arguments can be repeated indefinitely.                                                |
+| Option                              | Type    | Description                                                                                                                                        |
+| ----------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `arrayFunction`                     | Boolean | `true`: the function enables the [array arithmetic mode](arrays.md) in its arguments and nested expressions.                                       |
+| `doesNotNeedArgumentsToBeComputed`  | Boolean | `true`: the function treats reference or range arguments as arguments that don't create dependency.<br><br>Other arguments are properly evaluated. |
+| `expandRanges`                      | Boolean | `true`: ranges in the function's arguments are inlined to (possibly multiple) scalar arguments.                                                    |
+| `isDependentOnSheetStructureChange` | Boolean | `true`: the function gets recalculated with each sheet shape change (e.g. when adding/removing rows or columns).                                   |
+| `isVolatile`                        | Boolean | `true`: the function is [volatile](volatile-functions.md).                                                                                         |
+| `repeatLastArgs`                    | Number  | For functions with a variable number of arguments: sets how many last arguments can be repeated indefinitely.                                      |
 
-## Argument validation options
+### Argument validation options
 
 In an optional `parameters` array, you can set rules for your function's argument validation.
 
 ```javascript
-CountHF.implementedFunctions = {
+MyFunctionPlugin.implementedFunctions = {
   HYPER: {
     method: 'hyper',
     // set your argument validation options
@@ -175,15 +209,15 @@ CountHF.implementedFunctions = {
 
 You can set the following argument validation options:
 
-| Parameter      | Type                                     | Description                                                                                                                                                                                                                                |
-|----------------|------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `passSubtype`  | Boolean                                  | If set to `true`, arguments are passed with full type information.<br>(e.g. for numbers: `Date` or `DateTime` or `Time` or `Currency` or `Percentage`)                                                                                     |
-| `defaultValue` | `InternalScalarValue` \ `RawScalarValue` | If set to any value: if an argument is missing, its value defaults to `defaultValue`.                                                                                                                                                      |
-| `optionalArg`  | Boolean                                  | If set to `true`: if an argument is missing, and no `defaultValue` is set, the argument defaults to `undefined` (instead of throwing an error).<br><br>Setting this option to `true` is the same as setting `defaultValue` to `undefined`. |
-| `minValue`     | Number                                   | If set, numerical arguments need to be greater than or equal to `minValue`.                                                                                                                                                                |
-| `maxValue`     | Number                                   | If set, numerical arguments need to be less than or equal to `maxValue`.                                                                                                                                                                   |
-| `lessThan`     | Number                                   | If set, numerical argument need to be less than `lessThan`.                                                                                                                                                                                |
-| `greaterThan`  | Number                                   | If set, numerical argument need to be greater than `greaterThan`.                                                                                                                                                                          |
+| Parameter      | Type                                     | Description                                                                                                                                                                                                                      |
+| -------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `passSubtype`  | Boolean                                  | `true`: arguments are passed with full type information.<br>(e.g. for numbers: `Date` or `DateTime` or `Time` or `Currency` or `Percentage`)                                                                                     |
+| `defaultValue` | `InternalScalarValue` \ `RawScalarValue` | If set to any value: if an argument is missing, its value defaults to `defaultValue`.                                                                                                                                            |
+| `optionalArg`  | Boolean                                  | `true`: if an argument is missing, and no `defaultValue` is set, the argument defaults to `undefined` (instead of throwing an error).<br><br>Setting this option to `true` is the same as setting `defaultValue` to `undefined`. |
+| `minValue`     | Number                                   | If set, numerical arguments need to be greater than or equal to `minValue`.                                                                                                                                                      |
+| `maxValue`     | Number                                   | If set, numerical arguments need to be less than or equal to `maxValue`.                                                                                                                                                         |
+| `lessThan`     | Number                                   | If set, numerical argument need to be less than `lessThan`.                                                                                                                                                                      |
+| `greaterThan`  | Number                                   | If set, numerical argument need to be greater than `greaterThan`.                                                                                                                                                                |
 
 ### Handling missing arguments
 
@@ -195,35 +229,35 @@ But, the `defaultValue` option automatically replaces any missing arguments with
 
 If you don't want to set any `defaultValue` (because, for example, your function's behavior depends on the number of valid arguments passed), you can use the `optionalArg` setting.
 
-## Aliases
+## Function aliases
 
 Aliases are available since the <Badge text="v0.4.0" vertical="middle"/> version.
 
-If you want to include aliases (multiple names to a single implemented function) inside the plugin,
+If you want to include aliases (multiple names to a single implemented function) inside the function plugin,
 you can do this with the static `aliases` property, which maps the aliases' IDs to the functions' IDs.
 
 ```javascript
-CountHF.implementedFunctions = {
+MyFunctionPlugin.implementedFunctions = {
   HYPER: {
     // this method's functionality will be defined below
     method: 'hyper',
   }
 };
 
-CountHF.aliases = {
+MyFunctionPlugin.aliases = {
   'HYPERRR': 'HYPER'
   // HYPERRR is now an alias to HYPER
 };
 ```
 
-## Translations
+## Function translations
 
 `translations` object can be defined as a static property of a plugin class or as a separate object. It must be passed as a second argument to `registerFunctionPlugin()` function.
 
 
 ```javascript
 // translation as a static property of a plugin class
-CountHF.translations = {
+MyFunctionPlugin.translations = {
   enGB: {
     'HYPER': 'HYPER'
   },
@@ -232,12 +266,12 @@ CountHF.translations = {
   }
 };
 
-HyperFormula.registerFunctionPlugin(CountHF, CountHF.translations);
+HyperFormula.registerFunctionPlugin(MyFunctionPlugin, MyFunctionPlugin.translations);
 ```
 
 ```js
 // translations as a separate object
-export const countHFTranslations = {
+export const MyFunctionPluginTranslations = {
   enGB: {
     'HYPER': 'HYPER'
   },
@@ -246,7 +280,7 @@ export const countHFTranslations = {
   }
 };
 
-HyperFormula.registerFunctionPlugin(CountHF, countHFTranslations);
+HyperFormula.registerFunctionPlugin(MyFunctionPlugin, MyFunctionPluginTranslations);
 ```
 
 ## Returning errors
@@ -261,9 +295,9 @@ For example, if you want to return a `#DIV/0!` error with your custom error mess
 
 ```javascript
 // import `CellError` and `ErrorType`
-import { FunctionPlugin, CellError, ErrorType } from "hyperformula";
+import { FunctionPlugin, CellError, ErrorType } from 'hyperformula';
 
-export class CountHF extends FunctionPlugin {
+export class MyFunctionPlugin extends FunctionPlugin {
   hyper(ast, state) {
     if (!ast.args.length) {
       // create a `CellError` instance with an `ErrorType` of `DIV_BY_ZERO`

--- a/docs/guide/custom-functions.md
+++ b/docs/guide/custom-functions.md
@@ -1,29 +1,29 @@
 # Custom functions
 
-HyperFormula enables you to expand the library of functions available in your application by implementing a custom function.
+Expand the library of functions available in your app, by implementing a custom function.
 
-## A simple example
+## Custom function example
 
-This guide explains step-by-step how to create a custom function that
-returns the number of letters in the word 'HyperFormula'. It will be
-invoked by typing `"=HYPER()"`.
+Let's create a custom function that returns the number of letters in the word "HyperFormula".
 
 ### 1. Create a plugin class
 
-First, you need to import `FunctionPlugin` and extend it with your
-own class. Here is how you can do that:
+Import `FunctionPlugin`, and extend it with your own plugin class:
 
 ```javascript
-// import FunctionPlugin
 import { FunctionPlugin } from 'hyperformula';
 
-// start creating a class
 export class CountHF extends FunctionPlugin {
   
 }
 ```
 
 ### 2. Define a custom function provided by your plugin
+
+In your newly created class, define a static property called `implementedFunctions`.
+
+`implementedFunctions`, defines the IDs of that your plugin's functions (e.g., `HYPER`),
+and maps 
 
 Your newly created class should have a static `implementedFunctions`
 property that defines functions this plugin contains and maps them to their implementations.
@@ -34,7 +34,7 @@ corresponding translations in translation packages.
 ```javascript
 CountHF.implementedFunctions = {
   HYPER: {
-    // this method's functionality will be defined below
+    // we'll define this method's functionality below
     method: 'hyper',
   }
 };

--- a/docs/guide/custom-functions.md
+++ b/docs/guide/custom-functions.md
@@ -1,10 +1,12 @@
 # Custom functions
 
-Expand the library of functions available in your app, by creating custom functions.
+Expand your app's function library, by adding custom functions.
 
-## Create a custom function
+[[toc]]
 
-As an example, let's create a custom function that returns the number of letters in the word "HyperFormula".
+## Add a custom function
+
+As an example, let's create a function that returns the number of letters in the word "HyperFormula".
 
 <iframe
   src="https://codesandbox.io/embed/github/handsontable/hyperformula-demos/tree/2.0.x/custom-functions?autoresize=1&fontsize=11&hidenavigation=1&theme=light&view=preview"
@@ -28,9 +30,10 @@ export class MyFunctionPlugin extends FunctionPlugin {
 
 ### 2. Define your function's ID and method
 
-Inside the `implementedFunctions` property of your function plugin, define your custom function.
+In your function plugin, in the `implementedFunctions` property, define an object that contains your custom function.
 
-This is where you define an ID by which [translations](#function-translations), [aliases](#function-aliases), and other elements refer to your function. Make the ID unique among all HyperFormula [functions](built-in-functions.md#list-of-available-functions).
+The name of that object becomes the ID by which [translations](#function-translations), [aliases](#function-aliases), and other elements refer to your function.
+Make the ID unique among all HyperFormula functions ([built-in](built-in-functions.md#list-of-available-functions) and custom).
 
 Inside your function's object, define a `method` property, which maps your function to an implementation method (we'll define that method later on).
 
@@ -38,25 +41,23 @@ Inside your function's object, define a `method` property, which maps your funct
 MyFunctionPlugin.implementedFunctions = {
   // let's define the function's ID as `HYPER`
   HYPER: {
-    // we'll define the `hyper` method below
+    // we'll define the `hyper` method later on
     method: 'hyper',
   };
 };
 ```
 
 ::: tip
-In `implementedFunctions`, you can define more [custom function options](#custom-function-options).
+In `implementedFunctions`, you can also define your [custom function options](#custom-function-options) and [argument validation options](#argument-validation-options).
 :::
 
 ### 3. Add your function's names
 
-Inside the `translations` property of your function plugin, define your function's names, in every language that you want to support. This is how your end users call your function inside formulas.
+In your function plugin, in the `translations` property, define your function's names, in every language that you want to support. Your end users use these names to call your function inside formulas.
+
+If you support just one language, you still need to define the name of your function in that language.
 
 Function names are case-insensitive, as they are all normalized to uppercase.
-
-::: tip
-If you support just one language, you still need to define the name of your function in that language.
-:::
 
 ```javascript
 MyFunctionPlugin.translations = {
@@ -69,7 +70,7 @@ MyFunctionPlugin.translations = {
 
 ### 4. Implement your function's logic
 
-Inside your function plugin class, add a method that implements your function's calculations. Your method needs to:
+In your function plugin, add a method that implements your function's calculations. Your method needs to:
 * Take two optional arguments: `ast` and `state`.
 * Return the results of your calculations.
 
@@ -94,14 +95,14 @@ export class MyFunctionPlugin extends FunctionPlugin {
 };
 ```
 
-### 5. Register your plugin
+### 5. Register your function plugin
 
 Register your function plugin (and its translations), so that HyperFormula can recognize it. 
 
 Use the `registerFunctionPlugin()` method:
 
 ```javascript
-// register `MyFunctionPlugin` and its translations
+// register `MyFunctionPlugin` and translations
 HyperFormula.registerFunctionPlugin(MyFunctionPlugin, MyFunctionPlugin.translations);
 ```
 
@@ -132,13 +133,13 @@ export class MyFunctionPlugin extends FunctionPlugin {
   implementedFunctions: {
     HYPER: {
       method: 'hyper',
-    }
+    };
   };
 
   translations: {
     enGB: {
       HYPER: 'HYPER',
-    }
+    };
   };
 
   hyper(ast, state) {
@@ -151,8 +152,7 @@ HyperFormula.registerFunctionPlugin(MyFunctionPlugin, MyFunctionPlugin.translati
 
 ## Custom function options
 
-By passing optional parameters to the `implementedFunctions` object of your function plugin,
-you can configure your function to:
+You can configure your custom function to:
 * Treat reference or range arguments as arguments that don't create dependency.
 * Inline range arguments to scalar arguments.
 * Get recalculated with each sheet shape change.
@@ -160,40 +160,45 @@ you can configure your function to:
 * Repeat a specified number of last arguments indefinitely.
 * Never get vectorized.
 
+In your function plugin, in the `implementedFunctions` property, add your function's options:
+
 ```javascript
 MyFunctionPlugin.implementedFunctions = {
-    CUSTOM_FUNCTION: {
-      method: 'myCustomFunctionMethod',
-      arrayFunction: false,
-      doesNotNeedArgumentsToBeComputed: false,
-      expandRanges: false,
-      isDependentOnSheetStructureChange: false,
-      isVolatile: true,
-      repeatLastArgs: 4,
+  MY_FUNCTION: {
+    method: 'myCustomFunctionMethod',
+    // set options for `MY_FUNCTION`
+    arrayFunction: false,
+    doesNotNeedArgumentsToBeComputed: false,
+    expandRanges: false,
+    isDependentOnSheetStructureChange: false,
+    isVolatile: true,
+    repeatLastArgs: 4,
   };
 };
 ```
 
-You can set the following options:
+You can set the following options for your function:
 
-| Option                              | Type    | Description                                                                                                                                        |
-| ----------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `arrayFunction`                     | Boolean | `true`: the function enables the [array arithmetic mode](arrays.md) in its arguments and nested expressions.                                       |
-| `doesNotNeedArgumentsToBeComputed`  | Boolean | `true`: the function treats reference or range arguments as arguments that don't create dependency.<br><br>Other arguments are properly evaluated. |
-| `expandRanges`                      | Boolean | `true`: ranges in the function's arguments are inlined to (possibly multiple) scalar arguments.                                                    |
-| `isDependentOnSheetStructureChange` | Boolean | `true`: the function gets recalculated with each sheet shape change (e.g. when adding/removing rows or columns).                                   |
-| `isVolatile`                        | Boolean | `true`: the function is [volatile](volatile-functions.md).                                                                                         |
-| `repeatLastArgs`                    | Number  | For functions with a variable number of arguments: sets how many last arguments can be repeated indefinitely.                                      |
+| Option                              | Type    | Description                                                                                                                                  |
+| ----------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `arrayFunction`                     | Boolean | `true`: the function enables the [array arithmetic mode](arrays.md) in its arguments and nested expressions.                                 |
+| `doesNotNeedArgumentsToBeComputed`  | Boolean | `true`: the function treats reference or range arguments as arguments that don't create dependency (other arguments are properly evaluated). |
+| `expandRanges`                      | Boolean | `true`: ranges in the function's arguments are inlined to (possibly multiple) scalar arguments.                                              |
+| `isDependentOnSheetStructureChange` | Boolean | `true`: the function gets recalculated with each sheet shape change (e.g., when adding/removing rows or columns).                            |
+| `isVolatile`                        | Boolean | `true`: the function is [volatile](volatile-functions.md).                                                                                   |
+| `repeatLastArgs`                    | Number  | For functions with a variable number of arguments: sets how many last arguments can be repeated indefinitely.                                |
 
 ### Argument validation options
 
-In an optional `parameters` array, you can set rules for your function's argument validation.
+You can set rules for your function's argument validation.
+
+In your function plugin, in the `implementedFunctions` property, add an array called `parameters`:
 
 ```javascript
 MyFunctionPlugin.implementedFunctions = {
-  HYPER: {
-    method: 'hyper',
-    // set your argument validation options
+  MY_FUNCTION: {
+    method: 'myCustomFunctionMethod',
+    // set argument validation options for `MY_FUNCTION`
     parameters: [{
       passSubtype: false,
       defaultValue: 10,
@@ -209,78 +214,75 @@ MyFunctionPlugin.implementedFunctions = {
 
 You can set the following argument validation options:
 
-| Parameter      | Type                                     | Description                                                                                                                                                                                                                      |
+| Option         | Type                                     | Description                                                                                                                                                                                                                      |
 | -------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `passSubtype`  | Boolean                                  | `true`: arguments are passed with full type information.<br>(e.g. for numbers: `Date` or `DateTime` or `Time` or `Currency` or `Percentage`)                                                                                     |
-| `defaultValue` | `InternalScalarValue` \ `RawScalarValue` | If set to any value: if an argument is missing, its value defaults to `defaultValue`.                                                                                                                                            |
+| `passSubtype`  | Boolean                                  | `true`: arguments are passed with full type information (e.g., for numbers: `Date` or `DateTime` or `Time` or `Currency` or `Percentage`).                                                                                       |
+| `defaultValue` | `InternalScalarValue` \ `RawScalarValue` | If set: if an argument is missing, its value defaults to `defaultValue`.                                                                                                                                                         |
 | `optionalArg`  | Boolean                                  | `true`: if an argument is missing, and no `defaultValue` is set, the argument defaults to `undefined` (instead of throwing an error).<br><br>Setting this option to `true` is the same as setting `defaultValue` to `undefined`. |
-| `minValue`     | Number                                   | If set, numerical arguments need to be greater than or equal to `minValue`.                                                                                                                                                      |
-| `maxValue`     | Number                                   | If set, numerical arguments need to be less than or equal to `maxValue`.                                                                                                                                                         |
-| `lessThan`     | Number                                   | If set, numerical argument need to be less than `lessThan`.                                                                                                                                                                      |
-| `greaterThan`  | Number                                   | If set, numerical argument need to be greater than `greaterThan`.                                                                                                                                                                |
+| `minValue`     | Number                                   | If set: numerical arguments need to be greater than or equal to `minValue`.                                                                                                                                                      |
+| `maxValue`     | Number                                   | If set: numerical arguments need to be less than or equal to `maxValue`.                                                                                                                                                         |
+| `lessThan`     | Number                                   | If set: numerical argument need to be less than `lessThan`.                                                                                                                                                                      |
+| `greaterThan`  | Number                                   | If set: numerical argument need to be greater than `greaterThan`.                                                                                                                                                                |
 
-### Handling missing arguments
+#### Handling missing arguments
 
-The `defaultValue` and `optionalArg` options let you decide what happens when a user doesn't pass enough valid arguments to your custom function.
+Both the `defaultValue` and `optionalArg` options let you decide what happens when a user doesn't pass enough valid arguments to your custom function.
 
-Setting a `defaultValue` for an argument always makes that argument optional.
+Setting a `defaultValue` for an argument always makes that argument optional. But, the `defaultValue` option automatically replaces any missing arguments with `defaultValue`, so your custom function is not aware of the actual number of valid arguments passed.
 
-But, the `defaultValue` option automatically replaces any missing arguments with `defaultValue`, so your custom function is not aware of the actual number of valid arguments passed.
-
-If you don't want to set any `defaultValue` (because, for example, your function's behavior depends on the number of valid arguments passed), you can use the `optionalArg` setting.
+If you don't want to set any `defaultValue` (because, for example, your function's behavior depends on the number of valid arguments passed), use the `optionalArg` setting instead.
 
 ## Function aliases
 
-Aliases are available since the <Badge text="v0.4.0" vertical="middle"/> version.
+You can assign multiple aliases to a single custom function.
 
-If you want to include aliases (multiple names to a single implemented function) inside the function plugin,
-you can do this with the static `aliases` property, which maps the aliases' IDs to the functions' IDs.
+In your function plugin, in the `aliases` property, add aliases for your function:
 
 ```javascript
-MyFunctionPlugin.implementedFunctions = {
-  HYPER: {
-    // this method's functionality will be defined below
-    method: 'hyper',
-  }
-};
-
 MyFunctionPlugin.aliases = {
-  'HYPERRR': 'HYPER'
-  // HYPERRR is now an alias to HYPER
+  // `=MY_ALIAS()` will work the same as `=MY_FUNCTION()`
+  'MY_ALIAS': 'MY_FUNCTION'
 };
 ```
 
-## Function translations
+## Function name translations
 
-`translations` object can be defined as a static property of a plugin class or as a separate object. It must be passed as a second argument to `registerFunctionPlugin()` function.
+You can define translations of your function's name.
+Your end users use the translated name to call your function inside formulas.
 
+In your function plugin, in the `translations` property, define your function's names,
+in every language that you want to support.
+
+Function names are case-insensitive, as they are all normalized to uppercase.
 
 ```javascript
-// translation as a static property of a plugin class
 MyFunctionPlugin.translations = {
   enGB: {
-    'HYPER': 'HYPER'
+    'MY_FUNCTION': 'MY_FUNCTION'
   },
-  plPL: {
-    'HYPER': 'HAJPER'
+  deDE: {
+    'MY_FUNCTION': 'MEINE_FUNKTION'
   }
 };
 
+// register your function plugin and translations
 HyperFormula.registerFunctionPlugin(MyFunctionPlugin, MyFunctionPlugin.translations);
 ```
 
+You can also define `translations` as a standalone object:
+
 ```js
-// translations as a separate object
-export const MyFunctionPluginTranslations = {
+export const MyFunctionNameTranslations = {
   enGB: {
-    'HYPER': 'HYPER'
+    'MY_FUNCTION': 'MY_FUNCTION'
   },
-  plPL: {
-    'HYPER': 'HAJPER'
+  deDE: {
+    'MY_FUNCTION': 'MEINE_FUNKTION'
   }
 };
 
-HyperFormula.registerFunctionPlugin(MyFunctionPlugin, MyFunctionPluginTranslations);
+// register your function plugin and translations
+HyperFormula.registerFunctionPlugin(MyFunctionPlugin, MyFunctionNameTranslations);
 ```
 
 ## Returning errors

--- a/docs/guide/custom-functions.md
+++ b/docs/guide/custom-functions.md
@@ -52,6 +52,20 @@ CountHF.implementedFunctions = {
 In `implementedFunctions`, you can also define your [custom function options](#custom-function-options) and [argument validation options](#argument-validation-options).
 :::
 
+::: tip
+To define multiple functions in a single function plugin, add them all to the `implementedFunctions` object.
+```js
+CountHF.implementedFunctions = {
+  HYPER: {
+    //...
+  },
+  SUPER: {
+    //...
+  },
+};
+```
+:::
+
 ### 3. Add your function's names
 
 In your function plugin, in the static `translations` property, define your function's names in every language that you want to support. Your end users use these names to call your function inside formulas.
@@ -155,6 +169,7 @@ HyperFormula.registerFunctionPlugin(CountHF, CountHF.translations);
 ## Custom function options
 
 You can configure your custom function to:
+* Use the [array arithmetic mode](arrays.md).
 * Treat reference or range arguments as arguments that don't create dependency.
 * Inline range arguments to scalar arguments.
 * Get recalculated with each sheet shape change.

--- a/docs/guide/custom-functions.md
+++ b/docs/guide/custom-functions.md
@@ -1,6 +1,6 @@
 # Custom functions
 
-Expand your app's function library, by adding custom functions.
+Expand the function library of your application, by adding custom functions.
 
 [[toc]]
 

--- a/docs/guide/custom-functions.md
+++ b/docs/guide/custom-functions.md
@@ -23,14 +23,15 @@ Import `FunctionPlugin`, and extend it with a new class. For example:
 ```javascript
 import { FunctionPlugin } from 'hyperformula';
 
-export class MyFunctionPlugin extends FunctionPlugin {
+// let's call the function plugin `CountHF`
+export class CountHF extends FunctionPlugin {
   
 };
 ```
 
 ### 2. Define your function's ID and method
 
-In your function plugin, in the `implementedFunctions` property, define an object that contains your custom function.
+In your function plugin, in the static `implementedFunctions` property, define an object that contains your custom function.
 
 The name of that object becomes the ID by which [translations](#function-translations), [aliases](#function-aliases), and other elements refer to your function.
 Make the ID unique among all HyperFormula functions ([built-in](built-in-functions.md#list-of-available-functions) and custom).
@@ -38,7 +39,7 @@ Make the ID unique among all HyperFormula functions ([built-in](built-in-functio
 Inside your function's object, define a `method` property, which maps your function to an implementation method (we'll define that method later on).
 
 ```javascript
-MyFunctionPlugin.implementedFunctions = {
+CountHF.implementedFunctions = {
   // let's define the function's ID as `HYPER`
   HYPER: {
     // we'll define the `hyper` method later on
@@ -53,14 +54,16 @@ In `implementedFunctions`, you can also define your [custom function options](#c
 
 ### 3. Add your function's names
 
-In your function plugin, in the `translations` property, define your function's names, in every language that you want to support. Your end users use these names to call your function inside formulas.
+In your function plugin, in the static `translations` property, define your function's names in every language that you want to support. Your end users use these names to call your function inside formulas.
 
 If you support just one language, you still need to define the name of your function in that language.
 
+::: tip
 Function names are case-insensitive, as they are all normalized to uppercase.
+:::
 
 ```javascript
-MyFunctionPlugin.translations = {
+CountHF.translations = {
   enGB: {
     // in English, let's set the function's name to `HYPER`
     HYPER: 'HYPER',
@@ -75,7 +78,7 @@ In your function plugin, add a method that implements your function's calculatio
 * Return the results of your calculations.
 
 ```javascript
-export class MyFunctionPlugin extends FunctionPlugin {
+export class CountHF extends FunctionPlugin {
   hyper(ast, state) {
     return 'Hyperformula'.length;
   };
@@ -88,7 +91,7 @@ To benefit from HyperFormula's automatic validations, wrap your method in the bu
 * Validates arguments passed to your function against your [argument validation options](#argument-validation-options).
 
 ```javascript
-export class MyFunctionPlugin extends FunctionPlugin {
+export class CountHF extends FunctionPlugin {
   hyper(ast, state) {
     return this.runFunction(ast.args, state, this.metadata('HYPER'), () => 'Hyperformula'.length);
   };
@@ -102,13 +105,12 @@ Register your function plugin (and its translations), so that HyperFormula can r
 Use the `registerFunctionPlugin()` method:
 
 ```javascript
-// register `MyFunctionPlugin` and translations
-HyperFormula.registerFunctionPlugin(MyFunctionPlugin, MyFunctionPlugin.translations);
+HyperFormula.registerFunctionPlugin(CountHF, CountHF.translations);
 ```
 
 ### 6. Use your custom function inside a formula
 
-Now, you can use your HYPER function inside a `=HYPER()` formula:
+Now, you can use your HYPER function inside a formula:
 
 ```javascript
 // prepare spreadsheet data
@@ -129,7 +131,7 @@ console.log(result);
 ```javascript
 import { FunctionPlugin } from 'hyperformula';
 
-export class MyFunctionPlugin extends FunctionPlugin {
+export class CountHF extends FunctionPlugin {
   implementedFunctions: {
     HYPER: {
       method: 'hyper',
@@ -147,7 +149,7 @@ export class MyFunctionPlugin extends FunctionPlugin {
   };
 };
 
-HyperFormula.registerFunctionPlugin(MyFunctionPlugin, MyFunctionPlugin.translations);
+HyperFormula.registerFunctionPlugin(CountHF, CountHF.translations);
 ```
 
 ## Custom function options
@@ -160,12 +162,12 @@ You can configure your custom function to:
 * Repeat a specified number of last arguments indefinitely.
 * Never get vectorized.
 
-In your function plugin, in the `implementedFunctions` property, add your function's options:
+In your function plugin, in the static `implementedFunctions` property, add your function's options:
 
 ```javascript
 MyFunctionPlugin.implementedFunctions = {
   MY_FUNCTION: {
-    method: 'myCustomFunctionMethod',
+    method: 'myFunctionMethod',
     // set options for `MY_FUNCTION`
     arrayFunction: false,
     doesNotNeedArgumentsToBeComputed: false,
@@ -192,12 +194,12 @@ You can set the following options for your function:
 
 You can set rules for your function's argument validation.
 
-In your function plugin, in the `implementedFunctions` property, add an array called `parameters`:
+In your function plugin, in the static `implementedFunctions` property, next to other options add an array called `parameters`:
 
 ```javascript
 MyFunctionPlugin.implementedFunctions = {
   MY_FUNCTION: {
-    method: 'myCustomFunctionMethod',
+    method: 'myFunctionMethod',
     // set argument validation options for `MY_FUNCTION`
     parameters: [{
       passSubtype: false,
@@ -206,7 +208,7 @@ MyFunctionPlugin.implementedFunctions = {
       minValue: 5,
       maxValue: 15,
       lessThan: 15,
-      greaterThan: 5
+      greaterThan: 5,
     }],
   }
 };
@@ -214,15 +216,15 @@ MyFunctionPlugin.implementedFunctions = {
 
 You can set the following argument validation options:
 
-| Option         | Type                                     | Description                                                                                                                                                                                                                      |
-| -------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `passSubtype`  | Boolean                                  | `true`: arguments are passed with full type information (e.g., for numbers: `Date` or `DateTime` or `Time` or `Currency` or `Percentage`).                                                                                       |
-| `defaultValue` | `InternalScalarValue` \ `RawScalarValue` | If set: if an argument is missing, its value defaults to `defaultValue`.                                                                                                                                                         |
-| `optionalArg`  | Boolean                                  | `true`: if an argument is missing, and no `defaultValue` is set, the argument defaults to `undefined` (instead of throwing an error).<br><br>Setting this option to `true` is the same as setting `defaultValue` to `undefined`. |
-| `minValue`     | Number                                   | If set: numerical arguments need to be greater than or equal to `minValue`.                                                                                                                                                      |
-| `maxValue`     | Number                                   | If set: numerical arguments need to be less than or equal to `maxValue`.                                                                                                                                                         |
-| `lessThan`     | Number                                   | If set: numerical argument need to be less than `lessThan`.                                                                                                                                                                      |
-| `greaterThan`  | Number                                   | If set: numerical argument need to be greater than `greaterThan`.                                                                                                                                                                |
+| Option         | Type                                      | Description                                                                                                                                                                                                                      |
+| -------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `passSubtype`  | Boolean                                   | `true`: arguments are passed with full type information (e.g., for numbers: `Date` or `DateTime` or `Time` or `Currency` or `Percentage`).                                                                                       |
+| `defaultValue` | `InternalScalarValue` \| `RawScalarValue` | If set: if an argument is missing, its value defaults to `defaultValue`.                                                                                                                                                         |
+| `optionalArg`  | Boolean                                   | `true`: if an argument is missing, and no `defaultValue` is set, the argument defaults to `undefined` (instead of throwing an error).<br><br>Setting this option to `true` is the same as setting `defaultValue` to `undefined`. |
+| `minValue`     | Number                                    | If set: numerical arguments need to be greater than or equal to `minValue`.                                                                                                                                                      |
+| `maxValue`     | Number                                    | If set: numerical arguments need to be less than or equal to `maxValue`.                                                                                                                                                         |
+| `lessThan`     | Number                                    | If set: numerical argument need to be less than `lessThan`.                                                                                                                                                                      |
+| `greaterThan`  | Number                                    | If set: numerical argument need to be greater than `greaterThan`.                                                                                                                                                                |
 
 #### Handling missing arguments
 
@@ -236,7 +238,7 @@ If you don't want to set any `defaultValue` (because, for example, your function
 
 You can assign multiple aliases to a single custom function.
 
-In your function plugin, in the `aliases` property, add aliases for your function:
+In your function plugin, in the static `aliases` property, add aliases for your function:
 
 ```javascript
 MyFunctionPlugin.aliases = {
@@ -247,13 +249,15 @@ MyFunctionPlugin.aliases = {
 
 ## Function name translations
 
-You can define translations of your function's name.
-Your end users use the translated name to call your function inside formulas.
+You can configure the name of your function with mulitple translations.
+Your end users call your function by referring to those translations.
 
-In your function plugin, in the `translations` property, define your function's names,
+In your function plugin, in the static `translations` property, define your function's names,
 in every language that you want to support.
 
+::: tip
 Function names are case-insensitive, as they are all normalized to uppercase.
+:::
 
 ```javascript
 MyFunctionPlugin.translations = {

--- a/docs/guide/custom-functions.md
+++ b/docs/guide/custom-functions.md
@@ -36,7 +36,7 @@ In your function plugin, in the static `implementedFunctions` property, define a
 The name of that object becomes the ID by which [translations](#function-translations), [aliases](#function-aliases), and other elements refer to your function.
 Make the ID unique among all HyperFormula functions ([built-in](built-in-functions.md#list-of-available-functions) and custom).
 
-Inside your function's object, define a `method` property, which maps your function to an implementation method (we'll define that method later on).
+Then, in your function's object, define a `method` property, which maps your function to an implementation method (we'll define it later on).
 
 ```javascript
 CountHF.implementedFunctions = {
@@ -262,9 +262,11 @@ Function names are case-insensitive, as they are all normalized to uppercase.
 ```javascript
 MyFunctionPlugin.translations = {
   enGB: {
+    // formula in English: `=MY_FUNCTION()`
     'MY_FUNCTION': 'MY_FUNCTION'
   },
   deDE: {
+    // formula in German: `=MEINE_FUNKTION()`
     'MY_FUNCTION': 'MEINE_FUNKTION'
   }
 };


### PR DESCRIPTION
This PR:
- Adds review suggestions to #1000

My remarks:
- I added a TOC (compared to the Handsontable docs, I really miss the right-hand side navigation), but I'm not sure if it looks good, I'm leaving it up to you
- I moved the demo to the top of the **Create a custom function** section, to show the goal that we're trying to achieve upfront, and to make the page less text-heavy at first glance
- The **Create a custom function** section covers the HYPER example (which is cool), but the remaining sections (e.g., **Custom function options**) should work independently (they should be understandable without additional context, so you can start in the middle of the page, without the need to read the whole guide – this way, we can link to individual sections). That's why I changed `CountHF` to `MyFunction`, `hyper` to `myFunctionMethod` etc. (this way, we can tell straight away if sth's a part of an example, or an integral part of HyperFormula)