### PR TITLE
SEARCH: Bugfix and Increased Coverage

### DIFF
--- a/src/interpreter/plugin/TextPlugin.ts
+++ b/src/interpreter/plugin/TextPlugin.ts
@@ -274,7 +274,10 @@ export class TextPlugin extends FunctionPlugin implements FunctionPluginTypechec
         return new CellError(ErrorType.VALUE, ErrorMessage.LengthBounds)
       }
 
-      const normalizedText = text.substring(startIndex - 1).toLowerCase()
+      let normalizedText = text.substring(startIndex - 1)
+      if (!this.config.caseSensitive) {
+        normalizedText = normalizedText.toLowerCase()
+      }
 
       let index: number
       if (this.arithmeticHelper.requiresRegex(pattern)) {
@@ -283,7 +286,10 @@ export class TextPlugin extends FunctionPlugin implements FunctionPluginTypechec
         index = normalizedText.indexOf(pattern.toLowerCase())
       }
 
-      index = index + startIndex
+      if (index > -1) {
+        index = index + startIndex
+      }
+
       return index > 0 ? index : new CellError(ErrorType.VALUE, ErrorMessage.PatternNotFound)
     })
   }

--- a/test/interpreter/function-search.spec.ts
+++ b/test/interpreter/function-search.spec.ts
@@ -117,36 +117,6 @@ describe('Function SEARCH', () => {
     expect(engine.getCellValue(adr('A10'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.PatternNotFound))
   })
 
-  it('bug', () => {
-    const engineCaseInsensistive = HyperFormula.buildFromArray(
-      [
-        ['=SEARCH(".B", "fooBarBaz")'],
-        ['=SEARCH(".B", "fooBarBaz", 5)'],
-        ['=SEARCH(".b", "fooBarBaz")'],
-        ['=SEARCH(".b", "fooBarBaz", 5)'],
-      ],
-      {useRegularExpressions: true, caseSensitive: false}
-    )
-    expect(engineCaseInsensistive.getCellValue(adr('A1'))).toEqual(3)
-    expect(engineCaseInsensistive.getCellValue(adr('A2'))).toEqual(6)
-    expect(engineCaseInsensistive.getCellValue(adr('A3'))).toEqual(3)
-    expect(engineCaseInsensistive.getCellValue(adr('A4'))).toEqual(6)
-
-    const engineCaseSensistive = HyperFormula.buildFromArray(
-      [
-        ['=SEARCH(".B", "fooBarBaz")'],
-        ['=SEARCH(".B", "fooBarBaz", 5)'],
-        ['=SEARCH(".b", "fooBarBaz")'],
-        ['=SEARCH(".b", "fooBarBaz", 5)'],
-      ],
-      {useRegularExpressions: true, caseSensitive: true}
-    )
-    expect(engineCaseSensistive.getCellValue(adr('A1'))).toEqual(3)
-    expect(engineCaseSensistive.getCellValue(adr('A2'))).toEqual(6)
-    expect(engineCaseSensistive.getCellValue(adr('A3'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.PatternNotFound)) // getting 3
-    expect(engineCaseSensistive.getCellValue(adr('A4'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.PatternNotFound)) // getting 6
-  })
-
   it('should be case insensitive', () => {
     const engine = HyperFormula.buildFromArray([
       ['=SEARCH("R", "bar")'],

--- a/test/interpreter/function-search.spec.ts
+++ b/test/interpreter/function-search.spec.ts
@@ -65,13 +65,18 @@ describe('Function SEARCH', () => {
     expect(engine.getCellValue(adr('A5'))).toEqual(6)
   })
 
-  it('should work with regular expressions', () => {
+  it('should work with regular expressions - case insensitive', () => {
     const engine = HyperFormula.buildFromArray([
       ['=SEARCH(".*f", "foobarbaz")'],
       ['=SEARCH("b.*b", "foobarbaz")'],
       ['=SEARCH("b.z", "foobarbaz")'],
       ['=SEARCH("b.b", "foobarbaz")'],
       ['=SEARCH(".b", "foobarbaz", 5)'],
+      ['=SEARCH(".*F", "foobarbaz")'],
+      ['=SEARCH("b.*B", "foobarbaz")'],
+      ['=SEARCH("B.z", "foobarBaz")'],
+      ['=SEARCH("b.B", "foobarbaz")'],
+      ['=SEARCH(".b", "fooBarBaz", 5)'],
     ], {useRegularExpressions: true})
 
     expect(engine.getCellValue(adr('A1'))).toEqual(1)
@@ -79,6 +84,67 @@ describe('Function SEARCH', () => {
     expect(engine.getCellValue(adr('A3'))).toEqual(7)
     expect(engine.getCellValue(adr('A4'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.PatternNotFound))
     expect(engine.getCellValue(adr('A5'))).toEqual(6)
+    expect(engine.getCellValue(adr('A6'))).toEqual(1)
+    expect(engine.getCellValue(adr('A7'))).toEqual(4)
+    expect(engine.getCellValue(adr('A8'))).toEqual(7)
+    expect(engine.getCellValue(adr('A9'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.PatternNotFound))
+    expect(engine.getCellValue(adr('A10'))).toEqual(6)
+  })
+
+  it('should work with regular expressions - case sensitive', () => {
+    const engine = HyperFormula.buildFromArray([
+      ['=SEARCH(".*f", "foobarbaz")'],
+      ['=SEARCH("b.*b", "foobarbaz")'],
+      ['=SEARCH("b.z", "foobarbaz")'],
+      ['=SEARCH("b.b", "foobarbaz")'],
+      ['=SEARCH(".b", "foobarbaz", 5)'],
+      ['=SEARCH(".*F", "foobarbaz")'],
+      ['=SEARCH("b.*B", "foobarBaz")'],
+      ['=SEARCH("B.z", "foobarBaz")'],
+      ['=SEARCH("b.B", "foobarbaz")'],
+      ['=SEARCH(".b", "fooBarBaz", 5)'],
+    ], {useRegularExpressions: true, caseSensitive: true})
+
+    expect(engine.getCellValue(adr('A1'))).toEqual(1)
+    expect(engine.getCellValue(adr('A2'))).toEqual(4)
+    expect(engine.getCellValue(adr('A3'))).toEqual(7)
+    expect(engine.getCellValue(adr('A4'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.PatternNotFound))
+    expect(engine.getCellValue(adr('A5'))).toEqual(6)
+    expect(engine.getCellValue(adr('A6'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.PatternNotFound))
+    expect(engine.getCellValue(adr('A7'))).toEqual(4)
+    expect(engine.getCellValue(adr('A8'))).toEqualError(7)
+    expect(engine.getCellValue(adr('A9'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.PatternNotFound))
+    expect(engine.getCellValue(adr('A10'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.PatternNotFound))
+  })
+
+  it('bug', () => {
+    const engineCaseInsensistive = HyperFormula.buildFromArray(
+      [
+        ['=SEARCH(".B", "fooBarBaz")'],
+        ['=SEARCH(".B", "fooBarBaz", 5)'],
+        ['=SEARCH(".b", "fooBarBaz")'],
+        ['=SEARCH(".b", "fooBarBaz", 5)'],
+      ],
+      {useRegularExpressions: true, caseSensitive: false}
+    )
+    expect(engineCaseInsensistive.getCellValue(adr('A1'))).toEqual(3)
+    expect(engineCaseInsensistive.getCellValue(adr('A2'))).toEqual(6)
+    expect(engineCaseInsensistive.getCellValue(adr('A3'))).toEqual(3)
+    expect(engineCaseInsensistive.getCellValue(adr('A4'))).toEqual(6)
+
+    const engineCaseSensistive = HyperFormula.buildFromArray(
+      [
+        ['=SEARCH(".B", "fooBarBaz")'],
+        ['=SEARCH(".B", "fooBarBaz", 5)'],
+        ['=SEARCH(".b", "fooBarBaz")'],
+        ['=SEARCH(".b", "fooBarBaz", 5)'],
+      ],
+      {useRegularExpressions: true, caseSensitive: true}
+    )
+    expect(engineCaseSensistive.getCellValue(adr('A1'))).toEqual(3)
+    expect(engineCaseSensistive.getCellValue(adr('A2'))).toEqual(6)
+    expect(engineCaseSensistive.getCellValue(adr('A3'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.PatternNotFound)) // getting 3
+    expect(engineCaseSensistive.getCellValue(adr('A4'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.PatternNotFound)) // getting 6
   })
 
   it('should be case insensitive', () => {


### PR DESCRIPTION
### Context
While adding additional codecov for `SEARCH` the following issues were found when `Hyperformula` is using the `caseSensitive=false` config option
1. The `caseSensitive` option is ignored and always uses a case-insensitive `SEARCH`
2. An incorrect index is being calculated when the pattern is NOT found

These issues can be observed with the following unit test
```
it('bug', () => {
  const engineCaseInsensistive = HyperFormula.buildFromArray(
    [
      ['=SEARCH(".B", "fooBarBaz")'],
      ['=SEARCH(".B", "fooBarBaz", 5)'],
      ['=SEARCH(".b", "fooBarBaz")'],
      ['=SEARCH(".b", "fooBarBaz", 5)'],
    ],
    {useRegularExpressions: true, caseSensitive: false}
  )
  expect(engineCaseInsensistive.getCellValue(adr('A1'))).toEqual(3)
  expect(engineCaseInsensistive.getCellValue(adr('A2'))).toEqual(6)
  expect(engineCaseInsensistive.getCellValue(adr('A3'))).toEqual(3)
  expect(engineCaseInsensistive.getCellValue(adr('A4'))).toEqual(6)

  const engineCaseSensistive = HyperFormula.buildFromArray(
    [
      ['=SEARCH(".B", "fooBarBaz")'],
      ['=SEARCH(".B", "fooBarBaz", 5)'],
      ['=SEARCH(".b", "fooBarBaz")'],
      ['=SEARCH(".b", "fooBarBaz", 5)'],
    ],
    {useRegularExpressions: true, caseSensitive: true}
  )
  expect(engineCaseSensistive.getCellValue(adr('A1'))).toEqual(3) // getting ErrorMessage.PatternNotFound
  expect(engineCaseSensistive.getCellValue(adr('A2'))).toEqual(6) // getting 4
  expect(engineCaseSensistive.getCellValue(adr('A3'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.PatternNotFound)) // getting 3
  expect(engineCaseSensistive.getCellValue(adr('A4'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.PatternNotFound)) // getting 6
  })
```
Or in this JSFiddle example - [hyperformula-bug-search](https://jsfiddle.net/thilgen/nhat8d9w/35/)

### How did you test your changes?
`npm:test`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [X] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [X] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [X] Change to the documentation

### Related issues:
1. https://github.com/handsontable/hyperformula/issues/1225
2. https://github.com/handsontable/hyperformula/pull/1226

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [ ] My change is compatible with Microsoft Excel.
- [ ] My change is compatible with Google Sheets.
- [X] My code follows the code style of this project.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [X] My changes require a documentation update.
- [ ] My changes require a migration guide.
