### PR TITLE
Make the docs page "List of differences" wider than the default

### DIFF
--- a/docs/guide/list-of-differences.md
+++ b/docs/guide/list-of-differences.md
@@ -1,5 +1,18 @@
 # List of differences with other spreadsheets
 
+<!-- 
+The below dummy div uses a CSS class to alter the .page layout for the current page without any additional customization of VuePress. 
+It makes the page wider to accommodate large tables  
+-->
+<div class="widePage"></div>
+<style>
+.page:has(.widePage) .theme-default-content:not(.custom), /* markdown content */
+.page:has(.widePage) .page-edit, /* footer containing the "Help us improve the page" link */
+.page:has(.widePage) .page-nav /* footer links to the next and prev page */ {
+  max-width: 1200px !important; /* override default max-width of 740px for this page */
+}
+</style>
+
 See a full list of differences between HyperFormula, Microsoft Excel, and Google Sheets.
 
 **Contents:**


### PR DESCRIPTION
### Context
Even before the PR #1107, the page "List of differences" had a table with significant horizontal content, which slightly broke the page layout, since the max-width of a page is set to 740px.

PR #1107 added even more content to the table that was not wrappable, making the table even wider.

This PR adds a modification to this page to use a wider layout than other pages. 

The solution uses the CSS `:has()` selector as a "parent selector". This CSS selector is available in most of the modern browsers (https://caniuse.com/css-has) and does no harm to other browsers.

#### Screenshots before

<img width="1904" alt="Screen Shot 2022-12-08 at 11 40 16 PM" src="https://user-images.githubusercontent.com/566463/206582853-bb26d0e3-93cb-4417-9269-51e2b6cf781d.png">
<img width="1904" alt="Screen Shot 2022-12-08 at 11 47 44 PM" src="https://user-images.githubusercontent.com/566463/206583328-8a8cff25-c6ee-4321-a2a0-bb5dac23b716.png">

#### Screenshots after

<img width="1904" alt="Screen Shot 2022-12-08 at 11 39 29 PM" src="https://user-images.githubusercontent.com/566463/206582866-024e4f60-bbe1-4e87-86b3-a18d25355262.png">
<img width="1904" alt="Screen Shot 2022-12-08 at 11 47 28 PM" src="https://user-images.githubusercontent.com/566463/206583358-1dce3462-1db0-4d5f-a1ab-8502cf93b422.png">


### How did you test your changes?
<!--- Describe in detail how you tested your changes. -->
Tested the dev and production of the docs.

I verified that layout of the page expands and collapses correctly when going on and off this page, in Chrome and Safari.

I verified that layout looks indifferent in Firefox, which does not implement `:has()` yet.
