### PR TITLE
Fix caching issue with reversed ranges

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -80,7 +80,6 @@ module.exports = {
     "jsdoc/multiline-blocks": 'warn',
     "jsdoc/newline-after-description": 'warn',
     "jsdoc/no-multi-asterisks": 'warn',
-    "jsdoc/no-undefined-types": 'warn',
     "jsdoc/require-param-description": 'warn',
     "jsdoc/require-param-name": 'warn',
     "jsdoc/require-param-type": 'warn',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed error caused by the named expression names that start with a cell reference. [#1058](https://github.com/handsontable/hyperformula/issues/1058)
 - Fixed the validation of the named expression names. Strings `R4C5`, `RC1000`, `R1C`, `RC`, etc. are now considered invalid. (cell references in R1C1 style). [#1058](https://github.com/handsontable/hyperformula/issues/1058)
+- Fixed error caused by specific usage of reversed ranges with absolute addressing. [#1106](https://github.com/handsontable/hyperformula/issues/1106)
 
 ## [2.3.0] - 2022-12-22
 

--- a/src/AbsoluteCellRange.ts
+++ b/src/AbsoluteCellRange.ts
@@ -55,6 +55,21 @@ export class AbsoluteCellRange implements SimpleCellRange {
     return this.start.sheet
   }
 
+  public static fromSimpleCellAddresses(start: SimpleCellAddress, end: SimpleCellAddress): AbsoluteCellRange {
+    const width = end.col - start.col
+    const height = end.row - start.row
+
+    if (Number.isFinite(height) && Number.isFinite(width)) {
+      return new AbsoluteCellRange(start, end)
+    }
+
+    if (Number.isFinite(height)) {
+      return new AbsoluteRowRange(start.sheet, start.row, end.row)
+    }
+
+    return new AbsoluteColumnRange(start.sheet, start.col, end.col)
+  }
+
   public static fromAst(ast: CellRangeAst | ColumnRangeAst | RowRangeAst, baseAddress: SimpleCellAddress): AbsoluteCellRange {
     if (ast.type === AstNodeType.CELL_RANGE) {
       return AbsoluteCellRange.fromCellRange(ast, baseAddress)

--- a/src/AbsoluteCellRange.ts
+++ b/src/AbsoluteCellRange.ts
@@ -56,6 +56,10 @@ export class AbsoluteCellRange implements SimpleCellRange {
   }
 
   public static fromSimpleCellAddresses(start: SimpleCellAddress, end: SimpleCellAddress): AbsoluteCellRange {
+    if (start.sheet !== end.sheet) {
+      throw new SheetsNotEqual(start.sheet, end.sheet)
+    }
+
     const width = end.col - start.col
     const height = end.row - start.row
 

--- a/src/DependencyGraph/RangeMapping.ts
+++ b/src/DependencyGraph/RangeMapping.ts
@@ -213,7 +213,7 @@ export class RangeMapping {
       const valuesRangeEndRowLess = simpleCellAddress(range.end.sheet, range.end.col, range.end.row - 1)
       const rowLessVertex = this.getRange(range.start, valuesRangeEndRowLess)
       if (rowLessVertex !== undefined) {
-        const restRange = new AbsoluteCellRange(simpleCellAddress(range.start.sheet, range.start.col, range.end.row), range.end)
+        const restRange = AbsoluteCellRange.fromSimpleCellAddresses(simpleCellAddress(range.start.sheet, range.start.col, range.end.row), range.end)
         return {
           smallerRangeVertex: rowLessVertex,
           restRange,

--- a/src/parser/FormulaParser.ts
+++ b/src/parser/FormulaParser.ts
@@ -95,8 +95,6 @@ import {
   StringLiteral,
   TimesOp,
 } from './LexerConfig'
-import {RowAddress} from './RowAddress'
-import {ColumnAddress} from './ColumnAddress'
 import {AddressWithSheet} from './Address'
 
 export interface FormulaParserResult {
@@ -215,9 +213,8 @@ export class FormulaParser extends EmbeddedActionsParser {
     }
 
     const { firstEnd, secondEnd, sheetRefType } = FormulaParser.fixSheetIdsForRangeEnds(firstAddress, secondAddress)
-    const { start, end } = { start: firstEnd, end: secondEnd } // this.orderColumnRangeEnds(firstEnd, secondEnd)
 
-    return buildColumnRangeAst(start, end, sheetRefType, range.leadingWhitespace)
+    return buildColumnRangeAst(firstEnd, secondEnd, sheetRefType, range.leadingWhitespace)
   })
 
   /**
@@ -242,9 +239,8 @@ export class FormulaParser extends EmbeddedActionsParser {
     }
 
     const { firstEnd, secondEnd, sheetRefType } = FormulaParser.fixSheetIdsForRangeEnds(firstAddress, secondAddress)
-    const { start, end } = { start: firstEnd, end: secondEnd } //this.orderRowRangeEnds(firstEnd, secondEnd)
 
-    return buildRowRangeAst(start, end, sheetRefType, range.leadingWhitespace)
+    return buildRowRangeAst(firstEnd, secondEnd, sheetRefType, range.leadingWhitespace)
   })
 
   /**
@@ -454,8 +450,8 @@ export class FormulaParser extends EmbeddedActionsParser {
   /**
    * Parses tokenized formula and builds abstract syntax tree
    *
-   * @param tokens - tokenized formula
-   * @param formulaAddress - address of the cell in which formula is located
+   * @param {ExtendedToken[]} tokens - tokenized formula
+   * @param {SimpleCellAddress} formulaAddress - address of the cell in which formula is located
    */
   public parseFromTokens(tokens: ExtendedToken[], formulaAddress: SimpleCellAddress): FormulaParserResult {
     this.input = tokens
@@ -710,7 +706,7 @@ export class FormulaParser extends EmbeddedActionsParser {
   /**
    * Entry rule wrapper that sets formula address
    *
-   * @param address - address of the cell in which formula is located
+   * @param {SimpleCellAddress} address - address of the cell in which formula is located
    */
   private formulaWithContext(address: SimpleCellAddress): Ast {
     this.formulaAddress = address
@@ -723,9 +719,8 @@ export class FormulaParser extends EmbeddedActionsParser {
     }
 
     const { firstEnd, secondEnd, sheetRefType } = FormulaParser.fixSheetIdsForRangeEnds(firstAddress, secondAddress)
-    const { start, end } = { start: firstEnd, end: secondEnd } //this.orderCellRangeEnds(firstEnd, secondEnd)
 
-    return buildCellRangeAst(start, end, sheetRefType, leadingWhitespace)
+    return buildCellRangeAst(firstEnd, secondEnd, sheetRefType, leadingWhitespace)
   }
 
   private static fixSheetIdsForRangeEnds<T extends AddressWithSheet>(firstEnd: T, secondEnd: T): { firstEnd: T, secondEnd: T, sheetRefType: RangeSheetReferenceType } {
@@ -737,50 +732,10 @@ export class FormulaParser extends EmbeddedActionsParser {
     return { firstEnd, secondEnd: secondEndFixed, sheetRefType }
   }
 
-  private orderCellRangeEnds(endA: CellAddress, endB: CellAddress): { start: CellAddress, end: CellAddress } {
-    const ends = [ endA, endB ]
-    const [ startCol, endCol ] = ends.map(e => e.toColumnAddress()).sort(ColumnAddress.compareByAbsoluteAddress(this.formulaAddress))
-    const [ startRow, endRow ] = ends.map(e => e.toRowAddress()).sort(RowAddress.compareByAbsoluteAddress(this.formulaAddress))
-    const [ startSheet, endSheet ] = ends.map(e => e.sheet).sort(FormulaParser.compareSheetIds.bind(this))
-
-    return {
-      start: CellAddress.fromColAndRow(startCol, startRow, startSheet),
-      end: CellAddress.fromColAndRow(endCol, endRow, endSheet),
-    }
-  }
-
-  private orderColumnRangeEnds(endA: ColumnAddress, endB: ColumnAddress): { start: ColumnAddress, end: ColumnAddress } {
-    const ends = [ endA, endB ]
-    const [ startCol, endCol ] = ends.sort(ColumnAddress.compareByAbsoluteAddress(this.formulaAddress))
-    const [ startSheet, endSheet ] = ends.map(e => e.sheet).sort(FormulaParser.compareSheetIds.bind(this))
-
-    return {
-      start: new ColumnAddress(startCol.type, startCol.col, startSheet),
-      end: new ColumnAddress(endCol.type, endCol.col, endSheet),
-    }
-  }
-
-  private orderRowRangeEnds(endA: RowAddress, endB: RowAddress): { start: RowAddress, end: RowAddress } {
-    const ends = [ endA, endB ]
-    const [ startRow, endRow ] = ends.sort(RowAddress.compareByAbsoluteAddress(this.formulaAddress))
-    const [ startSheet, endSheet ] = ends.map(e => e.sheet).sort(FormulaParser.compareSheetIds.bind(this))
-
-    return {
-      start: new RowAddress(startRow.type, startRow.row, startSheet),
-      end: new RowAddress(endRow.type, endRow.row, endSheet),
-    }
-  }
-  
-  private static compareSheetIds(sheetA: number | undefined, sheetB: number | undefined): number {
-    sheetA = sheetA != null ? sheetA : Infinity
-    sheetB = sheetB != null ? sheetB : Infinity
-    return sheetA - sheetB
-  }
-
   /**
    * Returns {@link CellReferenceAst} or {@link CellRangeAst} based on OFFSET function arguments
    *
-   * @param args - OFFSET function arguments
+   * @param {Ast[]} args - OFFSET function arguments
    */
   private handleOffsetHeuristic(args: Ast[]): Ast {
     const cellArg = args[0]
@@ -906,7 +861,7 @@ export class FormulaLexer {
   /**
    * Returns Lexer tokens from formula string
    *
-   * @param text - string representation of a formula
+   * @param {string} text - string representation of a formula
    */
   public tokenizeFormula(text: string): ILexingResult {
     const lexingResult = this.lexer.tokenize(text)

--- a/src/parser/FormulaParser.ts
+++ b/src/parser/FormulaParser.ts
@@ -215,7 +215,7 @@ export class FormulaParser extends EmbeddedActionsParser {
     }
 
     const { firstEnd, secondEnd, sheetRefType } = FormulaParser.fixSheetIdsForRangeEnds(firstAddress, secondAddress)
-    const { start, end } = this.orderColumnRangeEnds(firstEnd, secondEnd)
+    const { start, end } = { start: firstEnd, end: secondEnd } // this.orderColumnRangeEnds(firstEnd, secondEnd)
 
     return buildColumnRangeAst(start, end, sheetRefType, range.leadingWhitespace)
   })
@@ -242,7 +242,7 @@ export class FormulaParser extends EmbeddedActionsParser {
     }
 
     const { firstEnd, secondEnd, sheetRefType } = FormulaParser.fixSheetIdsForRangeEnds(firstAddress, secondAddress)
-    const { start, end } = this.orderRowRangeEnds(firstEnd, secondEnd)
+    const { start, end } = { start: firstEnd, end: secondEnd } //this.orderRowRangeEnds(firstEnd, secondEnd)
 
     return buildRowRangeAst(start, end, sheetRefType, range.leadingWhitespace)
   })
@@ -723,7 +723,7 @@ export class FormulaParser extends EmbeddedActionsParser {
     }
 
     const { firstEnd, secondEnd, sheetRefType } = FormulaParser.fixSheetIdsForRangeEnds(firstAddress, secondAddress)
-    const { start, end } = this.orderCellRangeEnds(firstEnd, secondEnd)
+    const { start, end } = { start: firstEnd, end: secondEnd } //this.orderCellRangeEnds(firstEnd, secondEnd)
 
     return buildCellRangeAst(start, end, sheetRefType, leadingWhitespace)
   }
@@ -771,7 +771,7 @@ export class FormulaParser extends EmbeddedActionsParser {
     }
   }
   
-  private static  compareSheetIds(sheetA: number | undefined, sheetB: number | undefined): number {
+  private static compareSheetIds(sheetA: number | undefined, sheetB: number | undefined): number {
     sheetA = sheetA != null ? sheetA : Infinity
     sheetB = sheetB != null ? sheetB : Infinity
     return sheetA - sheetB

--- a/src/parser/ParserWithCaching.ts
+++ b/src/parser/ParserWithCaching.ts
@@ -101,12 +101,12 @@ export class ParserWithCaching {
         cacheResult = this.cache.set(hash, parsingResult.ast)
       }
     }
-    const {ast, hasVolatileFunction, hasStructuralChangeFunction, relativeDependencies } = cacheResult
+    const {ast, hasVolatileFunction, hasStructuralChangeFunction } = cacheResult
 
     const fixedAst = this.handleReversedRanges(ast)
-    const fixedRrelativeDependencies = collectDependencies(fixedAst, this.functionRegistry)
+    const dependencies = collectDependencies(fixedAst, this.functionRegistry)
 
-    return {ast: fixedAst, errors: [], hasVolatileFunction, hasStructuralChangeFunction, dependencies: fixedRrelativeDependencies}
+    return {ast: fixedAst, errors: [], hasVolatileFunction, hasStructuralChangeFunction, dependencies }
   }
 
   private handleReversedRanges(ast: Ast): Ast {

--- a/src/parser/ParserWithCaching.ts
+++ b/src/parser/ParserWithCaching.ts
@@ -6,7 +6,7 @@
 import {IToken, tokenMatcher, ILexingResult} from 'chevrotain'
 import {ErrorType, SimpleCellAddress} from '../Cell'
 import {FunctionRegistry} from '../interpreter/FunctionRegistry'
-import {AstNodeType, buildParsingErrorAst, RelativeDependency} from './'
+import {AstNodeType, buildParsingErrorAst, CellAddress, collectDependencies, RelativeDependency} from './'
 import {
   cellAddressFromString,
   columnAddressFromString,
@@ -27,6 +27,8 @@ import {
 } from './LexerConfig'
 import {ParserConfig} from './ParserConfig'
 import {formatNumber} from './Unparser'
+import {ColumnAddress} from './ColumnAddress'
+import {RowAddress} from './RowAddress'
 
 export interface ParsingResult {
   ast: Ast,
@@ -45,6 +47,7 @@ export class ParserWithCaching {
   private lexer: FormulaLexer
   private readonly lexerConfig: LexerConfig
   private formulaParser: FormulaParser
+  private formulaAddress?: SimpleCellAddress
 
   constructor(
     private readonly config: ParserConfig,
@@ -64,6 +67,7 @@ export class ParserWithCaching {
    * @param formulaAddress - address with regard to which formula should be parsed. Impacts computed addresses in R0C0 format.
    */
   public parse(text: string, formulaAddress: SimpleCellAddress): ParsingResult {
+    this.formulaAddress = formulaAddress
     const lexerResult = this.tokenizeFormula(text)
 
     if (lexerResult.errors.length > 0) {
@@ -97,9 +101,114 @@ export class ParserWithCaching {
         cacheResult = this.cache.set(hash, parsingResult.ast)
       }
     }
-    const {ast, hasVolatileFunction, hasStructuralChangeFunction, relativeDependencies} = cacheResult
+    const {ast, hasVolatileFunction, hasStructuralChangeFunction, relativeDependencies } = cacheResult
 
-    return {ast, errors: [], hasVolatileFunction, hasStructuralChangeFunction, dependencies: relativeDependencies}
+    const fixedAst = this.handleReversedRanges(ast)
+    const fixedRrelativeDependencies = collectDependencies(fixedAst, this.functionRegistry)
+
+    return {ast: fixedAst, errors: [], hasVolatileFunction, hasStructuralChangeFunction, dependencies: fixedRrelativeDependencies}
+  }
+
+  private handleReversedRanges(ast: Ast): Ast {
+    switch (ast.type) {
+      case AstNodeType.EMPTY:
+      case AstNodeType.NUMBER:
+      case AstNodeType.STRING:
+      case AstNodeType.ERROR:
+      case AstNodeType.ERROR_WITH_RAW_INPUT:
+      case AstNodeType.CELL_REFERENCE:
+      case AstNodeType.NAMED_EXPRESSION:
+        return ast
+      case AstNodeType.CELL_RANGE: {
+        const { start, end } = ast
+        const orderedEnds = this.orderCellRangeEnds(start, end)
+        return { ...ast, start: orderedEnds.start, end: orderedEnds.end }
+      }
+      case AstNodeType.COLUMN_RANGE: {
+        const { start, end } = ast
+        const orderedEnds = this.orderColumnRangeEnds(start, end)
+        return { ...ast, start: orderedEnds.start, end: orderedEnds.end }
+      }
+      case AstNodeType.ROW_RANGE: {
+        const { start, end } = ast
+        const orderedEnds = this.orderRowRangeEnds(start, end)
+        return { ...ast, start: orderedEnds.start, end: orderedEnds.end }
+      }
+      case AstNodeType.PERCENT_OP:
+      case AstNodeType.PLUS_UNARY_OP:
+      case AstNodeType.MINUS_UNARY_OP: {
+        const valueFixed = this.handleReversedRanges(ast.value)
+        return { ...ast, value: valueFixed }
+      }
+      case AstNodeType.CONCATENATE_OP:
+      case AstNodeType.EQUALS_OP:
+      case AstNodeType.NOT_EQUAL_OP:
+      case AstNodeType.LESS_THAN_OP:
+      case AstNodeType.GREATER_THAN_OP:
+      case AstNodeType.LESS_THAN_OR_EQUAL_OP:
+      case AstNodeType.GREATER_THAN_OR_EQUAL_OP:
+      case AstNodeType.MINUS_OP:
+      case AstNodeType.PLUS_OP:
+      case AstNodeType.TIMES_OP:
+      case AstNodeType.DIV_OP:
+      case AstNodeType.POWER_OP: {
+        const leftFixed = this.handleReversedRanges(ast.left)
+        const rightFixed = this.handleReversedRanges(ast.right)
+        return { ...ast, left: leftFixed, right: rightFixed }
+      }
+      case AstNodeType.PARENTHESIS: {
+        const exprFixed = this.handleReversedRanges(ast.expression)
+        return { ...ast, expression: exprFixed }
+      }
+      case AstNodeType.FUNCTION_CALL: {
+        const argsFixed = ast.args.map(arg => this.handleReversedRanges(arg))
+        return { ...ast, args: argsFixed }
+      }
+      case AstNodeType.ARRAY: {
+        const argsFixed = ast.args.map(argsRow => argsRow.map(arg => this.handleReversedRanges(arg)))
+        return { ...ast, args: argsFixed }
+      }
+    }
+  }
+
+  private orderCellRangeEnds(endA: CellAddress, endB: CellAddress): { start: CellAddress, end: CellAddress } {
+    const ends = [ endA, endB ]
+    const [ startCol, endCol ] = ends.map(e => e.toColumnAddress()).sort(ColumnAddress.compareByAbsoluteAddress(this.formulaAddress!))
+    const [ startRow, endRow ] = ends.map(e => e.toRowAddress()).sort(RowAddress.compareByAbsoluteAddress(this.formulaAddress!))
+    const [ startSheet, endSheet ] = ends.map(e => e.sheet).sort(ParserWithCaching.compareSheetIds.bind(this))
+
+    return {
+      start: CellAddress.fromColAndRow(startCol, startRow, startSheet),
+      end: CellAddress.fromColAndRow(endCol, endRow, endSheet),
+    }
+  }
+
+  private orderColumnRangeEnds(endA: ColumnAddress, endB: ColumnAddress): { start: ColumnAddress, end: ColumnAddress } {
+    const ends = [ endA, endB ]
+    const [ startCol, endCol ] = ends.sort(ColumnAddress.compareByAbsoluteAddress(this.formulaAddress!))
+    const [ startSheet, endSheet ] = ends.map(e => e.sheet).sort(ParserWithCaching.compareSheetIds.bind(this))
+
+    return {
+      start: new ColumnAddress(startCol.type, startCol.col, startSheet),
+      end: new ColumnAddress(endCol.type, endCol.col, endSheet),
+    }
+  }
+
+  private orderRowRangeEnds(endA: RowAddress, endB: RowAddress): { start: RowAddress, end: RowAddress } {
+    const ends = [ endA, endB ]
+    const [ startRow, endRow ] = ends.sort(RowAddress.compareByAbsoluteAddress(this.formulaAddress!))
+    const [ startSheet, endSheet ] = ends.map(e => e.sheet).sort(ParserWithCaching.compareSheetIds.bind(this))
+
+    return {
+      start: new RowAddress(startRow.type, startRow.row, startSheet),
+      end: new RowAddress(endRow.type, endRow.row, endSheet),
+    }
+  }
+
+  private static compareSheetIds(sheetA: number | undefined, sheetB: number | undefined): number {
+    sheetA = sheetA != null ? sheetA : Infinity
+    sheetB = sheetB != null ? sheetB : Infinity
+    return sheetA - sheetB
   }
 
   public fetchCachedResultForAst(ast: Ast): ParsingResult {

--- a/test/AbsoluteCellRange.spec.ts
+++ b/test/AbsoluteCellRange.spec.ts
@@ -40,6 +40,8 @@ describe('AbsoluteCellRange', () => {
         const end = { sheet: 0, row: 666, col: 666 }
         const range = AbsoluteCellRange.fromSimpleCellAddresses(start, end)
 
+        expect(range.start).toEqual(start)
+        expect(range.end).toEqual(end)
         expect(range).toBeInstanceOf(AbsoluteCellRange)
         expect(range).not.toBeInstanceOf(AbsoluteColumnRange)
         expect(range).not.toBeInstanceOf(AbsoluteRowRange)
@@ -50,6 +52,28 @@ describe('AbsoluteCellRange', () => {
         const end = { sheet: 0, row: Infinity, col: 43 }
         const range = AbsoluteCellRange.fromSimpleCellAddresses(start, end)
 
+        expect(range.start).toEqual(start)
+        expect(range.end).toEqual(end)
+        expect(range).toBeInstanceOf(AbsoluteColumnRange)
+      })
+
+      it('constructs a AbsoluteRowRange when called with end.col = Infinity', () => {
+        const start = { sheet: 0, row: 42, col: 0 }
+        const end = { sheet: 0, row: 43, col: Infinity }
+        const range = AbsoluteCellRange.fromSimpleCellAddresses(start, end)
+
+        expect(range.start).toEqual(start)
+        expect(range.end).toEqual(end)
+        expect(range).toBeInstanceOf(AbsoluteRowRange)
+      })
+
+      it('constructs a AbsoluteColumnRange when called with end.row = Infinity, and end.col = Infinity', () => {
+        const start = { sheet: 0, row: 0, col: 0 }
+        const end = { sheet: 0, row: Infinity, col: Infinity }
+        const range = AbsoluteCellRange.fromSimpleCellAddresses(start, end)
+
+        expect(range.start).toEqual(start)
+        expect(range.end).toEqual(end)
         expect(range).toBeInstanceOf(AbsoluteColumnRange)
       })
     })

--- a/test/AbsoluteCellRange.spec.ts
+++ b/test/AbsoluteCellRange.spec.ts
@@ -1,4 +1,4 @@
-import {AbsoluteCellRange} from '../src/AbsoluteCellRange'
+import {AbsoluteCellRange, AbsoluteColumnRange, AbsoluteRowRange} from '../src/AbsoluteCellRange'
 import {adr} from './testUtils'
 
 describe('AbsoluteCellRange', () => {
@@ -22,7 +22,6 @@ describe('AbsoluteCellRange', () => {
       const range = AbsoluteCellRange.spanFrom(start, 1, 1)
 
       expect(start).not.toBe(range.start)
-      expect(start).not.toBe(range.start)
     })
 
     it('ends should be copied whe using constructor', () => {
@@ -33,6 +32,26 @@ describe('AbsoluteCellRange', () => {
 
       expect(start).not.toBe(range.start)
       expect(end).not.toBe(range.end)
+    })
+
+    describe('fromSimpleCellAddresses()', () => {
+      it('constructs a AbsoluteCellRange when all the coordinates are finite', () => {
+        const start = { sheet: 0, row: 42, col: 42 }
+        const end = { sheet: 0, row: 666, col: 666 }
+        const range = AbsoluteCellRange.fromSimpleCellAddresses(start, end)
+
+        expect(range).toBeInstanceOf(AbsoluteCellRange)
+        expect(range).not.toBeInstanceOf(AbsoluteColumnRange)
+        expect(range).not.toBeInstanceOf(AbsoluteRowRange)
+      })
+
+      it('constructs a AbsoluteColumnRange when called with end.row = Infinity', () => {
+        const start = { sheet: 0, row: 0, col: 42 }
+        const end = { sheet: 0, row: Infinity, col: 43 }
+        const range = AbsoluteCellRange.fromSimpleCellAddresses(start, end)
+
+        expect(range).toBeInstanceOf(AbsoluteColumnRange)
+      })
     })
   })
 })

--- a/test/AbsoluteCellRange.spec.ts
+++ b/test/AbsoluteCellRange.spec.ts
@@ -1,5 +1,6 @@
 import {AbsoluteCellRange, AbsoluteColumnRange, AbsoluteRowRange} from '../src/AbsoluteCellRange'
 import {adr} from './testUtils'
+import {SheetsNotEqual} from '../src/errors'
 
 describe('AbsoluteCellRange', () => {
   describe('#addressInRange', () => {
@@ -35,7 +36,7 @@ describe('AbsoluteCellRange', () => {
     })
 
     describe('fromSimpleCellAddresses()', () => {
-      it('constructs a AbsoluteCellRange when all the coordinates are finite', () => {
+      it('constructs an AbsoluteCellRange when all the coordinates are finite', () => {
         const start = { sheet: 0, row: 42, col: 42 }
         const end = { sheet: 0, row: 666, col: 666 }
         const range = AbsoluteCellRange.fromSimpleCellAddresses(start, end)
@@ -47,7 +48,7 @@ describe('AbsoluteCellRange', () => {
         expect(range).not.toBeInstanceOf(AbsoluteRowRange)
       })
 
-      it('constructs a AbsoluteColumnRange when called with end.row = Infinity', () => {
+      it('constructs an AbsoluteColumnRange when called with end.row = Infinity', () => {
         const start = { sheet: 0, row: 0, col: 42 }
         const end = { sheet: 0, row: Infinity, col: 43 }
         const range = AbsoluteCellRange.fromSimpleCellAddresses(start, end)
@@ -57,7 +58,7 @@ describe('AbsoluteCellRange', () => {
         expect(range).toBeInstanceOf(AbsoluteColumnRange)
       })
 
-      it('constructs a AbsoluteRowRange when called with end.col = Infinity', () => {
+      it('constructs an AbsoluteRowRange when called with end.col = Infinity', () => {
         const start = { sheet: 0, row: 42, col: 0 }
         const end = { sheet: 0, row: 43, col: Infinity }
         const range = AbsoluteCellRange.fromSimpleCellAddresses(start, end)
@@ -67,7 +68,7 @@ describe('AbsoluteCellRange', () => {
         expect(range).toBeInstanceOf(AbsoluteRowRange)
       })
 
-      it('constructs a AbsoluteColumnRange when called with end.row = Infinity, and end.col = Infinity', () => {
+      it('constructs an AbsoluteColumnRange when called with end.row = Infinity, and end.col = Infinity', () => {
         const start = { sheet: 0, row: 0, col: 0 }
         const end = { sheet: 0, row: Infinity, col: Infinity }
         const range = AbsoluteCellRange.fromSimpleCellAddresses(start, end)
@@ -75,6 +76,27 @@ describe('AbsoluteCellRange', () => {
         expect(range.start).toEqual(start)
         expect(range.end).toEqual(end)
         expect(range).toBeInstanceOf(AbsoluteColumnRange)
+      })
+
+      it('throws error when trying to construct a cell range with different sheets', () => {
+        const start = { sheet: 1, row: 42, col: 42 }
+        const end = { sheet: 2, row: 43, col: 43 }
+
+        expect(() => AbsoluteCellRange.fromSimpleCellAddresses(start, end)).toThrow(new SheetsNotEqual(start.sheet, end.sheet))
+      })
+
+      it('throws error when trying to construct a column range with different sheets', () => {
+        const start = { sheet: 1, row: 0, col: 42 }
+        const end = { sheet: 2, row: Infinity, col: 43 }
+
+        expect(() => AbsoluteCellRange.fromSimpleCellAddresses(start, end)).toThrow(new SheetsNotEqual(start.sheet, end.sheet))
+      })
+
+      it('throws error when trying to construct a row range with different sheets', () => {
+        const start = { sheet: 1, row: 42, col: 0 }
+        const end = { sheet: 2, row: 43, col: Infinity }
+
+        expect(() => AbsoluteCellRange.fromSimpleCellAddresses(start, end)).toThrow(new SheetsNotEqual(start.sheet, end.sheet))
       })
     })
   })

--- a/test/interpreter/function-sum.spec.ts
+++ b/test/interpreter/function-sum.spec.ts
@@ -138,134 +138,71 @@ describe('SUM', () => {
     })
 
     describe('that has the same R1C1 representation (may cause cache clash)', () => {
-      it('relative addressing', () => {
+      it('when 1st row address is absolute', () => {
         const engine = HyperFormula.buildFromArray([
-          ['=SUM(B2:B1)', 1], // R[1]C[1]:R[0]C[1]
-          ['=SUM(B3:B2)', 2], // R[1]C[1]:R[0]C[1]
-          ['', 3],
-        ])
-
-        expect(engine.getCellValue(adr('A1'))).toEqual(3)
-        expect(engine.getCellValue(adr('A2'))).toEqual(5)
-      })
-
-      it('1st row absolute', () => {
-        const engine = HyperFormula.buildFromArray([
-          ['=SUM(B2:B1)', 1], // R[1]C[1]:R[0]C[1]
-          ['=SUM(B$2:B2)', 2], // R1C[1]:R[0]C[1]
-          ['', 3],
+          ['=SUM(B$2:B1)', 1], // R1C[+1]:R[+0]C[+1]
+          ['=SUM(B$2:B2)', 2], // R1C[+1]:R[+0]C[+1]
         ])
 
         expect(engine.getCellValue(adr('A1'))).toEqual(3)
         expect(engine.getCellValue(adr('A2'))).toEqual(2)
       })
 
-      it('2nd row absolute', () => {
+      it('when 2nd row address is absolute', () => {
         const engine = HyperFormula.buildFromArray([
-          ['=SUM(B2:B1)', 1], // R[1]C[1]:R[0]C[1]
-          ['=SUM(B3:B$1)', 2], // R[1]C[1]:R0C[1]
-          ['', 3],
+          ['=SUM(B1:B$1)', 1], // R[+0]C[+1]:R0C[+1]
+          ['=SUM(B2:B$1)', 2], // R[+0]C[+1]:R0C[+1]
         ])
 
-        expect(engine.getCellValue(adr('A1'))).toEqual(3)
-        expect(engine.getCellValue(adr('A2'))).toEqual(6)
-      })
-
-      it('both rows absolute', () => {
-        const engine = HyperFormula.buildFromArray([
-          ['', 0],
-          ['=SUM(B3:B2)', 1], // R[1]C[1]:R[0]C[1]
-          ['=SUM(B$2:B$1)', 2], // R1C[1]:R0C[1]
-          ['', 3],
-        ])
-
+        expect(engine.getCellValue(adr('A1'))).toEqual(1)
         expect(engine.getCellValue(adr('A2'))).toEqual(3)
-        expect(engine.getCellValue(adr('A3'))).toEqual(1)
       })
-    })
-
-    it('when one of the ranges is a single value', () => {
-      const engine = HyperFormula.buildFromArray([
-        [1, '=SUM(A1:A$1)'],
-        [2, '=SUM(A2:A$1)'],
-      ])
-
-      expect(engine.getCellValue(adr('B1'))).toEqual(1)
-      expect(engine.getCellValue(adr('B2'))).toEqual(3)
     })
   })
 
   describe('works with reversed column ranges', () => {
-    it('1st address absolute', () => {
+    it('when 1st address is absolute', () => {
       const engine = HyperFormula.buildFromArray([
-        ['', '=SUM(E:D)', 1, 2, 3], // C[3]:C[2]
-        ['', '=SUM($D:D)'], // C3:C[2]
+        ['=SUM($C:C)', '=SUM($C:D)', 1, 2], // C2:C[+2] // C2:C[+2]
       ])
 
-      expect(engine.getCellValue(adr('B1'))).toEqual(5)
-      expect(engine.getCellValue(adr('B2'))).toEqual(2)
+      expect(engine.getCellValue(adr('A1'))).toEqual(1)
+      expect(engine.getCellValue(adr('B1'))).toEqual(3)
     })
 
-    it('2nd address absolute', () => {
+    it('when 2nd address is absolute', () => {
       const engine = HyperFormula.buildFromArray([
-        ['', '=SUM(E:D)', 1, 2, 3], // C[3]:C[2]
-        ['', '=SUM(E:$C)'], // C[3]:C2
+        ['=SUM(C:$C)', '=SUM(D:$C)', 1, 2], // C[+2]:C2 // C[+2]:C2
       ])
 
-      expect(engine.getCellValue(adr('B1'))).toEqual(5)
-      expect(engine.getCellValue(adr('B2'))).toEqual(6)
-    })
-
-    it('both addresses absolute', () => {
-      const engine = HyperFormula.buildFromArray([
-        ['', '=SUM(E:D)', 1, 2, 3], // C[3]:C[2]
-        ['', '=SUM($D:$C)'], // C3:C2
-      ])
-
-      expect(engine.getCellValue(adr('B1'))).toEqual(5)
-      expect(engine.getCellValue(adr('B2'))).toEqual(3)
+      expect(engine.getCellValue(adr('A1'))).toEqual(1)
+      expect(engine.getCellValue(adr('B1'))).toEqual(3)
     })
   })
 
   describe('works with reversed row ranges', () => {
-    it('1st address absolute', () => {
+    it('when 1st address is absolute', () => {
       const engine = HyperFormula.buildFromArray([
-        [],
-        ['=SUM(5:4)', '=SUM($4:4)'], // R[3]:R[2] // R3:R[2]
+        ['=SUM($4:3)'], // R3:R[+2]
+        ['=SUM($4:4)'], // R3:R[+2]
         [1],
         [2],
-        [3],
       ])
 
-      expect(engine.getCellValue(adr('A2'))).toEqual(5)
-      expect(engine.getCellValue(adr('B2'))).toEqual(2)
+      expect(engine.getCellValue(adr('A1'))).toEqual(3)
+      expect(engine.getCellValue(adr('A2'))).toEqual(2)
     })
 
-    it('2st address absolute', () => {
+    it('when 2nd address is absolute', () => {
       const engine = HyperFormula.buildFromArray([
-        [],
-        ['=SUM(5:4)', '=SUM(5:$3)'], // R[3]:R[2] // R[3]:R2
+        ['=SUM(3:$3)'], // R[+2]:R2
+        ['=SUM(4:$3)'], // R[+2]:R2
         [1],
         [2],
-        [3],
       ])
 
-      expect(engine.getCellValue(adr('A2'))).toEqual(5)
-      expect(engine.getCellValue(adr('B2'))).toEqual(6)
-    })
-
-    it('both addresses absolute', () => {
-      const engine = HyperFormula.buildFromArray([
-        [],
-        ['=SUM(5:4)', '=SUM($4:$3)'], // R[3]:R[2] // R3:R2
-        [1],
-        [2],
-        [3],
-      ])
-
-      expect(engine.getCellValue(adr('A2'))).toEqual(5)
-      expect(engine.getCellValue(adr('B2'))).toEqual(3)
+      expect(engine.getCellValue(adr('A1'))).toEqual(1)
+      expect(engine.getCellValue(adr('A2'))).toEqual(3)
     })
   })
 })
-

--- a/test/interpreter/function-sum.spec.ts
+++ b/test/interpreter/function-sum.spec.ts
@@ -138,7 +138,31 @@ describe('SUM', () => {
     })
 
     describe('that has the same R1C1 representation (may cause cache clash)', () => {
-      it('when 1st row address is absolute', () => {
+      it('when 1st row address is absolute and one of the ranges is a single value', () => {
+        const engine = HyperFormula.buildFromArray([
+          ['=SUM(B$2:B1)', 1], // R1C[+1]:R[+0]C[+1]
+          ['            ', 2],
+          ['            ', 3],
+          ['=SUM(B$2:B4)', 4], // R1C[+1]:R[+0]C[+1]
+        ])
+
+        expect(engine.getCellValue(adr('A1'))).toEqual(3)
+        expect(engine.getCellValue(adr('A4'))).toEqual(9)
+      })
+
+      it('when 2nd row address is absolute and one of the ranges is a single value', () => {
+        const engine = HyperFormula.buildFromArray([
+          ['=SUM(B1:B$2)', 1], // R[+0]C[+1]:R1C[+1]
+          ['            ', 2],
+          ['            ', 3],
+          ['=SUM(B4:B$2)', 4], // R[+0]C[+1]:R1C[+1]
+        ])
+
+        expect(engine.getCellValue(adr('A1'))).toEqual(3)
+        expect(engine.getCellValue(adr('A4'))).toEqual(9)
+      })
+
+      it('when 1st row address is absolute and one of the ranges is a single value', () => {
         const engine = HyperFormula.buildFromArray([
           ['=SUM(B$2:B1)', 1], // R1C[+1]:R[+0]C[+1]
           ['=SUM(B$2:B2)', 2], // R1C[+1]:R[+0]C[+1]
@@ -148,7 +172,7 @@ describe('SUM', () => {
         expect(engine.getCellValue(adr('A2'))).toEqual(2)
       })
 
-      it('when 2nd row address is absolute', () => {
+      it('when 2nd row address is absolute and one of the ranges is a single value', () => {
         const engine = HyperFormula.buildFromArray([
           ['=SUM(B1:B$1)', 1], // R[+0]C[+1]:R0C[+1]
           ['=SUM(B2:B$1)', 2], // R[+0]C[+1]:R0C[+1]

--- a/test/interpreter/function-sum.spec.ts
+++ b/test/interpreter/function-sum.spec.ts
@@ -135,4 +135,33 @@ describe('SUM', () => {
     expect(engine.getCellValue(adr('A5'))).toEqual(10)
     expect(engine.getCellValue(adr('A6'))).toEqual(10)
   })
+
+  it('tmp relative', () => {
+    const engine = HyperFormula.buildFromArray([
+      [1, '=SUM(A1:A1)'],
+      [2, '=SUM(A2:A1)'],
+    ])
+
+    expect(engine.getCellValue(adr('B1'))).toEqual(1)
+    expect(engine.getCellValue(adr('B2'))).toEqual(3)
+  })
+
+  it('tmp absolute', () => {
+    const engine = HyperFormula.buildFromArray([
+      [1, '=SUM(A1:A$1)'],
+      [2, '=SUM(A2:A$1)'],
+    ])
+
+    expect(engine.getCellValue(adr('B1'))).toEqual(1)
+    expect(engine.getCellValue(adr('B2'))).toEqual(3)
+  })
+
+  it('tmp aux', () => {
+    const engine = HyperFormula.buildFromArray([
+      [1],
+      [2, '=SUM(A2:A$1)'],
+    ])
+
+    expect(engine.getCellValue(adr('B2'))).toEqual(3)
+  })
 })

--- a/test/interpreter/function-sum.spec.ts
+++ b/test/interpreter/function-sum.spec.ts
@@ -120,7 +120,7 @@ describe('SUM', () => {
     expect(engine.getCellValue(adr('A3'))).toEqualError(detailedError(ErrorType.DIV_BY_ZERO))
   })
 
-  describe('works with reversed ranges', () => {
+  describe('works with reversed cell ranges', () => {
     it('simple case', () => {
       const engine = HyperFormula.buildFromArray([
         ['1', '2'],
@@ -184,15 +184,88 @@ describe('SUM', () => {
       })
     })
 
-  it('when one of the ranges is a single value', () => {
-    const engine = HyperFormula.buildFromArray([
-      [1, '=SUM(A1:A$1)'],
-      [2, '=SUM(A2:A$1)'],
-    ])
+    it('when one of the ranges is a single value', () => {
+      const engine = HyperFormula.buildFromArray([
+        [1, '=SUM(A1:A$1)'],
+        [2, '=SUM(A2:A$1)'],
+      ])
 
-    expect(engine.getCellValue(adr('B1'))).toEqual(1)
-    expect(engine.getCellValue(adr('B2'))).toEqual(3)
+      expect(engine.getCellValue(adr('B1'))).toEqual(1)
+      expect(engine.getCellValue(adr('B2'))).toEqual(3)
+    })
   })
-})
+
+  describe('works with reversed column ranges', () => {
+    it('1st address absolute', () => {
+      const engine = HyperFormula.buildFromArray([
+        ['', '=SUM(E:D)', 1, 2, 3], // C[3]:C[2]
+        ['', '=SUM($D:D)'], // C3:C[2]
+      ])
+
+      expect(engine.getCellValue(adr('B1'))).toEqual(5)
+      expect(engine.getCellValue(adr('B2'))).toEqual(2)
+    })
+
+    it('2nd address absolute', () => {
+      const engine = HyperFormula.buildFromArray([
+        ['', '=SUM(E:D)', 1, 2, 3], // C[3]:C[2]
+        ['', '=SUM(E:$C)'], // C[3]:C2
+      ])
+
+      expect(engine.getCellValue(adr('B1'))).toEqual(5)
+      expect(engine.getCellValue(adr('B2'))).toEqual(6)
+    })
+
+    it('both addresses absolute', () => {
+      const engine = HyperFormula.buildFromArray([
+        ['', '=SUM(E:D)', 1, 2, 3], // C[3]:C[2]
+        ['', '=SUM($D:$C)'], // C3:C2
+      ])
+
+      expect(engine.getCellValue(adr('B1'))).toEqual(5)
+      expect(engine.getCellValue(adr('B2'))).toEqual(3)
+    })
+  })
+
+  describe('works with reversed row ranges', () => {
+    it('1st address absolute', () => {
+      const engine = HyperFormula.buildFromArray([
+        [],
+        ['=SUM(5:4)', '=SUM($4:4)'], // R[3]:R[2] // R3:R[2]
+        [1],
+        [2],
+        [3],
+      ])
+
+      expect(engine.getCellValue(adr('A2'))).toEqual(5)
+      expect(engine.getCellValue(adr('B2'))).toEqual(2)
+    })
+
+    it('2st address absolute', () => {
+      const engine = HyperFormula.buildFromArray([
+        [],
+        ['=SUM(5:4)', '=SUM(5:$3)'], // R[3]:R[2] // R[3]:R2
+        [1],
+        [2],
+        [3],
+      ])
+
+      expect(engine.getCellValue(adr('A2'))).toEqual(5)
+      expect(engine.getCellValue(adr('B2'))).toEqual(6)
+    })
+
+    it('both addresses absolute', () => {
+      const engine = HyperFormula.buildFromArray([
+        [],
+        ['=SUM(5:4)', '=SUM($4:$3)'], // R[3]:R[2] // R3:R2
+        [1],
+        [2],
+        [3],
+      ])
+
+      expect(engine.getCellValue(adr('A2'))).toEqual(5)
+      expect(engine.getCellValue(adr('B2'))).toEqual(3)
+    })
+  })
 })
 


### PR DESCRIPTION
### Context
<!--- Why are your changes required? What problem do they solve? -->

This bug was quite complicated. It involved using 2 ranges, which
- have the same R1C1 representation
- evaluate to different values
- exactly one of them is reversed

The reversed ranges are handled by converting them to regular ranges. Before this PR, this conversion was performed during the parsing stage. The AST of a reversed range is different before and after the conversion, but our parser uses caching and outputs the same ASTs for formulas that have the same R1C1 representation. In this PR I moved the code that handles reversed ranges to be run in the post-parsing stage so it is independent of the caching mechanism of the parser.

### How did you test your changes?
<!--- Describe in detail how you tested your changes. -->

- [x] unit tests pass
- [x] add unit tests for more corner cases

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Related issues:
Fixes #1106 

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [x] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [x] My change is compatible with Microsoft Excel.
- [x] My change is compatible with Google Sheets.
- [x] My code follows the code style of this project.
- [x] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
