### PR TITLE
Fix `entriesFromColumnsSpan` to return values in the same order regardless of the address mapping strategy

### DIFF
--- a/src/DependencyGraph/AddressMapping/DenseStrategy.ts
+++ b/src/DependencyGraph/AddressMapping/DenseStrategy.ts
@@ -170,8 +170,8 @@ export class DenseStrategy implements IAddressMappingStrategy {
   }
 
   public* entriesFromColumnsSpan(columnsSpan: ColumnsSpan): IterableIterator<[SimpleCellAddress, CellVertex]> {
-    for (let y = 0; y < this.height; ++y) {
-      for (let x = columnsSpan.columnStart; x <= columnsSpan.columnEnd; ++x) {
+    for (let x = columnsSpan.columnStart; x <= columnsSpan.columnEnd; ++x) {
+      for (let y = 0; y < this.height; ++y) {    
         const vertex = this.getCellVertex(x, y)
         if (vertex) {
           yield [simpleCellAddress(columnsSpan.sheet, x, y), vertex]

--- a/test/address-mapping.spec.ts
+++ b/test/address-mapping.spec.ts
@@ -353,6 +353,50 @@ const sharedExamples = (builder: (width: number, height: number) => AddressMappi
 
     expect(() => mapping.moveCell(adr('A1', 3), adr('A2', 3))).toThrowError('Sheet not initialized.')
   })
+
+  it('entriesFromColumnsSpan returns the same result regardless of the strategy', () => {
+    const denseMapping = new AddressMapping(new AlwaysDense())
+    denseMapping.addSheet(0, new DenseStrategy(5, 5))
+
+    const sparseMapping = new AddressMapping(new AlwaysSparse())
+    sparseMapping.addSheet(0, new SparseStrategy(5, 5))
+
+    const mappingsAndResults: { mapping: AddressMapping, results: String[][] }[] = [
+      {
+        mapping: denseMapping,
+        results: [],
+      },
+      {
+        mapping: sparseMapping,
+        results: [],
+      }
+    ]
+
+    mappingsAndResults.forEach((item) => {
+      item.mapping.setCell(adr('A1', 0), new ValueCellVertex(42, 42))
+      item.mapping.setCell(adr('A2', 0), new ValueCellVertex(43, 43))
+      item.mapping.setCell(adr('A3', 0), new ValueCellVertex(44, 44))
+      item.mapping.setCell(adr('B1', 0), new ValueCellVertex(45, 45))
+      item.mapping.setCell(adr('B2', 0), new ValueCellVertex(46, 46))
+      item.mapping.setCell(adr('B3', 0), new ValueCellVertex(47, 47))
+      item.mapping.setCell(adr('C1', 0), new ValueCellVertex(48, 48))
+      item.mapping.setCell(adr('C2', 0), new ValueCellVertex(49, 49))
+      item.mapping.setCell(adr('C3', 0), new ValueCellVertex(50, 50))
+    })
+
+    mappingsAndResults.forEach((item) => {
+      for (const [simpleCellAddress, cellVertex] of item.mapping.entriesFromColumnsSpan(new ColumnsSpan(0, 1, 2))) {
+        item.results.push([
+          String(simpleCellAddress.sheet),
+          String(simpleCellAddress.row),
+          String(simpleCellAddress.col),
+          String(cellVertex.getCellValue()),
+        ])
+      }
+    })
+
+    expect(mappingsAndResults[0].results).toEqual(mappingsAndResults[1].results)
+  })
 }
 
 describe('SparseStrategy', () => {

--- a/test/cruds/removing-columns.spec.ts
+++ b/test/cruds/removing-columns.spec.ts
@@ -1,4 +1,4 @@
-import {ExportedCellChange, HyperFormula} from '../../src'
+import {AlwaysDense, AlwaysSparse, ExportedCellChange, HyperFormula} from '../../src'
 import {AbsoluteCellRange} from '../../src/AbsoluteCellRange'
 import {ArrayVertex, RangeVertex} from '../../src/DependencyGraph'
 import {ColumnIndex} from '../../src/Lookup/ColumnIndex'
@@ -946,3 +946,19 @@ describe('Removing columns - merge ranges', () => {
     verifyValues(engine)
   })
 })
+
+  describe('Removing columns - changes', () => {
+    it('returns the same changes regardless of address mapping policy', () => {
+      const data = [
+        [1, 2, '=A2'],
+        [3, 4, '=B1'],
+      ]
+
+      const alwaysDenseEngine = HyperFormula.buildFromArray(data, { chooseAddressMappingPolicy: new AlwaysDense() })
+      const alwaysDenseChanges = alwaysDenseEngine.removeColumns(0, [0, 2])
+      const alwaysSparseEngine = HyperFormula.buildFromArray(data, { chooseAddressMappingPolicy: new AlwaysSparse() })
+      const alwaysSparseChanges = alwaysSparseEngine.removeColumns(0, [0, 2])
+
+      expect(alwaysDenseChanges).toEqual(alwaysSparseChanges)
+    })
+  })


### PR DESCRIPTION
### Context
<!--- Why are your changes required? What problem do they solve? -->

TBP

### How did you test your changes?
<!--- Describe in detail how you tested your changes. -->

- unit test pass
- new unit tests that describes this issue

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Related issues:
1. Fixes #...
2.
3.

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [ ] My change is compatible with Microsoft Excel.
- [ ] My change is compatible with Google Sheets.
- [ ] My code follows the code style of this project.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
