### PR TITLE
Docs: Make built-in-functions page wider

### DIFF
--- a/docs/guide/built-in-functions.md
+++ b/docs/guide/built-in-functions.md
@@ -1,5 +1,18 @@
 # Built-in functions
 
+<!--
+The below dummy div uses a CSS class to alter the .page layout for the current page without any additional customization of VuePress.
+It makes the page wider to accommodate large tables
+-->
+<div class="widePage"></div>
+<style>
+.page:has(.widePage) .theme-default-content:not(.custom), /* markdown content */
+.page:has(.widePage) .page-edit, /* footer containing the "Help us improve the page" link */
+.page:has(.widePage) .page-nav /* footer links to the next and prev page */ {
+  max-width: 1200px !important; /* override default max-width of 740px for this page */
+}
+</style>
+
 ## Overview
 
 HyperFormula comes with an extensive library of pre-built functions. You can use

--- a/docs/guide/list-of-differences.md
+++ b/docs/guide/list-of-differences.md
@@ -1,8 +1,8 @@
 # List of differences with other spreadsheets
 
-<!-- 
-The below dummy div uses a CSS class to alter the .page layout for the current page without any additional customization of VuePress. 
-It makes the page wider to accommodate large tables  
+<!--
+The below dummy div uses a CSS class to alter the .page layout for the current page without any additional customization of VuePress.
+It makes the page wider to accommodate large tables
 -->
 <div class="widePage"></div>
 <style>


### PR DESCRIPTION
### Context
<!--- Why are your changes required? What problem do they solve? -->

The big table with all functions looks clunky. Making in wider is better in my opinion. We already did the similar modification in the [runtime differences guide](https://hyperformula.handsontable.com/guide/list-of-differences.html).

### How did you test your changes?
<!--- Describe in detail how you tested your changes. -->
local docs build

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [x] Change to the documentation
