### PR TITLE
Improve the API reference for the static methods

### DIFF
--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -350,6 +350,8 @@ export class HyperFormula implements TypedEmitter {
   /**
    * Registers language from under given code string.
    *
+   * Note: This method has no effect on the existing HyperFormula instances.
+   *
    * @param {string} languageCode - code string of the translation package
    * @param {RawTranslationPackage} languagePackage - translation package to be registered
    *
@@ -376,6 +378,8 @@ export class HyperFormula implements TypedEmitter {
 
   /**
    * Unregisters language that is registered under given code string.
+   *
+   * Note: This method has no effect on the existing HyperFormula instances.
    *
    * @param {string} languageCode - code string of the translation package
    *
@@ -418,7 +422,9 @@ export class HyperFormula implements TypedEmitter {
   }
 
   /**
-   * Registers all functions in a given plugin with optional translations
+   * Registers all functions in a given plugin with optional translations.
+   *
+   * Note: This method has no effect on the existing HyperFormula instances.
    *
    * @param {FunctionPluginDefinition} plugin - plugin class
    * @param {FunctionTranslationsPackage} translations - optional package of function names translations
@@ -442,7 +448,9 @@ export class HyperFormula implements TypedEmitter {
   }
 
   /**
-   * Unregisters all functions defined in given plugin
+   * Unregisters all functions defined in given plugin.
+   *
+   * Note: This method has no effect on the existing HyperFormula instances.
    *
    * @param {FunctionPluginDefinition} plugin - plugin class
    *
@@ -463,6 +471,8 @@ export class HyperFormula implements TypedEmitter {
 
   /**
    * Registers a function with a given id if such exists in a plugin.
+   *
+   * Note: This method has no effect on the existing HyperFormula instances.
    *
    * @param {string} functionId - function id, e.g. 'SUMIF'
    * @param {FunctionPluginDefinition} plugin - plugin class
@@ -489,7 +499,9 @@ export class HyperFormula implements TypedEmitter {
   }
 
   /**
-   * Unregisters a function with a given id
+   * Unregisters a function with a given id.
+   *
+   * Note: This method has no effect on the existing HyperFormula instances.
    *
    * @param {string} functionId - function id, e.g. 'SUMIF'
    *
@@ -515,7 +527,9 @@ export class HyperFormula implements TypedEmitter {
   }
 
   /**
-   * Clears function registry
+   * Clears function registry.
+   *
+   * Note: This method has no effect on the existing HyperFormula instances.
    *
    * @example
    * ```js
@@ -577,7 +591,7 @@ export class HyperFormula implements TypedEmitter {
   }
 
   /**
-   * Returns classes of all plugins registered in this instance of HyperFormula
+   * Returns classes of all plugins registered in HyperFormula
    *
    * @example
    * ```js

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -350,8 +350,6 @@ export class HyperFormula implements TypedEmitter {
   /**
    * Registers language from under given code string.
    *
-   * Note: This method has no effect on the existing HyperFormula instances.
-   *
    * @param {string} languageCode - code string of the translation package
    * @param {RawTranslationPackage} languagePackage - translation package to be registered
    *
@@ -363,6 +361,7 @@ export class HyperFormula implements TypedEmitter {
    * ```js
    * // return registered language
    * HyperFormula.registerLanguage('plPL', plPL);
+   * const engine = HyperFormula.buildEmpty({language: 'plPL'});
    * ```
    *
    * @category Static Methods
@@ -378,8 +377,6 @@ export class HyperFormula implements TypedEmitter {
 
   /**
    * Unregisters language that is registered under given code string.
-   *
-   * Note: This method has no effect on the existing HyperFormula instances.
    *
    * @param {string} languageCode - code string of the translation package
    *
@@ -424,7 +421,7 @@ export class HyperFormula implements TypedEmitter {
   /**
    * Registers all functions in a given plugin with optional translations.
    *
-   * Note: This method has no effect on the existing HyperFormula instances.
+   * Note: This method does not affect the existing HyperFormula instances.
    *
    * @param {FunctionPluginDefinition} plugin - plugin class
    * @param {FunctionTranslationsPackage} translations - optional package of function names translations
@@ -450,7 +447,7 @@ export class HyperFormula implements TypedEmitter {
   /**
    * Unregisters all functions defined in given plugin.
    *
-   * Note: This method has no effect on the existing HyperFormula instances.
+   * Note: This method does not affect the existing HyperFormula instances.
    *
    * @param {FunctionPluginDefinition} plugin - plugin class
    *
@@ -472,7 +469,7 @@ export class HyperFormula implements TypedEmitter {
   /**
    * Registers a function with a given id if such exists in a plugin.
    *
-   * Note: This method has no effect on the existing HyperFormula instances.
+   * Note: This method does not affect the existing HyperFormula instances.
    *
    * @param {string} functionId - function id, e.g. 'SUMIF'
    * @param {FunctionPluginDefinition} plugin - plugin class
@@ -501,7 +498,7 @@ export class HyperFormula implements TypedEmitter {
   /**
    * Unregisters a function with a given id.
    *
-   * Note: This method has no effect on the existing HyperFormula instances.
+   * Note: This method does not affect the existing HyperFormula instances.
    *
    * @param {string} functionId - function id, e.g. 'SUMIF'
    *
@@ -529,7 +526,7 @@ export class HyperFormula implements TypedEmitter {
   /**
    * Clears function registry.
    *
-   * Note: This method has no effect on the existing HyperFormula instances.
+   * Note: This method does not affect the existing HyperFormula instances.
    *
    * @example
    * ```js

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -588,7 +588,7 @@ export class HyperFormula implements TypedEmitter {
   }
 
   /**
-   * Returns classes of all plugins registered in HyperFormula
+   * Returns classes of all plugins registered in HyperFormula.
    *
    * @example
    * ```js

--- a/test/custom-functions.spec.ts
+++ b/test/custom-functions.spec.ts
@@ -144,6 +144,20 @@ describe('Register static custom plugin', () => {
     expect(engine.getCellValue(adr('A1'))).toEqual('foo')
   })
 
+  it('registerFunction should not affect the existing HyperFormula instances', () => {
+    const engine = HyperFormula.buildFromArray([['=FOO()']])
+    HyperFormula.registerFunction('FOO', FooPlugin, FooPlugin.translations)
+
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.NAME, ErrorMessage.FunctionName('FOO')))
+  })
+
+  it('registerFunctionPlugin should not affect the existing HyperFormula instances', () => {
+    const engine = HyperFormula.buildFromArray([['=FOO()']])
+    HyperFormula.registerFunctionPlugin(FooPlugin, FooPlugin.translations)
+
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.NAME, ErrorMessage.FunctionName('FOO')))
+  })
+
   it('should return registered formula translations', () => {
     HyperFormula.unregisterAllFunctions()
     HyperFormula.registerLanguage('plPL', plPL)


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

Improved the API reference for static methods:
- registerLanguage
- registerFunctionPlugin
- unregisterFunctionPlugin
- registerFunction
- unregisterFunction
- unregisterAllFunctions
- getAllFunctionPlugins

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Additional language file or change to the existing one (translations)
- [x] Change to the documentation

### Related issues:
Fixes #1032

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I described the modification in the CHANGELOG.md file.
- [ ] My change requires a change to the documentation.
- [ ] My change requires a migration guide.
