### PR TITLE
Code Coverage: Improve coverage for ArithmeticHelper.ts (96.29% -> 98.47%)

### DIFF
--- a/test/interpreter/coercions.spec.ts
+++ b/test/interpreter/coercions.spec.ts
@@ -1,4 +1,4 @@
-import {ErrorType, HyperFormula} from '../../src'
+import {ErrorType, HyperFormula, SimpleRangeValue} from '../../src'
 import {CellError} from '../../src/Cell'
 import {Config} from '../../src/Config'
 import {DateTimeHelper} from '../../src/DateTimeHelper'
@@ -7,6 +7,7 @@ import {
   ArithmeticHelper,
   coerceBooleanToNumber,
   coerceScalarToBoolean,
+  coerceToRangeNumbersOrError,
   coerceScalarToString
 } from '../../src/interpreter/ArithmeticHelper'
 import {DateNumber, EmptyValue, TimeNumber} from '../../src/interpreter/InterpreterValue'
@@ -64,10 +65,22 @@ describe('#coerceScalarToComplex', () => {
   })
 })
 
+describe('#coerceToRangeNumbersOrError', () => {
+  it('works', () => {
+    const simpleRangeValueOnlyNumbers = SimpleRangeValue.onlyNumbers([[1, 2]])
+    const timeNumber = new TimeNumber(0, 'hh:mm:ss.ss')
+    expect(coerceToRangeNumbersOrError(simpleRangeValueOnlyNumbers)).toEqual(simpleRangeValueOnlyNumbers)
+    expect(coerceToRangeNumbersOrError(new CellError(ErrorType.DIV_BY_ZERO))).toEqual(new CellError(ErrorType.DIV_BY_ZERO))
+    expect(coerceToRangeNumbersOrError(999)).toEqual(SimpleRangeValue.onlyValues([[999]]))
+    expect(coerceToRangeNumbersOrError(timeNumber)).toEqual(SimpleRangeValue.onlyValues([[timeNumber]]))
+    expect(coerceToRangeNumbersOrError('foo')).toEqual(null)
+  })
+})
+
 describe('#coerceBooleanToNumber', () => {
   it('works', () => {
     expect(coerceBooleanToNumber(true)).toBe(1)
-    expect(coerceBooleanToNumber(false)).toBe(0)
+    expect(coerceBooleanToNumber(false)).toBe(0)    
   })
 
   it('behaves the same as more general coercion', () => {

--- a/test/interpreter/coercions.spec.ts
+++ b/test/interpreter/coercions.spec.ts
@@ -32,6 +32,7 @@ describe('#coerceNonDateScalarToMaybeNumber', () => {
     expect(arithmeticHelper.coerceNonDateScalarToMaybeNumber(EmptyValue)).toBe(0)
     expect(arithmeticHelper.coerceNonDateScalarToMaybeNumber('')).toBe(0)
     expect(arithmeticHelper.coerceNonDateScalarToMaybeNumber(' ')).toEqual(undefined)
+    expect(arithmeticHelper.coerceNonDateScalarToMaybeNumber(new CellError(ErrorType.DIV_BY_ZERO))).toEqual(undefined)
   })
 })
 

--- a/test/interpreter/coercions.spec.ts
+++ b/test/interpreter/coercions.spec.ts
@@ -327,3 +327,52 @@ describe('check if type coercions are applied', () => {
     expect(engine.getCellValue(adr('G1'))).toEqual(false)
   })
 })
+
+describe('#requiresRegex', () => {
+  it('config.useRegularExpressions = false && config.useWildcards = false)', () => {
+    const config = new Config({ useRegularExpressions: false, useWildcards: false })
+    const dateTimeHelper = new DateTimeHelper(config)
+    const numberLiteralsHelper = new NumberLiteralHelper(config)
+    const arithmeticHelper = new ArithmeticHelper(config, dateTimeHelper, numberLiteralsHelper)
+    expect(arithmeticHelper.requiresRegex('')).toEqual(!config.matchWholeCell)
+  })
+
+  it('config.useRegularExpressions = false && config.useWildcards = true)', () => {
+    const config = new Config({ useRegularExpressions: false, useWildcards: true })
+    const dateTimeHelper = new DateTimeHelper(config)
+    const numberLiteralsHelper = new NumberLiteralHelper(config)
+    const arithmeticHelper = new ArithmeticHelper(config, dateTimeHelper, numberLiteralsHelper)
+    expect(arithmeticHelper.requiresRegex('')).toEqual(false)
+    expect(arithmeticHelper.requiresRegex('foo')).toEqual(false)
+    expect(arithmeticHelper.requiresRegex('foo*bar')).toEqual(true)
+    expect(arithmeticHelper.requiresRegex('foo!bar')).toEqual(false)
+    expect(arithmeticHelper.requiresRegex('[ab][0-9]')).toEqual(false)
+    expect(arithmeticHelper.requiresRegex('[ab].*[0-9]')).toEqual(true)
+  })
+
+  it('config.useRegularExpressions = true  && config.useWildcards = false)', () => {
+    const config = new Config({ useRegularExpressions: true, useWildcards: false })
+    const dateTimeHelper = new DateTimeHelper(config)
+    const numberLiteralsHelper = new NumberLiteralHelper(config)
+    const arithmeticHelper = new ArithmeticHelper(config, dateTimeHelper, numberLiteralsHelper)
+    expect(arithmeticHelper.requiresRegex('')).toEqual(false)
+    expect(arithmeticHelper.requiresRegex('foo')).toEqual(false)
+    expect(arithmeticHelper.requiresRegex('foo*bar')).toEqual(true)
+    expect(arithmeticHelper.requiresRegex('foo!bar')).toEqual(true)
+    expect(arithmeticHelper.requiresRegex('[ab][0-9]')).toEqual(true)
+    expect(arithmeticHelper.requiresRegex('[ab].*[0-9]')).toEqual(true)
+  })
+
+  it('config.useRegularExpressions = true  && config.useWildcards = true)', () => {
+    const config = new Config({ useRegularExpressions: true, useWildcards: true })
+    const dateTimeHelper = new DateTimeHelper(config)
+    const numberLiteralsHelper = new NumberLiteralHelper(config)
+    const arithmeticHelper = new ArithmeticHelper(config, dateTimeHelper, numberLiteralsHelper)
+    expect(arithmeticHelper.requiresRegex('')).toEqual(false)
+    expect(arithmeticHelper.requiresRegex('foo')).toEqual(false)
+    expect(arithmeticHelper.requiresRegex('foo*bar')).toEqual(true)
+    expect(arithmeticHelper.requiresRegex('foo!bar')).toEqual(true)
+    expect(arithmeticHelper.requiresRegex('[ab][0-9]')).toEqual(true)
+    expect(arithmeticHelper.requiresRegex('[ab].*[0-9]')).toEqual(true)
+  })
+})

--- a/test/interpreter/coercions.spec.ts
+++ b/test/interpreter/coercions.spec.ts
@@ -62,6 +62,7 @@ describe('#coerceScalarToComplex', () => {
     expect(arithmeticHelper.coerceScalarToComplex('1+-i')).toEqual([1, -1])
     expect(arithmeticHelper.coerceScalarToComplex('0.1+.1 i')).toEqual([0.1, 0.1])
     expect(arithmeticHelper.coerceScalarToComplex(' - 1.0e+1 - - 1.0e+1j')).toEqual([-10, 10])
+    expect(arithmeticHelper.coerceScalarToComplex(new CellError(ErrorType.DIV_BY_ZERO))).toEqual(new CellError(ErrorType.DIV_BY_ZERO))
   })
 })
 

--- a/test/interpreter/coercions.spec.ts
+++ b/test/interpreter/coercions.spec.ts
@@ -82,7 +82,7 @@ describe('#coerceToRangeNumbersOrError', () => {
 describe('#coerceBooleanToNumber', () => {
   it('works', () => {
     expect(coerceBooleanToNumber(true)).toBe(1)
-    expect(coerceBooleanToNumber(false)).toBe(0)    
+    expect(coerceBooleanToNumber(false)).toBe(0)
   })
 
   it('behaves the same as more general coercion', () => {

--- a/test/interpreter/function-search.spec.ts
+++ b/test/interpreter/function-search.spec.ts
@@ -56,6 +56,7 @@ describe('Function SEARCH', () => {
       ['=SEARCH("b?z", "foobarbaz")'],
       ['=SEARCH("b?b", "foobarbaz")'],
       ['=SEARCH("?b", "foobarbaz", 5)'],
+      ['=SEARCH("?b~", "foobarb~az", 5)'],
     ])
 
     expect(engine.getCellValue(adr('A1'))).toEqual(1)
@@ -63,6 +64,7 @@ describe('Function SEARCH', () => {
     expect(engine.getCellValue(adr('A3'))).toEqual(7)
     expect(engine.getCellValue(adr('A4'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.PatternNotFound))
     expect(engine.getCellValue(adr('A5'))).toEqual(6)
+    expect(engine.getCellValue(adr('A6'))).toEqual(6)
   })
 
   it('should work with regular expressions', () => {


### PR DESCRIPTION
### Context
Improving Code Coverage for `ArithmeticHelper.ts`

```
< ArithmeticHelper.ts   |   96.35   |   93.33   |   98.52   |   96.29   |   77,250,389,533,547,563,
                                                                            597-602,704-705,734-737,
                                                                            750                                                                                                                                                                    

> ArithmeticHelper.ts   |   98.5    |   96.82   |   100     |   98.47   |   533,547,563,734-737,750
```

### How did you test your changes?
`npm:test` / `npm:test:coverage`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Related issues:
1. Improving codecov numbers
2. https://github.com/handsontable/hyperformula/pull/1224
3. https://github.com/handsontable/hyperformula/issues/1225

### Checklist:
- [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [ ] My change is compatible with Microsoft Excel.
- [ ] My change is compatible with Google Sheets.
- [X] My code follows the code style of this project.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
