### PR TITLE
Convert absolute links to relative in docs/guide/index.md

### DIFF
--- a/docs/guide/dependency-graph.md
+++ b/docs/guide/dependency-graph.md
@@ -75,7 +75,7 @@ node and avoid duplicating the work during computation.
 
 To get the immediate precedents of a cell or a range (the in-neighbors of the cell node or the range node), use the [`getCellPrecedents()`](../api/classes/hyperformula.html#getcellprecedents) method:
 
-```
+```js
 const hfInstance = HyperFormula.buildFromArray( [ ['1', '=A1', '=A1+B1'] ] );
 
 hfInstance.getCellPrecedents({ sheet: 0, col: 2, row: 0});
@@ -86,7 +86,7 @@ hfInstance.getCellPrecedents({ sheet: 0, col: 2, row: 0});
 
 To get the immediate dependents of a cell or a range (the out-neighbors of the cell node or the range node), use the [`getCellDependents()`](../api/classes/hyperformula.html#getcelldependents) method:
 
-```
+```js
 const hfInstance = HyperFormula.buildFromArray( [ ['1', '=A1', '=A1+B1'] ] );
 
 hfInstance.getCellDependents({ sheet: 0, col: 2, row: 0});

--- a/docs/guide/server-side-installation.md
+++ b/docs/guide/server-side-installation.md
@@ -18,13 +18,13 @@ following command:
   
 **npm:**
 
-```
+```bash
 $ npm install hyperformula
 ```
 
 **Yarn:**
 
-```
+```bash
 $ npm install hyperformula
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,16 +21,16 @@ description: HyperFormula® - Complex Calculations Made Easy
 HyperFormula is a headless spreadsheet built on top of TypeScript. It is a parser and evaluator of Excel formulas for web applications. You can use it in a browser or as a service, with Node.js as your back-end technology.
 
 - High-speed Excel formula parsing and evaluating
-- A library of [380+ built-in functions](https://handsontable.github.io/hyperformula/guide/built-in-functions.html) available in 16 languages
-- Support for [custom functions](https://handsontable.github.io/hyperformula/guide/custom-functions.html)
-- Function syntax [compatible with Excel and Google Sheets](https://handsontable.github.io/hyperformula/guide/known-limitations.html#google-sheets-and-microsoft-excel)
-- [Support for Node.js](https://handsontable.github.io/hyperformula/guide/server-side-installation.html#install-with-npm-or-yarn)
-- Support for [undo/redo](https://handsontable.github.io/hyperformula/guide/undo-redo.html)
-- Support for [CRUD operations](https://handsontable.github.io/hyperformula/guide/basic-operations.html)
-- Support for [clipboard](https://handsontable.github.io/hyperformula/guide/clipboard-operations.html)
-- Support for [named expressions](https://handsontable.github.io/hyperformula/guide/named-expressions.html)
-- Support for [data sorting](https://handsontable.github.io/hyperformula/guide/sorting-data.html)
-- Support for [React](https://handsontable.github.io/hyperformula/guide/integration-with-react.html), [Angular](https://handsontable.github.io/hyperformula/guide/integration-with-angular.html), and [Vue.js](https://handsontable.github.io/hyperformula/guide/integration-with-vue.html)
+- A library of [380+ built-in functions](/guide/built-in-functions.html) available in 16 languages
+- Support for [custom functions](/guide/custom-functions.html)
+- Function syntax [compatible with Excel and Google Sheets](/guide/known-limitations.html#google-sheets-and-microsoft-excel)
+- [Support for Node.js](/guide/server-side-installation.html#install-with-npm-or-yarn)
+- Support for [undo/redo](/guide/undo-redo.html)
+- Support for [CRUD operations](/guide/basic-operations.html)
+- Support for [clipboard](/guide/clipboard-operations.html)
+- Support for [named expressions](/guide/named-expressions.html)
+- Support for [data sorting](/guide/sorting-data.html)
+- Support for [React](/guide/integration-with-react.html), [Angular](/guide/integration-with-angular.html), and [Vue.js](/guide/integration-with-vue.html)
 - Open-source license
 - Actively maintained by the team that stands behind [Handsontable - JavaScript Data Grid](https://handsontable.com/)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,16 +21,16 @@ description: HyperFormula® - Complex Calculations Made Easy
 HyperFormula is a headless spreadsheet built on top of TypeScript. It is a parser and evaluator of Excel formulas for web applications. You can use it in a browser or as a service, with Node.js as your back-end technology.
 
 - High-speed Excel formula parsing and evaluating
-- A library of [380+ built-in functions](/guide/built-in-functions.html) available in 16 languages
-- Support for [custom functions](/guide/custom-functions.html)
-- Function syntax [compatible with Excel and Google Sheets](/guide/known-limitations.html#google-sheets-and-microsoft-excel)
-- [Support for Node.js](/guide/server-side-installation.html#install-with-npm-or-yarn)
-- Support for [undo/redo](/guide/undo-redo.html)
-- Support for [CRUD operations](/guide/basic-operations.html)
-- Support for [clipboard](/guide/clipboard-operations.html)
-- Support for [named expressions](/guide/named-expressions.html)
-- Support for [data sorting](/guide/sorting-data.html)
-- Support for [React](/guide/integration-with-react.html), [Angular](/guide/integration-with-angular.html), and [Vue.js](/guide/integration-with-vue.html)
+- A library of [380+ built-in functions](/guide/built-in-functions.md) available in 16 languages
+- Support for [custom functions](/guide/custom-functions.md)
+- Function syntax [compatible with Excel and Google Sheets](/guide/known-limitations.md#google-sheets-and-microsoft-excel)
+- [Support for Node.js](/guide/server-side-installation.md#install-with-npm-or-yarn)
+- Support for [undo/redo](/guide/undo-redo.md)
+- Support for [CRUD operations](/guide/basic-operations.md)
+- Support for [clipboard](/guide/clipboard-operations.md)
+- Support for [named expressions](/guide/named-expressions.md)
+- Support for [data sorting](/guide/sorting-data.md)
+- Support for [React](/guide/integration-with-react.md), [Angular](/guide/integration-with-angular.md), and [Vue.js](/guide/integration-with-vue.md)
 - Open-source license
 - Actively maintained by the team that stands behind [Handsontable - JavaScript Data Grid](https://handsontable.com/)
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Change all the absolute links to relative ones in `docs/guide/index.md`.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations and documentation changes). -->
Docs run locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Additional language file or change to the existing one (translations)
- [x] Change to the documentation

### Related issues:
1. Fixes #1017 
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I described the modification in the CHANGELOG.md file.
- [ ] My change requires a change to the documentation.
- [ ] My change requires a migration guide.
