### PR TITLE
Disallow literal (non Error-wrapped) throws

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
     '@typescript-eslint/brace-style': 'error', // wtf
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': ['error'],
     '@typescript-eslint/no-extra-non-null-assertion': ['error'],
+    '@typescript-eslint/no-throw-literal': ['error'],
     '@typescript-eslint/array-type': ['error'],
     '@typescript-eslint/space-before-function-paren': ["error", {
       "anonymous": "never",

--- a/src/ArrayValue.ts
+++ b/src/ArrayValue.ts
@@ -134,13 +134,13 @@ export class ArrayValue implements IArray {
       this.addRows(this.height(), newSize.height - this.height())
     }
     if (this.height() > newSize.height) {
-      throw 'Resizing to smaller array'
+      throw Error('Resizing to smaller array')
     }
     if (this.width() < newSize.width && isFinite(newSize.width)) {
       this.addColumns(this.width(), newSize.width - this.width())
     }
     if (this.width() > newSize.width) {
-      throw 'Resizing to smaller array'
+      throw Error('Resizing to smaller array')
     }
   }
 

--- a/src/DependencyGraph/ValueCellVertex.ts
+++ b/src/DependencyGraph/ValueCellVertex.ts
@@ -39,6 +39,6 @@ export class ValueCellVertex {
   }
 
   public setCellValue(_cellValue: ValueCellVertexValue): never {
-    throw 'SetCellValue is deprecated for ValueCellVertex'
+    throw Error('SetCellValue is deprecated for ValueCellVertex')
   }
 }

--- a/src/LazilyTransformingAstService.ts
+++ b/src/LazilyTransformingAstService.ts
@@ -43,7 +43,7 @@ export class LazilyTransformingAstService {
 
   public commitCombinedMode(): number {
     if (this.combinedTransformer === undefined) {
-      throw 'Combined mode wasn\'t started'
+      throw Error('Combined mode wasn\'t started')
     }
     this.transformations.push(this.combinedTransformer)
     this.combinedTransformer = undefined

--- a/src/NamedExpressions.ts
+++ b/src/NamedExpressions.ts
@@ -231,7 +231,7 @@ export class NamedExpressions {
     }
     const namedExpression = store?.get(expressionName)
     if (store === undefined || namedExpression === undefined || !namedExpression.added) {
-      throw 'Named expression does not exist'
+      throw Error('Named expression does not exist')
     }
     store.remove(expressionName)
     if (store instanceof WorksheetStore && store.mapping.size === 0) {

--- a/src/UndoRedo.ts
+++ b/src/UndoRedo.ts
@@ -439,7 +439,7 @@ export class UndoRedo {
 
   public commitBatchMode() {
     if (this.batchUndoEntry === undefined) {
-      throw 'Batch mode wasn\'t started'
+      throw Error('Batch mode wasn\'t started')
     }
     this.addUndoEntry(this.batchUndoEntry)
     this.batchUndoEntry = undefined
@@ -472,7 +472,7 @@ export class UndoRedo {
   public undo() {
     const operation = this.undoStack.pop()
     if (!operation) {
-      throw 'Attempted to undo without operation on stack'
+      throw Error('Attempted to undo without operation on stack')
     }
 
     this.undoEntry(operation)
@@ -654,7 +654,7 @@ export class UndoRedo {
     const operation = this.redoStack.pop()
 
     if (!operation) {
-      throw 'Attempted to redo without operation on stack'
+      throw Error('Attempted to redo without operation on stack')
     }
 
     this.redoEntry(operation)


### PR DESCRIPTION
### Context
I encountered https://github.com/handsontable/hyperformula/pull/1192 while improving code coverage.

Where `jest` tests that were checking for exceptions like this
```
it('resize dimensions - reduce height', () => {
  const matrix = new ArrayValue([
    [1, 2, 3],
    [4, 5, 6],
    [7, 8, 9],
  ])
  expect(() => {
    const newSize = new ArraySize(3, 1)
    matrix.resize(newSize)
  }).toThrowError('Resizing to smaller array')
})
```
Would work just fine for unit test runs - but when the same tests were run for headless Firefox (as part of `npm:test`) some tests would fail because they were expecting to be catching `Error()` objects - not raw Strings.

```
public resize(newSize: ArraySize) {
  ...
  throw 'Resizing to smaller array'
  ...
}
```

The good news is that currently - most all throws are wrapped in `Error` - with only a few outliers that I see for throws of Strings

```
hyperformula/src/LazilyTransformingAstService.ts
  46,7:       throw 'Combined mode wasn\'t started'

hyperformula/src/NamedExpressions.ts
  234,7:       throw 'Named expression does not exist'

hyperformula/src/UndoRedo.ts
  442,7:       throw 'Batch mode wasn\'t started'
  475,7:       throw 'Attempted to undo without operation on stack'
  657,7:       throw 'Attempted to redo without operation on stack'

hyperformula/src/DependencyGraph/ValueCellVertex.ts
  42,5:     throw 'SetCellValue is deprecated for ValueCellVertex'
```

**This PR**
* Fixes those cases
* Adds a new linting rule that will begin flagging literal throws as errors (per conversation in https://github.com/handsontable/hyperformula/issues/1195)

### How did you test your changes?
* Added the new linting rule - verified that `npm:lint` identified the same list of items identified above
* Modified the src files to wrap `String` throws in `Error`
* Re-ran `npm:lint`- verified success
* Ran `npm:test` - verified successful run of full test suite (lint, unit, and browser)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [X] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Related issues:
1. Fixes https://github.com/handsontable/hyperformula/issues/1195

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [ ] My change is compatible with Microsoft Excel.
- [ ] My change is compatible with Google Sheets.
- [ ] My code follows the code style of this project.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
