### PR TITLE
Code Coverage: Improve coverage for Statistics.ts (to 100%)

### DIFF
--- a/docs/guide/custom-functions.md
+++ b/docs/guide/custom-functions.md
@@ -51,7 +51,8 @@ MyCustomPlugin.implementedFunctions = {
 };
 ```
 
-::: tip To define multiple functions in a single function plugin, add them all
+::: tip
+To define multiple functions in a single function plugin, add them all
 to the `implementedFunctions` object.
 
 ```js
@@ -64,7 +65,6 @@ MyCustomPlugin.implementedFunctions = {
   },
 };
 ```
-
 :::
 
 ### 3. Add your function's names
@@ -302,9 +302,11 @@ if (rangeData.some((row) => row.some((val) => typeof rawValue !== 'number'))) {
 }
 ```
 
-::: tip All HyperFormula [error types](types-of-errors.md) support optional
+::: tip
+All HyperFormula [error types](types-of-errors.md) support optional
 custom error messages. Put them to good use: let your users know what caused the
-error and how to avoid it in the future. :::
+error and how to avoid it in the future.
+:::
 
 ### Test your function
 
@@ -476,8 +478,10 @@ function's behavior depends on the number of valid arguments passed), use the
 You can add translations of your function's name in multiple languages. Your end
 users use the translated names to call your function inside formulas.
 
-::: tip If you support just one language, you still need to define the name of
-your function in that language. :::
+::: tip
+If you support just one language, you still need to define the name of
+your function in that language.
+:::
 
 In a separate object, define the translations of your custom functions' names in
 every language you want to support. Function names are case-insensitive, as they
@@ -500,8 +504,10 @@ export const MyCustomPluginTranslations = {
 HyperFormula.registerFunctionPlugin(MyCustomPlugin, MyCustomPluginTranslations);
 ```
 
-::: tip Before using a translated function name, remember to
-[register and set the language](localizing-functions.md). :::
+::: tip
+Before using a translated function name, remember to
+[register and set the language](localizing-functions.md).
+:::
 
 ## Function aliases
 
@@ -517,7 +523,8 @@ MyCustomPlugin.aliases = {
 };
 ```
 
-::: tip For each alias of your function, define a translation, even if you want
+::: tip
+For each alias of your function, define a translation, even if you want
 to support only one language.
 
 ```js
@@ -528,5 +535,4 @@ MyCustomPlugin.translations = {
   },
 };
 ```
-
 :::

--- a/docs/guide/named-expressions.md
+++ b/docs/guide/named-expressions.md
@@ -45,7 +45,6 @@ Expression names are case-insensitive, and they:
 - Must be unique within a given scope.
 
 ::: tip
-
 Expression names must be unique within a given scope, but you can override a
 global named-expression with a local one. For example:
 
@@ -56,7 +55,6 @@ hfInstance.addNamedExpression('MyRevenue', '=SUM(100+10)');
 // but you can still use `MyRevenue` within the local scope of Sheet2 (sheetId = 1)
 hfInstance.addNamedExpression('MyRevenue', '=Sheet2!$A$1+100', 1);
 ```
-
 :::
 
 For examples of valid and invalid expression names, see the following table:

--- a/test/statistics/statistics.spec.ts
+++ b/test/statistics/statistics.spec.ts
@@ -1,0 +1,69 @@
+import {Statistics, StatType} from '../../src/statistics'
+
+describe('Statistics', () => {
+
+  it('reset - should return to base values', () => {
+    const statistics = new Statistics()
+
+    const baseSnapshot = statistics.snapshot()
+
+    statistics.start(StatType.BUILD_ENGINE_TOTAL)
+    statistics.end(StatType.BUILD_ENGINE_TOTAL)
+    statistics.start(StatType.VLOOKUP)
+    statistics.end(StatType.VLOOKUP)
+    statistics.start(StatType.PROCESS_DEPENDENCIES)
+    statistics.end(StatType.PROCESS_DEPENDENCIES)
+    statistics.incrementCriterionFunctionFullCacheUsed()
+    statistics.incrementCriterionFunctionPartialCacheUsed()
+
+    const modifiedSnapshot = statistics.snapshot()
+
+    statistics.reset()
+
+    const resetSnapshot = statistics.snapshot()
+
+    expect(baseSnapshot.size).toEqual(2)
+    expect(baseSnapshot.get(StatType.CRITERION_FUNCTION_FULL_CACHE_USED)).toEqual(0)
+    expect(baseSnapshot.get(StatType.CRITERION_FUNCTION_PARTIAL_CACHE_USED)).toEqual(0)
+
+    expect(modifiedSnapshot.size).toEqual(5)
+    expect(modifiedSnapshot.has(StatType.CRITERION_FUNCTION_FULL_CACHE_USED)).toEqual(true)
+    expect(modifiedSnapshot.has(StatType.CRITERION_FUNCTION_PARTIAL_CACHE_USED)).toEqual(true)
+    expect(modifiedSnapshot.has(StatType.BUILD_ENGINE_TOTAL)).toEqual(true)
+    expect(modifiedSnapshot.has(StatType.VLOOKUP)).toEqual(true)
+    expect(modifiedSnapshot.has(StatType.PROCESS_DEPENDENCIES)).toEqual(true)
+
+    expect(resetSnapshot).toEqual(baseSnapshot)
+  })
+
+  it('start - should throw if you try and start multiple of the same StatType', () => {
+    const statistics = new Statistics()
+
+    statistics.start(StatType.BUILD_ENGINE_TOTAL)
+    statistics.start(StatType.VLOOKUP)
+
+    expect(() => {
+      statistics.start(StatType.BUILD_ENGINE_TOTAL)  
+    }).toThrowError(`Statistics ${StatType.BUILD_ENGINE_TOTAL} already started`)
+
+    expect(() => {
+      statistics.start(StatType.VLOOKUP)  
+    }).toThrowError(`Statistics ${StatType.VLOOKUP} already started`)
+  })
+
+  it('end - should throw if you try and end a StatType that has not been started', () => {
+    const statistics = new Statistics()
+
+    statistics.start(StatType.BUILD_ENGINE_TOTAL)
+    statistics.start(StatType.VLOOKUP)
+
+    expect(() => {
+      statistics.end(StatType.PROCESS_DEPENDENCIES)  
+    }).toThrowError(`Statistics ${StatType.PROCESS_DEPENDENCIES} not started`)
+
+    expect(() => {
+      statistics.end(StatType.ADJUSTING_ADDRESS_MAPPING)  
+    }).toThrowError(`Statistics ${StatType.ADJUSTING_ADDRESS_MAPPING} not started`)
+  })
+
+})


### PR DESCRIPTION
### Context
Improving Code Coverage for `Statistics.ts`

**Note: The doc changes picked up in this PR request - https://github.com/handsontable/hyperformula/commit/f829f4c57519fffab0ce3a2e3d27182b73cb9a56 - are not from me. It looks those changes might not have been merged from `Hyperformula:master` to `Hyperformula:develop`?**

### How did you test your changes?
`npm:test`

### Types of changes
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Related issues:
1. Improving codecov numbers

### Checklist:
- [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [ ] My change is compatible with Microsoft Excel.
- [ ] My change is compatible with Google Sheets.
- [ ] My code follows the code style of this project.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
