### PR TITLE
Add typecheck for FunctionPlugin.implementedFunctions

### DIFF
--- a/docs/guide/custom-functions.md
+++ b/docs/guide/custom-functions.md
@@ -51,7 +51,8 @@ MyCustomPlugin.implementedFunctions = {
 };
 ```
 
-::: tip To define multiple functions in a single function plugin, add them all
+::: tip
+To define multiple functions in a single function plugin, add them all
 to the `implementedFunctions` object.
 
 ```js
@@ -64,7 +65,6 @@ MyCustomPlugin.implementedFunctions = {
   },
 };
 ```
-
 :::
 
 ### 3. Add your function's names
@@ -302,9 +302,11 @@ if (rangeData.some((row) => row.some((val) => typeof rawValue !== 'number'))) {
 }
 ```
 
-::: tip All HyperFormula [error types](types-of-errors.md) support optional
+::: tip
+All HyperFormula [error types](types-of-errors.md) support optional
 custom error messages. Put them to good use: let your users know what caused the
-error and how to avoid it in the future. :::
+error and how to avoid it in the future.
+:::
 
 ### Test your function
 
@@ -476,8 +478,10 @@ function's behavior depends on the number of valid arguments passed), use the
 You can add translations of your function's name in multiple languages. Your end
 users use the translated names to call your function inside formulas.
 
-::: tip If you support just one language, you still need to define the name of
-your function in that language. :::
+::: tip
+If you support just one language, you still need to define the name of
+your function in that language.
+:::
 
 In a separate object, define the translations of your custom functions' names in
 every language you want to support. Function names are case-insensitive, as they
@@ -500,8 +504,10 @@ export const MyCustomPluginTranslations = {
 HyperFormula.registerFunctionPlugin(MyCustomPlugin, MyCustomPluginTranslations);
 ```
 
-::: tip Before using a translated function name, remember to
-[register and set the language](localizing-functions.md). :::
+::: tip
+Before using a translated function name, remember to
+[register and set the language](localizing-functions.md).
+:::
 
 ## Function aliases
 
@@ -517,7 +523,8 @@ MyCustomPlugin.aliases = {
 };
 ```
 
-::: tip For each alias of your function, define a translation, even if you want
+::: tip
+For each alias of your function, define a translation, even if you want
 to support only one language.
 
 ```js
@@ -528,5 +535,4 @@ MyCustomPlugin.translations = {
   },
 };
 ```
-
 :::

--- a/docs/guide/named-expressions.md
+++ b/docs/guide/named-expressions.md
@@ -45,7 +45,6 @@ Expression names are case-insensitive, and they:
 - Must be unique within a given scope.
 
 ::: tip
-
 Expression names must be unique within a given scope, but you can override a
 global named-expression with a local one. For example:
 
@@ -56,7 +55,6 @@ hfInstance.addNamedExpression('MyRevenue', '=SUM(100+10)');
 // but you can still use `MyRevenue` within the local scope of Sheet2 (sheetId = 1)
 hfInstance.addNamedExpression('MyRevenue', '=Sheet2!$A$1+100', 1);
 ```
-
 :::
 
 For examples of valid and invalid expression names, see the following table:

--- a/src/interpreter/plugin/AbsPlugin.ts
+++ b/src/interpreter/plugin/AbsPlugin.ts
@@ -6,10 +6,10 @@
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class AbsPlugin extends FunctionPlugin implements FunctionPluginTypecheck<AbsPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'ABS': {
       method: 'abs',
       parameters: [

--- a/src/interpreter/plugin/ArrayPlugin.ts
+++ b/src/interpreter/plugin/ArrayPlugin.ts
@@ -11,10 +11,10 @@ import {coerceScalarToBoolean} from '../ArithmeticHelper'
 import {InterpreterState} from '../InterpreterState'
 import {InternalScalarValue, InterpreterValue} from '../InterpreterValue'
 import {SimpleRangeValue} from '../../SimpleRangeValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypecheck<ArrayPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'ARRAYFORMULA': {
       method: 'arrayformula',
       arraySizeMethod: 'arrayformulaArraySize',

--- a/src/interpreter/plugin/BitShiftPlugin.ts
+++ b/src/interpreter/plugin/BitShiftPlugin.ts
@@ -8,14 +8,14 @@ import {ErrorMessage} from '../../error-message'
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 const MAX_48BIT_INTEGER = 281474976710655
 const SHIFT_MIN_POSITIONS = -53
 const SHIFT_MAX_POSITIONS = 53
 
 export class BitShiftPlugin extends FunctionPlugin implements FunctionPluginTypecheck<BitShiftPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'BITLSHIFT': {
       method: 'bitlshift',
       parameters: [

--- a/src/interpreter/plugin/BitwiseLogicOperationsPlugin.ts
+++ b/src/interpreter/plugin/BitwiseLogicOperationsPlugin.ts
@@ -6,10 +6,10 @@
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class BitwiseLogicOperationsPlugin extends FunctionPlugin implements FunctionPluginTypecheck<BitwiseLogicOperationsPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'BITAND': {
       method: 'bitand',
       parameters: [

--- a/src/interpreter/plugin/BooleanPlugin.ts
+++ b/src/interpreter/plugin/BooleanPlugin.ts
@@ -8,13 +8,13 @@ import {ErrorMessage} from '../../error-message'
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InternalNoErrorScalarValue, InternalScalarValue, InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 /**
  * Interpreter plugin containing boolean functions
  */
 export class BooleanPlugin extends FunctionPlugin implements FunctionPluginTypecheck<BooleanPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'TRUE': {
       method: 'literalTrue',
       parameters: [],

--- a/src/interpreter/plugin/CharPlugin.ts
+++ b/src/interpreter/plugin/CharPlugin.ts
@@ -8,10 +8,10 @@ import {ErrorMessage} from '../../error-message'
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class CharPlugin extends FunctionPlugin implements FunctionPluginTypecheck<CharPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'CHAR': {
       method: 'char',
       parameters: [

--- a/src/interpreter/plugin/CodePlugin.ts
+++ b/src/interpreter/plugin/CodePlugin.ts
@@ -8,10 +8,10 @@ import {ErrorMessage} from '../../error-message'
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class CodePlugin extends FunctionPlugin implements FunctionPluginTypecheck<CodePlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'CODE': {
       method: 'code',
       parameters: [

--- a/src/interpreter/plugin/ComplexPlugin.ts
+++ b/src/interpreter/plugin/ComplexPlugin.ts
@@ -9,10 +9,10 @@ import {ProcedureAst} from '../../parser'
 import {coerceComplexToString, complex} from '../ArithmeticHelper'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue, RawInterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class ComplexPlugin extends FunctionPlugin implements FunctionPluginTypecheck<ComplexPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'COMPLEX': {
       method: 'complex',
       parameters: [

--- a/src/interpreter/plugin/ConditionalAggregationPlugin.ts
+++ b/src/interpreter/plugin/ConditionalAggregationPlugin.ts
@@ -18,7 +18,7 @@ import {
   RawScalarValue
 } from '../InterpreterValue'
 import {SimpleRangeValue} from '../../SimpleRangeValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 class AverageResult {
   public static empty = new AverageResult(0, 0)
@@ -75,7 +75,7 @@ function mapToRawScalarValue(arg: InternalScalarValue): Maybe<CellError | RawSca
 }
 
 export class ConditionalAggregationPlugin extends FunctionPlugin implements FunctionPluginTypecheck<ConditionalAggregationPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     SUMIF: {
       method: 'sumif',
       parameters: [

--- a/src/interpreter/plugin/CountBlankPlugin.ts
+++ b/src/interpreter/plugin/CountBlankPlugin.ts
@@ -6,14 +6,14 @@
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {EmptyValue, InterpreterValue, RawScalarValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 /**
  * Interpreter plugin containing MEDIAN function
  */
 export class CountBlankPlugin extends FunctionPlugin implements FunctionPluginTypecheck<CountBlankPlugin> {
 
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'COUNTBLANK': {
       method: 'countblank',
       parameters: [

--- a/src/interpreter/plugin/CountUniquePlugin.ts
+++ b/src/interpreter/plugin/CountUniquePlugin.ts
@@ -7,13 +7,13 @@ import {CellError, ErrorType} from '../../Cell'
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {EmptyValueType, InterpreterValue, RawScalarValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 /**
  * Interpreter plugin containing COUNTUNIQUE function
  */
 export class CountUniquePlugin extends FunctionPlugin implements FunctionPluginTypecheck<CountUniquePlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'COUNTUNIQUE': {
       method: 'countunique',
       parameters: [

--- a/src/interpreter/plugin/DateTimePlugin.ts
+++ b/src/interpreter/plugin/DateTimePlugin.ts
@@ -31,13 +31,13 @@ import {
   RawScalarValue,
 } from '../InterpreterValue'
 import {SimpleRangeValue} from '../../SimpleRangeValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 /**
  * Interpreter plugin containing date-specific functions
  */
 export class DateTimePlugin extends FunctionPlugin implements FunctionPluginTypecheck<DateTimePlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'DATE': {
       method: 'date',
       parameters: [

--- a/src/interpreter/plugin/DegreesPlugin.ts
+++ b/src/interpreter/plugin/DegreesPlugin.ts
@@ -6,10 +6,10 @@
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class DegreesPlugin extends FunctionPlugin implements FunctionPluginTypecheck<DegreesPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'DEGREES': {
       method: 'degrees',
       parameters: [

--- a/src/interpreter/plugin/DeltaPlugin.ts
+++ b/src/interpreter/plugin/DeltaPlugin.ts
@@ -6,10 +6,10 @@
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class DeltaPlugin extends FunctionPlugin implements FunctionPluginTypecheck<DeltaPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'DELTA': {
       method: 'delta',
       parameters: [

--- a/src/interpreter/plugin/ExpPlugin.ts
+++ b/src/interpreter/plugin/ExpPlugin.ts
@@ -6,10 +6,10 @@
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class ExpPlugin extends FunctionPlugin implements FunctionPluginTypecheck<ExpPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions= {
     'EXP': {
       method: 'exp',
       parameters: [

--- a/src/interpreter/plugin/FinancialPlugin.ts
+++ b/src/interpreter/plugin/FinancialPlugin.ts
@@ -16,10 +16,10 @@ import {
   RawInterpreterValue
 } from '../InterpreterValue'
 import {SimpleRangeValue} from '../../SimpleRangeValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class FinancialPlugin extends FunctionPlugin implements FunctionPluginTypecheck<FinancialPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'PMT': {
       method: 'pmt',
       parameters: [

--- a/src/interpreter/plugin/FormulaTextPlugin.ts
+++ b/src/interpreter/plugin/FormulaTextPlugin.ts
@@ -9,10 +9,10 @@ import {ProcedureAst} from '../../parser'
 import {FunctionPlugin} from '../index'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class FormulaTextPlugin extends FunctionPlugin implements FunctionPluginTypecheck<FormulaTextPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'FORMULATEXT': {
       method: 'formulatext',
       parameters: [

--- a/src/interpreter/plugin/InformationPlugin.ts
+++ b/src/interpreter/plugin/InformationPlugin.ts
@@ -10,17 +10,17 @@ import {AstNodeType, ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {EmptyValue, InternalScalarValue, InterpreterValue, isExtendedNumber} from '../InterpreterValue'
 import {SimpleRangeValue} from '../../SimpleRangeValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 /**
  * Interpreter plugin containing information functions
  */
 export class InformationPlugin extends FunctionPlugin implements FunctionPluginTypecheck<InformationPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'COLUMN': {
       method: 'column',
       parameters: [
-        {argumentType: FunctionArgumentType.NOERROR, optional: true}
+        {argumentType: FunctionArgumentType.NOERROR, optionalArg: true}
       ],
       isDependentOnSheetStructureChange: true,
       doesNotNeedArgumentsToBeComputed: true,
@@ -119,7 +119,7 @@ export class InformationPlugin extends FunctionPlugin implements FunctionPluginT
     'ROW': {
       method: 'row',
       parameters: [
-        {argumentType: FunctionArgumentType.NOERROR, optional: true}
+        {argumentType: FunctionArgumentType.NOERROR, optionalArg: true}
       ],
       isDependentOnSheetStructureChange: true,
       doesNotNeedArgumentsToBeComputed: true,

--- a/src/interpreter/plugin/IsEvenPlugin.ts
+++ b/src/interpreter/plugin/IsEvenPlugin.ts
@@ -6,10 +6,10 @@
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class IsEvenPlugin extends FunctionPlugin implements FunctionPluginTypecheck<IsEvenPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'ISEVEN': {
       method: 'iseven',
       parameters: [

--- a/src/interpreter/plugin/IsOddPlugin.ts
+++ b/src/interpreter/plugin/IsOddPlugin.ts
@@ -6,10 +6,10 @@
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class IsOddPlugin extends FunctionPlugin implements FunctionPluginTypecheck<IsOddPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'ISODD': {
       method: 'isodd',
       parameters: [

--- a/src/interpreter/plugin/LogarithmPlugin.ts
+++ b/src/interpreter/plugin/LogarithmPlugin.ts
@@ -6,11 +6,11 @@
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class LogarithmPlugin extends FunctionPlugin implements FunctionPluginTypecheck<LogarithmPlugin> {
 
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'LOG10': {
       method: 'log10',
       parameters: [

--- a/src/interpreter/plugin/LookupPlugin.ts
+++ b/src/interpreter/plugin/LookupPlugin.ts
@@ -14,10 +14,10 @@ import {zeroIfEmpty} from '../ArithmeticHelper'
 import {InterpreterState} from '../InterpreterState'
 import {InternalScalarValue, InterpreterValue, RawNoErrorScalarValue} from '../InterpreterValue'
 import {SimpleRangeValue} from '../../SimpleRangeValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class LookupPlugin extends FunctionPlugin implements FunctionPluginTypecheck<LookupPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'VLOOKUP': {
       method: 'vlookup',
       parameters: [

--- a/src/interpreter/plugin/MathConstantsPlugin.ts
+++ b/src/interpreter/plugin/MathConstantsPlugin.ts
@@ -6,12 +6,12 @@
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export const PI = parseFloat(Math.PI.toFixed(14))
 
 export class MathConstantsPlugin extends FunctionPlugin implements FunctionPluginTypecheck<MathConstantsPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'PI': {
       method: 'pi',
       parameters: [],

--- a/src/interpreter/plugin/MathPlugin.ts
+++ b/src/interpreter/plugin/MathPlugin.ts
@@ -9,10 +9,10 @@ import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue, RawInterpreterValue} from '../InterpreterValue'
 import {SimpleRangeValue} from '../../SimpleRangeValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class MathPlugin extends FunctionPlugin implements FunctionPluginTypecheck<MathPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'FACT': {
       method: 'fact',
       parameters: [

--- a/src/interpreter/plugin/MatrixPlugin.ts
+++ b/src/interpreter/plugin/MatrixPlugin.ts
@@ -10,7 +10,7 @@ import {AstNodeType, ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InternalScalarValue, InterpreterValue} from '../InterpreterValue'
 import {SimpleRangeValue} from '../../SimpleRangeValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export type KernelRunShortcut = (...args: any[]) => number[][]
 
@@ -38,7 +38,7 @@ function arraySizeForPoolFunction(inputArray: ArraySize, windowSize: number, str
 }
 
 export class MatrixPlugin extends FunctionPlugin implements FunctionPluginTypecheck<MatrixPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'MMULT': {
       method: 'mmult',
       arraySizeMethod: 'mmultArraySize',

--- a/src/interpreter/plugin/MedianPlugin.ts
+++ b/src/interpreter/plugin/MedianPlugin.ts
@@ -9,14 +9,14 @@ import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue, RawScalarValue} from '../InterpreterValue'
 import {SimpleRangeValue} from '../../SimpleRangeValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 /**
  * Interpreter plugin containing MEDIAN function
  */
 export class MedianPlugin extends FunctionPlugin implements FunctionPluginTypecheck<MedianPlugin> {
 
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'MEDIAN': {
       method: 'median',
       parameters: [

--- a/src/interpreter/plugin/ModuloPlugin.ts
+++ b/src/interpreter/plugin/ModuloPlugin.ts
@@ -7,10 +7,10 @@ import {CellError, ErrorType} from '../../Cell'
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class ModuloPlugin extends FunctionPlugin implements FunctionPluginTypecheck<ModuloPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'MOD': {
       method: 'mod',
       parameters: [

--- a/src/interpreter/plugin/NumericAggregationPlugin.ts
+++ b/src/interpreter/plugin/NumericAggregationPlugin.ts
@@ -14,7 +14,7 @@ import {coerceBooleanToNumber} from '../ArithmeticHelper'
 import {InterpreterState} from '../InterpreterState'
 import {EmptyValue, ExtendedNumber, getRawValue, InternalScalarValue, isExtendedNumber} from '../InterpreterValue'
 import {SimpleRangeValue} from '../../SimpleRangeValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 import {RangeVertex} from '../../DependencyGraph'
 
 export type BinaryOperation<T> = (left: T, right: T) => T
@@ -76,7 +76,7 @@ class MomentsAggregate {
 }
 
 export class NumericAggregationPlugin extends FunctionPlugin implements FunctionPluginTypecheck<NumericAggregationPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'SUM': {
       method: 'sum',
       parameters: [

--- a/src/interpreter/plugin/PowerPlugin.ts
+++ b/src/interpreter/plugin/PowerPlugin.ts
@@ -6,10 +6,10 @@
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class PowerPlugin extends FunctionPlugin implements FunctionPluginTypecheck<PowerPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'POWER': {
       method: 'power',
       parameters: [

--- a/src/interpreter/plugin/RadiansPlugin.ts
+++ b/src/interpreter/plugin/RadiansPlugin.ts
@@ -6,10 +6,10 @@
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class RadiansPlugin extends FunctionPlugin implements FunctionPluginTypecheck<RadiansPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'RADIANS': {
       method: 'radians',
       parameters: [

--- a/src/interpreter/plugin/RadixConversionPlugin.ts
+++ b/src/interpreter/plugin/RadixConversionPlugin.ts
@@ -10,7 +10,7 @@ import {Maybe} from '../../Maybe'
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 const MAX_LENGTH = 10
 const DECIMAL_NUMBER_OF_BITS = 255
@@ -19,7 +19,7 @@ const MAX_BASE = 36
 const ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 export class RadixConversionPlugin extends FunctionPlugin implements FunctionPluginTypecheck<RadixConversionPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'DEC2BIN': {
       method: 'dec2bin',
       parameters: [

--- a/src/interpreter/plugin/RandomPlugin.ts
+++ b/src/interpreter/plugin/RandomPlugin.ts
@@ -8,10 +8,10 @@ import {ErrorMessage} from '../../error-message'
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class RandomPlugin extends FunctionPlugin implements FunctionPluginTypecheck<RandomPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'RAND': {
       method: 'rand',
       parameters: [],

--- a/src/interpreter/plugin/RomanPlugin.ts
+++ b/src/interpreter/plugin/RomanPlugin.ts
@@ -8,10 +8,10 @@ import {ErrorMessage} from '../../error-message'
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {getRawValue, InterpreterValue, RawScalarValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class RomanPlugin extends FunctionPlugin implements FunctionPluginTypecheck<RomanPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'ROMAN': {
       method: 'roman',
       parameters: [

--- a/src/interpreter/plugin/RoundingPlugin.ts
+++ b/src/interpreter/plugin/RoundingPlugin.ts
@@ -8,7 +8,7 @@ import {ErrorMessage} from '../../error-message'
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export function findNextOddNumber(arg: number): number {
   const ceiled = Math.ceil(arg)
@@ -21,7 +21,7 @@ export function findNextEvenNumber(arg: number): number {
 }
 
 export class RoundingPlugin extends FunctionPlugin implements FunctionPluginTypecheck<RoundingPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'ROUNDUP': {
       method: 'roundup',
       parameters: [

--- a/src/interpreter/plugin/SimpleArithmertic.ts
+++ b/src/interpreter/plugin/SimpleArithmertic.ts
@@ -6,10 +6,10 @@
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class SimpleArithmerticPlugin extends FunctionPlugin implements FunctionPluginTypecheck<SimpleArithmerticPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'HF.ADD': {
       method: 'add',
       parameters: [

--- a/src/interpreter/plugin/SqrtPlugin.ts
+++ b/src/interpreter/plugin/SqrtPlugin.ts
@@ -6,10 +6,10 @@
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class SqrtPlugin extends FunctionPlugin implements FunctionPluginTypecheck<SqrtPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'SQRT': {
       method: 'sqrt',
       parameters: [

--- a/src/interpreter/plugin/StatisticalAggregationPlugin.ts
+++ b/src/interpreter/plugin/StatisticalAggregationPlugin.ts
@@ -28,10 +28,10 @@ import {
   sumsqerr,
   variance
 } from './3rdparty/jstat/jstat'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class StatisticalAggregationPlugin extends FunctionPlugin implements FunctionPluginTypecheck<StatisticalAggregationPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'AVEDEV': {
       method: 'avedev',
       parameters: [

--- a/src/interpreter/plugin/StatisticalPlugin.ts
+++ b/src/interpreter/plugin/StatisticalPlugin.ts
@@ -30,10 +30,10 @@ import {
   tci,
   weibull
 } from './3rdparty/jstat/jstat'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class StatisticalPlugin extends FunctionPlugin implements FunctionPluginTypecheck<StatisticalPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'ERF': {
       method: 'erf',
       parameters: [

--- a/src/interpreter/plugin/SumprodPlugin.ts
+++ b/src/interpreter/plugin/SumprodPlugin.ts
@@ -9,10 +9,10 @@ import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {getRawValue, InterpreterValue, isExtendedNumber} from '../InterpreterValue'
 import {SimpleRangeValue} from '../../SimpleRangeValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class SumprodPlugin extends FunctionPlugin implements FunctionPluginTypecheck<SumprodPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'SUMPRODUCT': {
       method: 'sumproduct',
       parameters: [

--- a/src/interpreter/plugin/TextPlugin.ts
+++ b/src/interpreter/plugin/TextPlugin.ts
@@ -8,13 +8,13 @@ import {ErrorMessage} from '../../error-message'
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue, RawScalarValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 /**
  * Interpreter plugin containing text-specific functions
  */
 export class TextPlugin extends FunctionPlugin implements FunctionPluginTypecheck<TextPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'CONCATENATE': {
       method: 'concatenate',
       parameters: [

--- a/src/interpreter/plugin/TrigonometryPlugin.ts
+++ b/src/interpreter/plugin/TrigonometryPlugin.ts
@@ -8,7 +8,7 @@ import {ErrorMessage} from '../../error-message'
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 import {PI} from './MathConstantsPlugin'
 
 /**
@@ -16,7 +16,7 @@ import {PI} from './MathConstantsPlugin'
  */
 export class TrigonometryPlugin extends FunctionPlugin implements FunctionPluginTypecheck<TrigonometryPlugin> {
 
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'ACOS': {
       method: 'acos',
       parameters: [

--- a/src/interpreter/plugin/VersionPlugin.ts
+++ b/src/interpreter/plugin/VersionPlugin.ts
@@ -8,7 +8,7 @@ import {HyperFormula} from '../../HyperFormula'
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
-import {FunctionPlugin, FunctionPluginTypecheck} from './FunctionPlugin'
+import {FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 const LICENSE_STATUS_MAP = new Map([
   ['gpl-v3', 1],
@@ -18,7 +18,7 @@ const LICENSE_STATUS_MAP = new Map([
 ])
 
 export class VersionPlugin extends FunctionPlugin implements FunctionPluginTypecheck<VersionPlugin> {
-  public static implementedFunctions = {
+  public static implementedFunctions: ImplementedFunctions = {
     'VERSION': {
       method: 'version',
       parameters: [],


### PR DESCRIPTION
### Context
As seen in https://github.com/handsontable/hyperformula/issues/885 - it is currently possible to (erroneously) assign properties to `FunctionMetadata` that are not part of the working set

This change modifies all the current `FunctionPlugins` to formerly declare the type of their static `implementedFunctions` as `ImplementedFunctions` so errors like this can be detected in the future.

This change also includes a modification to `InformationPlugin` to rename the (erroneously) named `optional` properties to `optionalArg`

### How did you test your changes?
`npm-test` `npm-bundle-all`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [X] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Related issues:
1. https://github.com/handsontable/hyperformula/issues/885
2. https://github.com/handsontable/hyperformula/pull/1227

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [ ] My change is compatible with Microsoft Excel.
- [ ] My change is compatible with Google Sheets.
- [X] My code follows the code style of this project.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
