### PR TITLE
Remove sections `Internationalization` and `Custom functions` from built-in-functions guide

### DIFF
--- a/docs/guide/built-in-functions.md
+++ b/docs/guide/built-in-functions.md
@@ -31,7 +31,7 @@ _Some categories such as compatibility, cube, and database are yet to be
 supported._
 
 ::: tip
-You can use [custom functions](custom-functions) to overwrite the standard implementations or add your own functions.
+You can modify the built-in functions or create your own, by adding a [custom function](custom-functions).
 :::
 
 ## Demo

--- a/docs/guide/built-in-functions.md
+++ b/docs/guide/built-in-functions.md
@@ -9,6 +9,8 @@ spreadsheet software. That is because a spreadsheet is probably the most
 universal software ever created. We wanted the same flexibility for HyperFormula
 but without the constraints of the spreadsheet UI.
 
+Each of HyperFormula's built-in function names is available in [17 languages](localizing-functions.md#list-of-supported-languages) and [custom language packs](localizing-functions) can be added.
+
 The latest version of HyperFormula has an extensive collection of
 **{{ $page.functionsCount }}** functions grouped into categories:
 
@@ -28,22 +30,9 @@ The latest version of HyperFormula has an extensive collection of
 _Some categories such as compatibility, cube, and database are yet to be
 supported._
 
-## Internationalization
-
-Each of HyperFormula's built-in function names (and
-[errors](types-of-errors.md)) is available in
-[17 language versions](localizing-functions.md#list-of-supported-languages).
-
-To support more languages or properties, create a
-[custom language pack](localizing-functions).
-
-## Custom functions
-
-One of the most valuable features of HyperFormula is its extensibility. All
-functions are implemented within the plugin architecture which means it is easy
-to remove or replace them. This means you are not limited by the current
-functionality of the engine. HyperFormula lets you design your own
-[custom functions](custom-functions).
+::: tip
+You can use [custom functions](custom-functions) to overwrite the standard implementations or add your own functions.
+:::
 
 ## Demo
 


### PR DESCRIPTION
### Context
<!--- Why are your changes required? What problem do they solve? -->

We decided that these sections were redundant. We just need links to the appropriate guides.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [x] Change to the documentation

### Related issues:
https://handsoncode.slack.com/archives/C031GBX62SE/p1679064663017329 (internal)

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [ ] My change is compatible with Microsoft Excel.
- [ ] My change is compatible with Google Sheets.
- [ ] My code follows the code style of this project.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
