### PR TITLE
Improve efficiency of the dependency graph (56% speed-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Changed
 
 - Improve efficiency of the default date/time parsing methods. [#876](https://github.com/handsontable/hyperformula/issues/876)
+- Improve efficiency of the operations on the dependency graph. [#876](https://github.com/handsontable/hyperformula/issues/876)
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/handsontable/hyperformula/issues"
   },
   "author": "Handsoncode <hello@handsontable.com>",
-  "version": "3.0.0-perf",
+  "version": "2.5.0",
   "keywords": [
     "formula",
     "spreadsheet",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/handsontable/hyperformula/issues"
   },
   "author": "Handsoncode <hello@handsontable.com>",
-  "version": "2.12.0-perf",
+  "version": "3.0.0-perf",
   "keywords": [
     "formula",
     "spreadsheet",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/handsontable/hyperformula/issues"
   },
   "author": "Handsoncode <hello@handsontable.com>",
-  "version": "2.5.0",
+  "version": "2.12.0-perf",
   "keywords": [
     "formula",
     "spreadsheet",

--- a/src/BuildEngineFactory.ts
+++ b/src/BuildEngineFactory.ts
@@ -86,7 +86,7 @@ export class BuildEngineFactory {
           throw new SheetSizeLimitExceededError()
         }
         const sheetId = sheetMapping.addSheet(sheetName)
-        addressMapping.autoAddSheet(sheetId, sheet, boundaries)
+        addressMapping.autoAddSheet(sheetId, boundaries)
       }
     }
 

--- a/src/DateTimeDefault.ts
+++ b/src/DateTimeDefault.ts
@@ -6,18 +6,24 @@
 import {DateTime, SimpleDate, SimpleTime} from './DateTimeHelper'
 import {Maybe} from './Maybe'
 
-//const QUICK_CHECK_REGEXP = new RegExp('^[0-9/.\\-:\\s]+[ap]?m?\\s*$', '')
-const QUICK_CHECK_REGEXP = new RegExp('^[0-9/.\\-: ]+[ap]?m?$', '')
+export const TIME_FORMAT_SECONDS_ITEM_REGEXP = new RegExp('^ss(\.(s+|0+))?$')
+
+const QUICK_CHECK_REGEXP = new RegExp('^[0-9/.\\-: ]+[ap]?m?$')
 const WHITESPACE_REGEXP = new RegExp('\\s+')
 const DATE_SEPARATOR_REGEXP = new RegExp('[ /.-]')
 const TIME_SEPARATOR = ':'
+const SECONDS_PRECISION = 1000
 
-export function defaultParseToDateTime(text: string, dateFormat?: string, timeFormat?: string): Maybe<DateTime> {
-  let dateTimeString = text.replace(WHITESPACE_REGEXP, ' ').trim().toLowerCase()
-
-  if (!doesItLookLikeADateTimeQuickCheck(dateTimeString)) {
+export function defaultParseToDateTime(text: string, dateFormat: Maybe<string>, timeFormat: Maybe<string>): Maybe<DateTime> {
+  if (dateFormat === undefined && timeFormat === undefined) {
     return undefined
   }
+
+  let dateTimeString = text.replace(WHITESPACE_REGEXP, ' ').trim().toLowerCase()
+
+  // if (!doesItLookLikeADateTimeQuickCheck(dateTimeString)) {
+  //   return undefined
+  // }
 
   let ampmToken: Maybe<string> = dateTimeString.substring(dateTimeString.length - 2)
   if (ampmToken === 'am' || ampmToken === 'pm') {
@@ -57,25 +63,18 @@ export function defaultParseToDateTime(text: string, dateFormat?: string, timeFo
   }
 }
 
-function doesItLookLikeADateTimeQuickCheck(text: string): boolean {
-  return QUICK_CHECK_REGEXP.test(text)
-}
-
-export const secondsExtendedRegexp = /^ss(\.(s+|0+))?$/
-
 function defaultParseToTime(timeItems: string[], timeFormat: Maybe<string>): Maybe<SimpleTime> {
-  const precision = 1000
-
   if (timeFormat === undefined) {
     return undefined
   }
-  timeFormat = timeFormat.toLowerCase()
-  if (timeFormat.endsWith('am/pm')) {
-    timeFormat = timeFormat.substring(0, timeFormat.length - 5).trim()
-  } else if (timeFormat.endsWith('a/p')) {
-    timeFormat = timeFormat.substring(0, timeFormat.length - 3).trim()
-  }
-  const formatItems = timeFormat.split(TIME_SEPARATOR)
+
+  const {
+    itemsCount,
+    hourItem,
+    minuteItem,
+    secondItem,
+  } = memoizedParseTimeFormat(timeFormat)
+
   let ampm = undefined
   if (timeItems[timeItems.length - 1] === 'am' || timeItems[timeItems.length - 1] === 'a') {
     ampm = false
@@ -85,15 +84,11 @@ function defaultParseToTime(timeItems: string[], timeFormat: Maybe<string>): May
     timeItems.pop()
   }
 
-  if (timeItems.length !== formatItems.length) {
+  if (timeItems.length !== itemsCount) {
     return undefined
   }
 
-  const hourIndex = formatItems.indexOf('hh')
-  const minuteIndex = formatItems.indexOf('mm')
-  const secondIndex = formatItems.findIndex(item => secondsExtendedRegexp.test(item))
-
-  const hourString = hourIndex !== -1 ? timeItems[hourIndex] : '0'
+  const hourString = hourItem !== -1 ? timeItems[hourItem] : '0'
   if (!/^\d+$/.test(hourString)) {
     return undefined
   }
@@ -108,44 +103,58 @@ function defaultParseToTime(timeItems: string[], timeFormat: Maybe<string>): May
     }
   }
 
-  const minuteString = minuteIndex !== -1 ? timeItems[minuteIndex] : '0'
+  const minuteString = minuteItem !== -1 ? timeItems[minuteItem] : '0'
   if (!/^\d+$/.test(minuteString)) {
     return undefined
   }
   const minutes = Number(minuteString)
 
-  const secondString = secondIndex !== -1 ? timeItems[secondIndex] : '0'
+  const secondString = secondItem !== -1 ? timeItems[secondItem] : '0'
   if (!/^\d+(\.\d+)?$/.test(secondString)) {
     return undefined
   }
+  const seconds = Math.round(Number(secondString) * SECONDS_PRECISION) / SECONDS_PRECISION
 
-  const seconds = Math.round(Number(secondString) * precision) / precision
+  return { hours, minutes, seconds }
+}
 
-  return {hours, minutes, seconds}
+function parseDateFormat(dateFormat: string) {
+  const items = dateFormat.toLowerCase().trim().split(DATE_SEPARATOR_REGEXP)
+
+  return {
+    itemsCount: items.length,
+    dayItem: items.indexOf('dd'),
+    monthItem: items.indexOf('mm'),
+    shortYearItem: items.indexOf('yy'),
+    longYearItem: items.indexOf('yyyy'),
+  }
 }
 
 function defaultParseToDate(dateItems: string[], dateFormat: Maybe<string>): Maybe<SimpleDate> {
   if (dateFormat === undefined) {
     return undefined
   }
-  const formatItems = dateFormat.toLowerCase().split(DATE_SEPARATOR_REGEXP)
-  if (dateItems.length !== formatItems.length) {
+  const {
+    itemsCount,
+    dayItem,
+    monthItem,
+    shortYearItem,
+    longYearItem,
+  } = memoizedParseDateFormat(dateFormat)
+
+  if (dateItems.length !== itemsCount) {
     return undefined
   }
-  const monthIndex = formatItems.indexOf('mm')
-  const dayIndex = formatItems.indexOf('dd')
-  const yearIndexLong = formatItems.indexOf('yyyy')
-  const yearIndexShort = formatItems.indexOf('yy')
-  if (!(monthIndex in dateItems) || !(dayIndex in dateItems) ||
-    (!(yearIndexLong in dateItems) && !(yearIndexShort in dateItems))) {
+  if (!(monthItem in dateItems) || !(dayItem in dateItems) ||
+    (!(longYearItem in dateItems) && !(shortYearItem in dateItems))) {
     return undefined
   }
-  if (yearIndexLong in dateItems && yearIndexShort in dateItems) {
+  if (longYearItem in dateItems && shortYearItem in dateItems) {
     return undefined
   }
   let year
-  if (yearIndexLong in dateItems) {
-    const yearString = dateItems[yearIndexLong]
+  if (longYearItem in dateItems) {
+    const yearString = dateItems[longYearItem]
     if (/^\d+$/.test(yearString)) {
       year = Number(yearString)
       if (year < 1000 || year > 9999) {
@@ -155,7 +164,7 @@ function defaultParseToDate(dateItems: string[], dateFormat: Maybe<string>): May
       return undefined
     }
   } else {
-    const yearString = dateItems[yearIndexShort]
+    const yearString = dateItems[shortYearItem]
     if (/^\d+$/.test(yearString)) {
       year = Number(yearString)
       if (year < 0 || year > 99) {
@@ -165,17 +174,56 @@ function defaultParseToDate(dateItems: string[], dateFormat: Maybe<string>): May
       return undefined
     }
   }
-  const monthString = dateItems[monthIndex]
+  const monthString = dateItems[monthItem]
   if (!/^\d+$/.test(monthString)) {
     return undefined
   }
   const month = Number(monthString)
-  const dayString = dateItems[dayIndex]
+  const dayString = dateItems[dayItem]
   if (!/^\d+$/.test(dayString)) {
     return undefined
   }
   const day = Number(dayString)
   return {year, month, day}
+}
+
+function doesItLookLikeADateTimeQuickCheck(text: string): boolean {
+  return QUICK_CHECK_REGEXP.test(text)
+}
+
+function parseTimeFormat(timeFormat: string): { itemsCount: number, hourItem: number, minuteItem: number, secondItem: number } {
+  const formatLowercase = timeFormat.toLowerCase().trim()
+  const formatWithoutAmPmItem = formatLowercase.endsWith('am/pm')
+    ? formatLowercase.substring(0, formatLowercase.length - 5)
+    : (formatLowercase.endsWith('a/p')
+      ? formatLowercase.substring(0, timeFormat.length - 3)
+      : formatLowercase)
+
+  const items = formatWithoutAmPmItem.trim().split(TIME_SEPARATOR)
+  return {
+    itemsCount: items.length,
+    hourItem: items.indexOf('hh'),
+    minuteItem: items.indexOf('mm'),
+    secondItem: items.findIndex(item => TIME_FORMAT_SECONDS_ITEM_REGEXP.test(item)),
+  }
+}
+
+const memoizedParseTimeFormat = memoize(parseTimeFormat)
+const memoizedParseDateFormat = memoize(parseDateFormat)
+
+function memoize<T>(fn: (arg: string) => T) {
+  const memoizedResults: {[key: string]: T} = {}
+
+  return (arg: string) => {
+    const memoizedResult = memoizedResults[arg]
+    if (memoizedResult !== undefined) {
+      return memoizedResult
+    }
+
+    const result = fn(arg)
+    memoizedResults[arg] = result
+    return result
+  }
 }
 
 // Ideas:

--- a/src/DateTimeDefault.ts
+++ b/src/DateTimeDefault.ts
@@ -6,7 +6,7 @@
 import {DateTime, SimpleDate, SimpleTime} from './DateTimeHelper'
 import {Maybe} from './Maybe'
 
-export const TIME_FORMAT_SECONDS_ITEM_REGEXP = new RegExp('^ss(\.(s+|0+))?$')
+export const TIME_FORMAT_SECONDS_ITEM_REGEXP = new RegExp('^ss(\\.(s+|0+))?$')
 
 const QUICK_CHECK_REGEXP = new RegExp('^[0-9/.\\-: ]+[ap]?m?$')
 const WHITESPACE_REGEXP = new RegExp('\\s+')

--- a/src/DateTimeHelper.ts
+++ b/src/DateTimeHelper.ts
@@ -229,10 +229,10 @@ export class DateTimeHelper {
   }
 
   private parseDateTimeFromFormats(dateTimeString: string, dateFormats: string[], timeFormats: string[]): Partial<{ dateTime: DateTime, dateFormat: string, timeFormat: string }> {
-    const dateFormatsIterate = dateFormats.length === 0 ? [undefined] : dateFormats
-    const timeFormatsIterate = timeFormats.length === 0 ? [undefined] : timeFormats
-    for (const dateFormat of dateFormatsIterate) {
-      for (const timeFormat of timeFormatsIterate) {
+    const dateFormatsArray = dateFormats.length === 0 ? [undefined] : dateFormats
+    const timeFormatsArray = timeFormats.length === 0 ? [undefined] : timeFormats
+    for (const dateFormat of dateFormatsArray) {
+      for (const timeFormat of timeFormatsArray) {
         const dateTime = this.parseSingleFormat(dateTimeString, dateFormat, timeFormat)
         if (dateTime !== undefined) {
           return {dateTime, timeFormat, dateFormat}
@@ -319,4 +319,3 @@ export function timeToNumber(time: SimpleTime): number {
 export function toBasisEU(date: SimpleDate): SimpleDate {
   return {year: date.year, month: date.month, day: Math.min(30, date.day)}
 }
-

--- a/src/DependencyGraph/AddressMapping/AddressMapping.ts
+++ b/src/DependencyGraph/AddressMapping/AddressMapping.ts
@@ -61,7 +61,7 @@ export class AddressMapping {
     this.mapping.set(sheetId, strategy)
   }
 
-  public autoAddSheet(sheetId: number, sheet: Sheet, sheetBoundaries: SheetBoundaries) {
+  public autoAddSheet(sheetId: number, sheetBoundaries: SheetBoundaries) {
     const {height, width, fill} = sheetBoundaries
     const strategyConstructor = this.policy.call(fill)
     this.addSheet(sheetId, new strategyConstructor(width, height))

--- a/src/DependencyGraph/DependencyGraph.ts
+++ b/src/DependencyGraph/DependencyGraph.ts
@@ -165,7 +165,7 @@ export class DependencyGraph {
   }
 
   public verticesToRecompute() {
-    return new Set([...this.graph.specialNodesRecentlyChanged, ...this.volatileVertices()])
+    return new Set([...this.graph.getSpecialRecentlyChangedNodes(), ...this.volatileVertices()])
   }
 
   public processCellDependencies(cellDependencies: CellDependency[], endVertex: Vertex) {

--- a/src/DependencyGraph/DependencyGraph.ts
+++ b/src/DependencyGraph/DependencyGraph.ts
@@ -528,7 +528,7 @@ export class DependencyGraph {
   }
 
   public* arrayFormulaNodes(): IterableIterator<ArrayVertex> {
-    for (const vertex of this.graph.nodes) {
+    for (const vertex of this.graph.getNodes()) {
       if (vertex instanceof ArrayVertex) {
         yield vertex
       }
@@ -612,7 +612,7 @@ export class DependencyGraph {
   }
 
   public forceApplyPostponedTransformations() {
-    for (const vertex of this.graph.nodes.values()) {
+    for (const vertex of this.graph.getNodes()) {
       if (vertex instanceof FormulaCellVertex) {
         vertex.ensureRecentData(this.lazilyTransformingAstService)
       }

--- a/src/DependencyGraph/DependencyGraph.ts
+++ b/src/DependencyGraph/DependencyGraph.ts
@@ -41,10 +41,11 @@ import {AddressMapping} from './AddressMapping/AddressMapping'
 import {ArrayMapping} from './ArrayMapping'
 import {collectAddressesDependentToRange} from './collectAddressesDependentToRange'
 import {FormulaVertex} from './FormulaCellVertex'
-import {DependencyQuery, Graph, TopSortResult} from './Graph'
+import {DependencyQuery, Graph} from './Graph'
 import {RangeMapping} from './RangeMapping'
 import {SheetMapping} from './SheetMapping'
 import {RawAndParsedValue} from './ValueCellVertex'
+import {TopSortResult} from './TopSort'
 
 export class DependencyGraph {
   public readonly graph: Graph<Vertex>

--- a/src/DependencyGraph/DependencyGraph.ts
+++ b/src/DependencyGraph/DependencyGraph.ts
@@ -112,6 +112,7 @@ export class DependencyGraph {
     if (vertex instanceof ArrayVertex) {
       this.arrayMapping.removeArray(vertex.getRange())
     }
+
     if (vertex instanceof ValueCellVertex) {
       const oldValues = vertex.getValues()
       if (oldValues.rawValue !== value.rawValue) {
@@ -1091,7 +1092,7 @@ export class DependencyGraph {
     const adjNodesStored = this.graph.adjacentNodes(newVertex)
 
     this.removeVertexAndCleanupDependencies(newVertex)
-    this.graph.softRemoveEdge(existingVertex, newVertex)
+    this.graph.removeEdgeIfExists(existingVertex, newVertex)
     adjNodesStored.forEach((adjacentNode) => {
       if (this.graph.hasNode(adjacentNode)) {
         this.graph.addEdge(existingVertex, adjacentNode)

--- a/src/DependencyGraph/DependencyGraph.ts
+++ b/src/DependencyGraph/DependencyGraph.ts
@@ -169,6 +169,8 @@ export class DependencyGraph {
   }
 
   public processCellDependencies(cellDependencies: CellDependency[], endVertex: Vertex) {
+    const endVertexId = this.graph.getNodeId(endVertex)!
+
     cellDependencies.forEach((dep: CellDependency) => {
       if (dep instanceof AbsoluteCellRange) {
         const range = dep
@@ -179,18 +181,20 @@ export class DependencyGraph {
           this.rangeMapping.setRange(rangeVertex)
         }
 
-        this.graph.addNode(rangeVertex)
+        this.graph.addNodeAndReturnId(rangeVertex)
+        const rangeVertexId = this.graph.getNodeId(rangeVertex)!
+
         if (!range.isFinite()) {
-          this.graph.markNodeAsInfiniteRange(rangeVertex)
+          this.graph.markNodeAsInfiniteRange(rangeVertexId)
         }
 
         const {smallerRangeVertex, restRange} = this.rangeMapping.findSmallerRange(range)
         if (smallerRangeVertex !== undefined) {
-          this.graph.addEdge(smallerRangeVertex, rangeVertex)
+          this.graph.addEdge(smallerRangeVertex, rangeVertexId)
           if (rangeVertex.bruteForce) {
             rangeVertex.bruteForce = false
             for (const cellFromRange of range.addresses(this)) { //if we ever switch heuristic to processing by sorted sizes, this would be unnecessary
-              this.graph.removeEdge(this.fetchCell(cellFromRange), rangeVertex)
+              this.graph.removeEdge(this.fetchCell(cellFromRange), rangeVertexId)
             }
           }
         } else {
@@ -199,58 +203,69 @@ export class DependencyGraph {
 
         const array = this.arrayMapping.getArray(restRange)
         if (array !== undefined) {
-          this.graph.addEdge(array, rangeVertex)
+          this.graph.addEdge(array, rangeVertexId)
         } else {
           for (const cellFromRange of restRange.addresses(this)) {
-            this.graph.addEdge(this.fetchCellOrCreateEmpty(cellFromRange), rangeVertex)
+            const { vertex, id } = this.fetchCellOrCreateEmpty(cellFromRange)
+            this.graph.addEdge(id ?? vertex, rangeVertexId)
           }
         }
-        this.graph.addEdge(rangeVertex, endVertex)
+        this.graph.addEdge(rangeVertexId, endVertexId)
 
         if (range.isFinite()) {
           this.correctInfiniteRangesDependenciesByRangeVertex(rangeVertex)
         }
       } else if (dep instanceof NamedExpressionDependency) {
         const sheetOfVertex = (endVertex as FormulaCellVertex).getAddress(this.lazilyTransformingAstService).sheet
-        const namedExpressionVertex = this.fetchNamedExpressionVertex(dep.name, sheetOfVertex)
-        this.graph.addEdge(namedExpressionVertex, endVertex)
+        const { vertex, id } = this.fetchNamedExpressionVertex(dep.name, sheetOfVertex)
+        this.graph.addEdge(id ?? vertex, endVertexId)
       } else {
-        this.graph.addEdge(this.fetchCellOrCreateEmpty(dep), endVertex)
+        const { vertex, id } = this.fetchCellOrCreateEmpty(dep)
+        this.graph.addEdge(id ?? vertex, endVertexId)
       }
     })
   }
 
-  public fetchNamedExpressionVertex(expressionName: string, sheetId: number): CellVertex {
+  public fetchNamedExpressionVertex(expressionName: string, sheetId: number): { vertex: CellVertex, id: Maybe<number>} {
     const namedExpression = this.namedExpressions.namedExpressionOrPlaceholder(expressionName, sheetId)
     return this.fetchCellOrCreateEmpty(namedExpression.address)
   }
 
   public exchangeNode(addressFrom: SimpleCellAddress, addressTo: SimpleCellAddress) {
-    const vertexFrom = this.fetchCellOrCreateEmpty(addressFrom)
-    const vertexTo = this.fetchCellOrCreateEmpty(addressTo)
+    const vertexFrom = this.fetchCellOrCreateEmpty(addressFrom).vertex
+    const vertexTo = this.fetchCellOrCreateEmpty(addressTo).vertex
     this.addressMapping.removeCell(addressFrom)
     this.exchangeGraphNode(vertexFrom, vertexTo)
   }
 
   public correctInfiniteRangesDependency(address: SimpleCellAddress) {
-    let vertex: Maybe<Vertex> = undefined;
+    const relevantInfiniteRanges = (this.graph.getInfiniteRanges())
+      .filter(({ node }) => (node as RangeVertex).range.addressInRange(address))
 
-    (this.graph.getInfiniteRanges() as RangeVertex[])
-      .filter((infiniteRangeVertex: RangeVertex) => infiniteRangeVertex.range.addressInRange(address))
-      .forEach((infiniteRangeVertex: RangeVertex) => {
-        vertex = vertex ?? this.fetchCellOrCreateEmpty(address)
-        this.graph.addEdge(vertex, infiniteRangeVertex)
-      })
+    if (relevantInfiniteRanges.length <= 0) {
+      return
+    }
+
+    const { vertex, id: maybeVertexId } = this.fetchCellOrCreateEmpty(address)
+    const vertexId = maybeVertexId ?? this.graph.getNodeId(vertex)!
+
+    relevantInfiniteRanges.forEach(({ id }) => {
+      this.graph.addEdge(vertexId, id)
+    })
   }
 
-  public fetchCellOrCreateEmpty(address: SimpleCellAddress): CellVertex {
-    let vertex = this.addressMapping.getCell(address)
-    if (vertex === undefined) {
-      vertex = new EmptyCellVertex()
-      this.graph.addNode(vertex)
-      this.addressMapping.setCell(address, vertex)
+  public fetchCellOrCreateEmpty(address: SimpleCellAddress): { vertex: CellVertex, id: Maybe<number> } {
+    const existingVertex = this.addressMapping.getCell(address)
+
+    if (existingVertex !== undefined) {
+      return { vertex: existingVertex, id: undefined }
     }
-    return vertex
+
+    const newVertex = new EmptyCellVertex()
+    const newVertexId = this.graph.addNodeAndReturnId(newVertex)
+    this.addressMapping.setCell(address, newVertex)
+
+    return { vertex: newVertex, id: newVertexId }
   }
 
   public removeRows(removedRows: RowsSpan): EagerChangesGraphChangeResult {
@@ -453,7 +468,7 @@ export class DependencyGraph {
         let emptyVertex = undefined
         for (const adjacentNode of this.graph.adjacentNodes(sourceVertex)) {
           if (adjacentNode instanceof RangeVertex && !sourceRange.containsRange(adjacentNode.range)) {
-            emptyVertex = emptyVertex ?? this.fetchCellOrCreateEmpty(sourceAddress)
+            emptyVertex = emptyVertex ?? this.fetchCellOrCreateEmpty(sourceAddress).vertex
             this.graph.addEdge(emptyVertex, adjacentNode)
             this.graph.removeEdge(sourceVertex, adjacentNode)
           }
@@ -469,7 +484,7 @@ export class DependencyGraph {
           this.addressMapping.removeCell(targetAddress)
         }
         for (const adjacentNode of this.graph.adjacentNodes(targetVertex)) {
-          sourceVertex = sourceVertex ?? this.fetchCellOrCreateEmpty(targetAddress)
+          sourceVertex = sourceVertex ?? this.fetchCellOrCreateEmpty(targetAddress).vertex
           this.graph.addEdge(sourceVertex, adjacentNode)
           this.graph.markNodeAsDirty(sourceVertex)
         }
@@ -483,10 +498,10 @@ export class DependencyGraph {
           this.graph.removeEdge(rangeVertex, adjacentNode)
 
           for (const address of rangeVertex.range.addresses(this)) {
-            const newEmptyVertex = this.fetchCellOrCreateEmpty(address)
-            this.graph.addEdge(newEmptyVertex, adjacentNode)
-            this.addressMapping.setCell(address, newEmptyVertex)
-            this.graph.markNodeAsDirty(newEmptyVertex)
+            const { vertex, id } = this.fetchCellOrCreateEmpty(address)
+            this.graph.addEdge(id ?? vertex, adjacentNode)
+            this.addressMapping.setCell(address, vertex)
+            this.graph.markNodeAsDirty(vertex)
           }
         }
       }
@@ -506,8 +521,8 @@ export class DependencyGraph {
     for (const adjacentNode of adjacentNodes.values()) {
       const nodeDependencies = collectAddressesDependentToRange(this.functionRegistry, adjacentNode, arrayVertex.getRange(), this.lazilyTransformingAstService, this)
       for (const address of nodeDependencies) {
-        const vertex = this.fetchCellOrCreateEmpty(address)
-        this.graph.addEdge(vertex, adjacentNode)
+        const { vertex, id } = this.fetchCellOrCreateEmpty(address)
+        this.graph.addEdge(id ?? vertex, adjacentNode)
       }
       if (nodeDependencies.length > 0) {
         this.graph.markNodeAsDirty(adjacentNode)
@@ -519,12 +534,12 @@ export class DependencyGraph {
   }
 
   public addVertex(address: SimpleCellAddress, vertex: CellVertex): void {
-    this.graph.addNode(vertex)
+    this.graph.addNodeAndReturnId(vertex)
     this.addressMapping.setCell(address, vertex)
   }
 
   public addArrayVertex(address: SimpleCellAddress, vertex: ArrayVertex): void {
-    this.graph.addNode(vertex)
+    this.graph.addNodeAndReturnId(vertex)
     this.setAddressMappingForArrayVertex(vertex, address)
   }
 
@@ -647,7 +662,7 @@ export class DependencyGraph {
   }
 
   public exchangeGraphNode(oldNode: Vertex, newNode: Vertex) {
-    this.graph.addNode(newNode)
+    this.graph.addNodeAndReturnId(newNode)
     const adjNodesStored = this.graph.adjacentNodes(oldNode)
     this.removeVertex(oldNode)
     adjNodesStored.forEach((adjacentNode) => {
@@ -661,7 +676,7 @@ export class DependencyGraph {
     if (oldNode) {
       this.exchangeGraphNode(oldNode, newNode)
     } else {
-      this.graph.addNode(newNode)
+      this.graph.addNodeAndReturnId(newNode)
     }
   }
 
@@ -769,16 +784,17 @@ export class DependencyGraph {
   }
 
   private correctInfiniteRangesDependenciesByRangeVertex(vertex: RangeVertex) {
-    (this.graph.getInfiniteRanges() as RangeVertex[])
-      .forEach((infiniteRangeVertex: RangeVertex) => {
-        const intersection = vertex.range.intersectionWith(infiniteRangeVertex.range)
+    this.graph.getInfiniteRanges()
+      .forEach(({ id: infiniteRangeVertexId, node: infiniteRangeVertex }) => {
+        const intersection = vertex.range.intersectionWith((infiniteRangeVertex as RangeVertex).range)
 
         if (intersection === undefined) {
           return
         }
 
         intersection.addresses(this).forEach((address: SimpleCellAddress) => {
-          this.graph.addEdge(this.fetchCellOrCreateEmpty(address), infiniteRangeVertex)
+          const { vertex, id } = this.fetchCellOrCreateEmpty(address)
+          this.graph.addEdge(id ?? vertex, infiniteRangeVertexId)
         })
       })
   }
@@ -810,7 +826,7 @@ export class DependencyGraph {
         continue
       }
       if (array.getRange().addressInRange(dependency)) {
-        const vertex = this.fetchCellOrCreateEmpty(dependency)
+        const vertex = this.fetchCellOrCreateEmpty(dependency).vertex
         yield [dependency, vertex]
       }
     }
@@ -820,7 +836,7 @@ export class DependencyGraph {
     const {restRange: range} = this.rangeMapping.findSmallerRange(vertex.range)
     for (const address of range.addresses(this)) {
       if (array.getRange().addressInRange(address)) {
-        const cell = this.fetchCellOrCreateEmpty(address)
+        const cell = this.fetchCellOrCreateEmpty(address).vertex
         yield [address, cell]
       }
     }
@@ -878,7 +894,8 @@ export class DependencyGraph {
         if (rangeVertex.bruteForce) {
           const addedSubrangeInThatRange = rangeVertex.range.rangeWithSameWidth(row, numberOfRows)
           for (const address of addedSubrangeInThatRange.addresses(this)) {
-            this.graph.addEdge(this.fetchCellOrCreateEmpty(address), rangeVertex)
+            const { vertex, id } = this.fetchCellOrCreateEmpty(address)
+            this.graph.addEdge(id ?? vertex, rangeVertex)
           }
         } else {
           let currentRangeVertex = rangeVertex
@@ -889,7 +906,7 @@ export class DependencyGraph {
           while (find.smallerRangeVertex === undefined) {
             const newRangeVertex = new RangeVertex(AbsoluteCellRange.spanFrom(currentRangeVertex.range.start, currentRangeVertex.range.width(), currentRangeVertex.range.height() - 1))
             this.rangeMapping.setRange(newRangeVertex)
-            this.graph.addNode(newRangeVertex)
+            this.graph.addNodeAndReturnId(newRangeVertex)
             const restRange = new AbsoluteCellRange(simpleCellAddress(currentRangeVertex.range.start.sheet, currentRangeVertex.range.start.col, currentRangeVertex.range.end.row), currentRangeVertex.range.end)
             this.addAllFromRange(restRange, currentRangeVertex)
             this.graph.addEdge(newRangeVertex, currentRangeVertex)
@@ -904,9 +921,10 @@ export class DependencyGraph {
     }
   }
 
-  private addAllFromRange(range: AbsoluteCellRange, vertex: RangeVertex) {
+  private addAllFromRange(range: AbsoluteCellRange, rangeVertex: RangeVertex) {
     for (const address of range.addresses(this)) {
-      this.graph.addEdge(this.fetchCellOrCreateEmpty(address), vertex)
+      const { vertex, id } = this.fetchCellOrCreateEmpty(address)
+      this.graph.addEdge(id ?? vertex, rangeVertex)
     }
   }
 
@@ -920,7 +938,8 @@ export class DependencyGraph {
           subrange = AbsoluteCellRange.spanFrom(simpleCellAddress(sheet, column, rangeVertex.range.end.row), numberOfColumns, 1)
         }
         for (const address of subrange.addresses(this)) {
-          this.graph.addEdge(this.fetchCellOrCreateEmpty(address), rangeVertex)
+          const { vertex, id } = this.fetchCellOrCreateEmpty(address)
+          this.graph.addEdge(id ?? vertex, rangeVertex)
         }
       }
     }

--- a/src/DependencyGraph/Graph.ts
+++ b/src/DependencyGraph/Graph.ts
@@ -72,7 +72,7 @@ export class Graph<T> {
    *
    * @param node - node to which adjacent nodes we want to retrieve
    */
-  public adjacentNodes(node: T): Set<T> { // TODO: return array
+  public adjacentNodes(node: T): Set<T> { // TODO: try returning array
     const id = this.nodesIds.get(node)
 
     if (id === undefined) {
@@ -83,22 +83,10 @@ export class Graph<T> {
   }
 
   /**
-   * @internal
+   * Returns number of nodes adjacent to given node. Contrary to adjacentNodes(), this method returns only nodes that are present in graph.
+   *
+   * @param node - node to which adjacent nodes we want to retrieve
    */
-  public reversedAdjacentNodes(node: T): T[] {
-    const id = this.nodesIds.get(node)
-
-    if (id === undefined) {
-      throw this.missingNodeError(node)
-    }
-
-    return this.nodesSparseArray.reduce((acc: number[], sourceNode, sourceId) =>
-      sourceNode && this.edgesSparseArray[sourceId].includes(id)
-      ? [ ...acc, sourceId ]
-      : acc
-    , []).map(resultId => this.nodesSparseArray[resultId])
-  }
-
   public adjacentNodesCount(node: T): number {
     const id = this.nodesIds.get(node)
 

--- a/src/DependencyGraph/Graph.ts
+++ b/src/DependencyGraph/Graph.ts
@@ -76,12 +76,6 @@ export class Graph<T> {
     this.edges.get(fromNode)?.delete(toNode)
   }
 
-  public removeIncomingEdges(toNode: T) {
-    this.edges.forEach((nodeEdges) => {
-      nodeEdges.delete(toNode)
-    })
-  }
-
   /**
    * Returns nodes adjacent to given node
    *
@@ -188,7 +182,7 @@ export class Graph<T> {
     return topSortAlgorithm.getTopSortedWithSccSubgraphFrom(modifiedNodes, operatingFunction, onCycle)
   }
 
-  public getDependencies(vertex: T): T[] {
+  public reversedAdjacentNodes(vertex: T): T[] {
     const result: T[] = []
     this.edges.forEach((adjacentNodes, sourceNode) => {
       if (adjacentNodes.has(vertex)) {

--- a/src/DependencyGraph/Graph.ts
+++ b/src/DependencyGraph/Graph.ts
@@ -13,6 +13,11 @@ export interface TopSortResult<T> {
   cycled: T[],
 }
 
+// interface GraphNode<T> {
+//   id: number,
+//   data: T,
+// }
+
 enum NodeVisitStatus {
   ON_STACK,
   PROCESSED,
@@ -28,9 +33,10 @@ enum NodeVisitStatus {
  * - this.edges(node) is subset of this.nodes (i.e. it does not contain nodes not present in graph) -- this invariant DOES NOT HOLD right now
  */
 export class Graph<T> {
-  /** Set with nodes in graph. */
-  public nodes: Set<T> = new Set()
+  // private _nodes: Set<GraphNode<T>> = new Set()
+  // private nextId = 0
 
+  public nodes: Set<T> = new Set()
   public specialNodes: Set<T> = new Set()
   public specialNodesStructuralChanges: Set<T> = new Set()
   public specialNodesRecentlyChanged: Set<T> = new Set()
@@ -175,7 +181,7 @@ export class Graph<T> {
    * @param toNode - node to which edge is incoming
    */
   public existsEdge(fromNode: T, toNode: T): boolean {
-    return this.edges.get(fromNode)?.has(toNode) ?? false
+    return this.adjacentNodes(fromNode)?.has(toNode) ?? false
   }
 
   /*
@@ -288,15 +294,16 @@ export class Graph<T> {
     const cycled: T[] = []
     order.reverse()
     order.forEach((t: T) => {
+      const adjacentNodes = this.adjacentNodes(t)
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      if (sccNonSingletons.has(t) || this.adjacentNodes(t).has(t)) {
+      if (sccNonSingletons.has(t) || adjacentNodes.has(t)) {
         cycled.push(t)
         onCycle(t)
-        this.adjacentNodes(t).forEach((s: T) => shouldBeUpdatedMapping.add(s))
+        adjacentNodes.forEach((s: T) => shouldBeUpdatedMapping.add(s))
       } else {
         sorted.push(t)
         if (shouldBeUpdatedMapping.has(t) && operatingFunction(t)) {
-          this.adjacentNodes(t).forEach((s: T) => shouldBeUpdatedMapping.add(s))
+          adjacentNodes.forEach((s: T) => shouldBeUpdatedMapping.add(s))
         }
       }
     })

--- a/src/DependencyGraph/Graph.ts
+++ b/src/DependencyGraph/Graph.ts
@@ -23,10 +23,11 @@ export class Graph<T> {
   private nodesIds: Map<T, number> = new Map()
   private nextId: number = 0
 
+  private specialRecentlyChangedIds: number[] = [] // may contain duplicates, may contain removed nodes
+
   // TODO: try using number[] for these collections
   public specialNodes: Set<T> = new Set()
   public specialNodesStructuralChanges: Set<T> = new Set()
-  public specialNodesRecentlyChanged: Set<T> = new Set()
   public infiniteRanges: Set<T> = new Set()
 
   constructor(
@@ -160,7 +161,6 @@ export class Graph<T> {
     delete this.edgesSparseArray[id]
     this.nodesIds.delete(node)
     this.specialNodes.delete(node)
-    this.specialNodesRecentlyChanged.delete(node)
     this.specialNodesStructuralChanges.delete(node)
     this.infiniteRanges.delete(node)
 
@@ -254,11 +254,27 @@ export class Graph<T> {
    * Marks node as specialRecentlyChanged.
    */
   public markNodeAsSpecialRecentlyChanged(node: T): void {
-    if (!this.hasNode(node)) {
+    const id = this.nodesIds.get(node)
+
+    if (id === undefined) {
       return
     }
 
-    this.specialNodesRecentlyChanged.add(node)
+    this.specialRecentlyChangedIds.push(id)
+  }
+
+  /**
+   * Returns special recently changed nodes. May contain duplicates.
+   */
+  public getSpecialRecentlyChangedNodes(): T[] {
+    return this.specialRecentlyChangedIds.map(id => this.nodesSparseArray[id]).filter(node => node !== undefined)
+  }
+
+  /**
+   * Clears special recently changed nodes.
+   */
+  public clearSpecialNodesRecentlyChanged(): void {
+    this.specialRecentlyChangedIds = []
   }
 
   /**
@@ -281,13 +297,6 @@ export class Graph<T> {
     }
 
     this.infiniteRanges.add(node)
-  }
-
-  /**
-   * Clears specialNodesRecentlyChanged.
-   */
-  public clearSpecialNodesRecentlyChanged(): void {
-    this.specialNodesRecentlyChanged.clear()
   }
 
   /**

--- a/src/DependencyGraph/Graph.ts
+++ b/src/DependencyGraph/Graph.ts
@@ -10,13 +10,12 @@ import {TopSort, TopSortResult} from './TopSort'
 export type DependencyQuery<T> = (vertex: T) => [(SimpleCellAddress | SimpleCellRange), T][]
 
 /**
- * Provides graph directed structure
+ * Provides directed graph structure.
  *
  * - nodesSparseArray is a sparse array. nodesSparseArray[n] exists if and only if node n is in the graph
  * - nodesIds is a mapping from node to its id. nodesIds.get(node) exists if and only if node is in the graph
  * - edgesSparseArray is a sparse array. edgesSparseArray[n] exists if and only if node n is in the graph
  * - edgesSparseArray[n] is a sparse array. edgesSparseArray[n] may contain removed nodes. To make sure check nodesSparseArray.
- *
  */
 export class Graph<T> {
   private nodesSparseArray: T[] = []

--- a/src/DependencyGraph/Graph.ts
+++ b/src/DependencyGraph/Graph.ts
@@ -138,7 +138,7 @@ export class Graph<T> {
 
     this.edgesSparseArray[fromId].push(toId)
   }
-  
+
   /**
    * Removes node from graph
    */
@@ -150,20 +150,20 @@ export class Graph<T> {
     }
 
     this.edgesSparseArray[id]
-      .filter(adjacentId => adjacentId !== undefined)
-      .map(adjacentId => this.nodesSparseArray[adjacentId])
-      .forEach(adjacentNode => this.markNodeAsSpecialRecentlyChanged(adjacentNode))
+    .filter(adjacentId => adjacentId !== undefined)
+    .map(adjacentId => this.nodesSparseArray[adjacentId])
+    .forEach(adjacentNode => this.markNodeAsSpecialRecentlyChanged(adjacentNode))
 
     const dependencies = this.removeDependencies(node)
 
     delete this.nodesSparseArray[id]
     delete this.edgesSparseArray[id]
     this.nodesIds.delete(node)
-
     this.specialNodes.delete(node)
     this.specialNodesRecentlyChanged.delete(node)
     this.specialNodesStructuralChanges.delete(node)
     this.infiniteRanges.delete(node)
+
     return dependencies
   }
 
@@ -219,8 +219,7 @@ export class Graph<T> {
    * Sorts the whole graph topologically. Nodes that are on cycles are kept separate.
    */
   public topSortWithScc(): TopSortResult<T> {
-    return this.getTopSortedWithSccSubgraphFrom(this.getNodes(), () => true, () => {
-    })
+    return this.getTopSortedWithSccSubgraphFrom(this.getNodes(), () => true, () => {})
   }
 
   /**
@@ -230,7 +229,11 @@ export class Graph<T> {
    * @param operatingFunction - recomputes value of a node, and returns whether a change occurred
    * @param onCycle - action to be performed when node is on cycle
    */
-  public getTopSortedWithSccSubgraphFrom(modifiedNodes: T[], operatingFunction: (node: T) => boolean, onCycle: (node: T) => void): TopSortResult<T> {
+  public getTopSortedWithSccSubgraphFrom(
+    modifiedNodes: T[],
+    operatingFunction: (node: T) => boolean,
+    onCycle: (node: T) => void
+  ): TopSortResult<T> {
     const topSortAlgorithm = new TopSort<T>(this.nodesSparseArray, this.edgesSparseArray)
     const modifiedNodesIds = modifiedNodes.map(node => this.nodesIds.get(node)).filter(id => id !== undefined) as number[]
     return topSortAlgorithm.getTopSortedWithSccSubgraphFrom(modifiedNodesIds, operatingFunction, onCycle)
@@ -301,9 +304,11 @@ export class Graph<T> {
    */
   private removeDependencies(node: T): [(SimpleCellAddress | SimpleCellRange), T][] {
     const dependencies = this.dependencyQuery(node)
-    for (const [_, dependency] of dependencies) {
+
+    dependencies.forEach(([_, dependency]) => {
       this.removeEdgeIfExists(dependency, node)
-    }
+    })
+
     return dependencies
   }
 

--- a/src/DependencyGraph/Graph.ts
+++ b/src/DependencyGraph/Graph.ts
@@ -12,26 +12,54 @@ export type DependencyQuery<T> = (vertex: T) => [(SimpleCellAddress | SimpleCell
 /**
  * Provides directed graph structure.
  *
- * - nodesSparseArray is a sparse array. nodesSparseArray[n] exists if and only if node n is in the graph
- * - nodesIds is a mapping from node to its id. nodesIds.get(node) exists if and only if node is in the graph
- * - edgesSparseArray is a sparse array. edgesSparseArray[n] exists if and only if node n is in the graph
- * - edgesSparseArray[n] is a sparse array. edgesSparseArray[n] may contain removed nodes. To make sure check nodesSparseArray.
- *
- * - dirtyNodeIds is a dense array; it may contain duplicates and removed nodes.
- * - volatileNodeIds is a dense array; it may contain duplicates and removed nodes.
- * - infiniteRangeIds is a dense array; it may contain duplicates and removed nodes.
- * - changingWithStructureNodeIds is a dense array; it may contain duplicates and removed nodes.
+ * Idea for performance improvement:
+ * - use Set<T>[] instead of number[][] for edgesSparseArray
  */
 export class Graph<T> {
+  /**
+   * A sparse array. The value nodesSparseArray[n] exists if and only if node n is in the graph.
+   * @private
+   */
   private nodesSparseArray: T[] = []
-  private edgesSparseArray: number[][] = [] // TODO: try using Set<T>[]
-  private nodesIds: Map<T, number> = new Map()
-  private nextId: number = 0
 
+  /**
+   * A sparse array. The value edgesSparseArray[n] exists if and only if node n is in the graph.
+   * The edgesSparseArray[n] is also a sparse array. It may contain removed nodes. To make sure check nodesSparseArray.
+   * @private
+   */
+  private edgesSparseArray: number[][] = []
+
+  /**
+   * A mapping from node to its id. The value nodesIds.get(node) exists if and only if node is in the graph.
+   * @private
+   */
+  private nodesIds: Map<T, number> = new Map()
+
+  /**
+   * A dense array. It may contain duplicates and removed nodes.
+   * @private
+   */
   private dirtyNodeIds: number[] = []
+
+  /**
+   * A dense array. It may contain duplicates and removed nodes.
+   * @private
+   */
   private volatileNodeIds: number[] = []
+
+  /**
+   * A dense array. It may contain duplicates and removed nodes.
+   * @private
+   */
   private infiniteRangeIds: number[] = []
+
+  /**
+   * A dense array. It may contain duplicates and removed nodes.
+   * @private
+   */
   private changingWithStructureNodeIds: number[] = []
+
+  private nextId: number = 0
 
   constructor(
     private readonly dependencyQuery: DependencyQuery<T>
@@ -74,8 +102,11 @@ export class Graph<T> {
    * Returns nodes adjacent to given node. May contain removed nodes.
    *
    * @param node - node to which adjacent nodes we want to retrieve
+   *
+   * Idea for performance improvement:
+   * - return an array instead of set
    */
-  public adjacentNodes(node: T): Set<T> { // TODO: try returning array
+  public adjacentNodes(node: T): Set<T> {
     const id = this.nodesIds.get(node)
 
     if (id === undefined) {

--- a/src/DependencyGraph/Graph.ts
+++ b/src/DependencyGraph/Graph.ts
@@ -6,6 +6,7 @@
 import {SimpleCellAddress} from '../Cell'
 import {SimpleCellRange} from '../AbsoluteCellRange'
 import {TopSort, TopSortResult} from './TopSort'
+import {ArrayVertex} from './FormulaCellVertex'
 
 export type DependencyQuery<T> = (vertex: T) => [(SimpleCellAddress | SimpleCellRange), T][]
 
@@ -18,7 +19,9 @@ export type DependencyQuery<T> = (vertex: T) => [(SimpleCellAddress | SimpleCell
  * - this.edges(node) is subset of this.nodes (i.e. it does not contain nodes not present in graph) -- this invariant DOES NOT HOLD right now
  */
 export class Graph<T> {
-  public nodes: Set<T> = new Set()
+  private nodes: Set<T> = new Set()
+
+  // also convert?
   public specialNodes: Set<T> = new Set()
   public specialNodesStructuralChanges: Set<T> = new Set()
   public specialNodesRecentlyChanged: Set<T> = new Set()
@@ -30,6 +33,13 @@ export class Graph<T> {
   constructor(
     private readonly dependencyQuery: DependencyQuery<T>
   ) {
+  }
+
+  /**
+   * Iterate over all nodes the in graph
+   */
+  public getNodes(): IterableIterator<T> {
+    return [ ...this.nodes ].values()
   }
 
   /**

--- a/src/DependencyGraph/Graph.ts
+++ b/src/DependencyGraph/Graph.ts
@@ -16,6 +16,9 @@ export type DependencyQuery<T> = (vertex: T) => [(SimpleCellAddress | SimpleCell
  * - nodesIds is a mapping from node to its id. nodesIds.get(node) exists if and only if node is in the graph
  * - edgesSparseArray is a sparse array. edgesSparseArray[n] exists if and only if node n is in the graph
  * - edgesSparseArray[n] is a sparse array. edgesSparseArray[n] may contain removed nodes. To make sure check nodesSparseArray.
+ *
+ * - recentlyChangedNodeIds is a dense array; it may contain duplicates and removed nodes.
+ * - volatileNodeIds is a dense array; it may contain duplicates and removed nodes.
  */
 export class Graph<T> {
   private nodesSparseArray: T[] = []
@@ -23,10 +26,10 @@ export class Graph<T> {
   private nodesIds: Map<T, number> = new Map()
   private nextId: number = 0
 
-  private specialRecentlyChangedIds: number[] = [] // may contain duplicates, may contain removed nodes
+  private recentlyChangedNodeIds: number[] = []
+  private volatileNodeIds: number[] = []
 
   // TODO: try using number[] for these collections
-  public specialNodes: Set<T> = new Set()
   public specialNodesStructuralChanges: Set<T> = new Set()
   public infiniteRanges: Set<T> = new Set()
 
@@ -150,17 +153,13 @@ export class Graph<T> {
       throw this.missingNodeError(node)
     }
 
-    this.edgesSparseArray[id]
-    .filter(adjacentId => adjacentId !== undefined)
-    .map(adjacentId => this.nodesSparseArray[adjacentId])
-    .forEach(adjacentNode => this.markNodeAsSpecialRecentlyChanged(adjacentNode))
+    this.edgesSparseArray[id].forEach(adjacentId => this.recentlyChangedNodeIds.push(adjacentId))
 
     const dependencies = this.removeDependencies(node)
 
     delete this.nodesSparseArray[id]
     delete this.edgesSparseArray[id]
     this.nodesIds.delete(node)
-    this.specialNodes.delete(node)
     this.specialNodesStructuralChanges.delete(node)
     this.infiniteRanges.delete(node)
 
@@ -240,41 +239,45 @@ export class Graph<T> {
   }
 
   /**
-   * Marks node as special.
+   * Marks node as volatile.
    */
-  public markNodeAsSpecial(node: T): void {
-    if (!this.hasNode(node)) {
-      return
-    }
-
-    this.specialNodes.add(node)
-  }
-
-  /**
-   * Marks node as specialRecentlyChanged.
-   */
-  public markNodeAsSpecialRecentlyChanged(node: T): void {
+  public markNodeAsVolatile(node: T): void {
     const id = this.nodesIds.get(node)
 
     if (id === undefined) {
       return
     }
 
-    this.specialRecentlyChangedIds.push(id)
+    this.volatileNodeIds.push(id)
   }
 
   /**
-   * Returns special recently changed nodes. May contain duplicates.
+   * Marks node as recently changed.
    */
-  public getSpecialRecentlyChangedNodes(): T[] {
-    return this.specialRecentlyChangedIds.map(id => this.nodesSparseArray[id]).filter(node => node !== undefined)
+  public markNodeAsRecentlyChanged(node: T): void {
+    const id = this.nodesIds.get(node)
+
+    if (id === undefined) {
+      return
+    }
+
+    this.recentlyChangedNodeIds.push(id)
   }
 
   /**
-   * Clears special recently changed nodes.
+   * Returns an array of nodes that are marked as recently changed and/or volatile
    */
-  public clearSpecialNodesRecentlyChanged(): void {
-    this.specialRecentlyChangedIds = []
+  public getRecentlyChangedAndVolatile(): T[] {
+    const withoutDuplicates = new Set([ ...this.recentlyChangedNodeIds, ...this.volatileNodeIds ])
+    const mappedToNodes = [ ...withoutDuplicates ].map(id => this.nodesSparseArray[id]).filter(node => node !== undefined)
+    return mappedToNodes
+  }
+
+  /**
+   * Clears recently changed nodes.
+   */
+  public clearRecentlyChangedNodes(): void {
+    this.recentlyChangedNodeIds = []
   }
 
   /**

--- a/src/DependencyGraph/Graph.ts
+++ b/src/DependencyGraph/Graph.ts
@@ -6,7 +6,6 @@
 import {SimpleCellAddress} from '../Cell'
 import {SimpleCellRange} from '../AbsoluteCellRange'
 import {TopSort, TopSortResult} from './TopSort'
-import {ArrayVertex} from './FormulaCellVertex'
 
 export type DependencyQuery<T> = (vertex: T) => [(SimpleCellAddress | SimpleCellRange), T][]
 

--- a/src/DependencyGraph/Graph.ts
+++ b/src/DependencyGraph/Graph.ts
@@ -51,17 +51,6 @@ export class Graph<T> {
   }
 
   /**
-   * Returns number of edges in graph
-   *
-   * @internal
-   */
-  public edgesCount(): number {
-    return this.nodesSparseArray.reduce((acc, node, id) =>
-        node ? acc + this.cleanupAdjacentNodeIds(id).length : acc
-      , 0)
-  }
-
-  /**
    * Checks whether exists edge between nodes. If one or both of nodes are not present in graph, returns false.
    *
    * @param fromNode - node from which edge is outcoming

--- a/src/DependencyGraph/Graph.ts
+++ b/src/DependencyGraph/Graph.ts
@@ -200,7 +200,7 @@ export class Graph<T> {
     const entranceTime: Map<T, number> = new Map()
     const low: Map<T, number> = new Map()
     const parent: Map<T, T> = new Map()
-    const inSCC: Set<T> = new Set()
+    const inSCC: Set<T> = new Set() // do we need these data structures? logarithmic factor?
 
     // node status life cycle:
     // undefined -> ON_STACK -> PROCESSED -> POPPED
@@ -242,7 +242,7 @@ export class Graph<T> {
             let uLow: number
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             uLow = entranceTime.get(u)!
-            this.adjacentNodes(u).forEach((t: T) => {
+            this.adjacentNodes(u).forEach((t: T) => { // Ta petla chyba jest niepotrzebna. Chiecko mogloby updatowac low[parent]
               if (!inSCC.has(t)) {
                 if (parent.get(t) === u) {
                   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/DependencyGraph/Graph.ts
+++ b/src/DependencyGraph/Graph.ts
@@ -12,19 +12,19 @@ export type DependencyQuery<T> = (vertex: T) => [(SimpleCellAddress | SimpleCell
 /**
  * Provides graph directed structure
  *
- * Invariants:
- * - this.edges(node) exists if and only if node is in the graph
- * - this.specialNodes* are always subset of this.nodes
- * - this.edges(node) is subset of this.nodes (i.e. it does not contain nodes not present in graph) -- this invariant DOES NOT HOLD right now
+ * - nodesSparseArray is a sparse array. nodesSparseArray[n] exists if and only if node n is in the graph
+ * - nodesIds is a mapping from node to its id. nodesIds.get(node) exists if and only if node is in the graph
+ * - edgesSparseArray is a sparse array. edgesSparseArray[n] exists if and only if node n is in the graph
+ * - edgesSparseArray[n] is a sparse array. edgesSparseArray[n] may contain removed nodes. To make sure check nodesSparseArray.
+ *
  */
 export class Graph<T> {
   private nodesSparseArray: T[] = []
-  private edgesSparseArray: number[][] = [] // may contain removed nodes // try using Set<T>[]
+  private edgesSparseArray: number[][] = [] // TODO: try using Set<T>[]
   private nodesIds: Map<T, number> = new Map()
-  private _nodesCount: number = 0
   private nextId: number = 0
 
-  // also convert?
+  // TODO: try using number[] for these collections
   public specialNodes: Set<T> = new Set()
   public specialNodesStructuralChanges: Set<T> = new Set()
   public specialNodesRecentlyChanged: Set<T> = new Set()
@@ -33,15 +33,6 @@ export class Graph<T> {
   constructor(
     private readonly dependencyQuery: DependencyQuery<T>
   ) {}
-
-  /**
-   * Returns number of nodes in graph
-   *
-   * @internal
-   */
-  public nodesCount(): number {
-    return this._nodesCount
-  }
 
   /**
    * Iterate over all nodes the in graph
@@ -142,7 +133,6 @@ export class Graph<T> {
     this.nodesSparseArray[this.nextId] = node
     this.edgesSparseArray[this.nextId] = []
     this.nodesIds.set(node, this.nextId)
-    this._nodesCount++
     this.nextId++
   }
 
@@ -190,7 +180,6 @@ export class Graph<T> {
     delete this.nodesSparseArray[id]
     delete this.edgesSparseArray[id]
     this.nodesIds.delete(node)
-    this._nodesCount--
 
     this.specialNodes.delete(node)
     this.specialNodesRecentlyChanged.delete(node)

--- a/src/DependencyGraph/ProcessableValue.ts
+++ b/src/DependencyGraph/ProcessableValue.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright (c) 2023 Handsoncode. All rights reserved.
+ */
+
+export class ProcessableValue<Raw, Processed> {
+  private processedValue: Processed | null = null
+
+  constructor(
+    public rawValue: Raw,
+    private processFn: (r: Raw) => Processed
+  ) {}
+
+  getProcessedValue(): Processed {
+    if (this.processedValue === null) {
+      this.processedValue = this.processFn(this.rawValue)
+    }
+
+    return this.processedValue
+  }
+
+  markAsModified() {
+    this.processedValue = null
+  }
+}

--- a/src/DependencyGraph/TopSort.ts
+++ b/src/DependencyGraph/TopSort.ts
@@ -18,6 +18,20 @@ enum NodeVisitStatus {
  * An algorithm class. Provides topological sorting of a graph.
  */
 export class TopSort<T> {
+  private entranceTime: Map<T, number> = new Map()
+  private low: Map<T, number> = new Map()
+  private parent: Map<T, T> = new Map()
+  private inSCC: Set<T> = new Set() // do we need these data structures? logarithmic factor?
+
+  // node status life cycle:
+  // undefined -> ON_STACK -> PROCESSED -> POPPED
+  private nodeStatus: Map<T, NodeVisitStatus> = new Map()
+  private order: T[] = []
+
+  private time: number = 0
+
+  private sccNonSingletons: Set<T> = new Set()
+
   constructor(
     private edges: Map<T, Set<T>> = new Map()
   ) {}
@@ -36,99 +50,100 @@ export class TopSort<T> {
    * @param onCycle - action to be performed when node is on cycle
    */
   public getTopSortedWithSccSubgraphFrom(modifiedNodes: T[], operatingFunction: (node: T) => boolean, onCycle: (node: T) => void): TopSortResult<T> {
-    const entranceTime: Map<T, number> = new Map()
-    const low: Map<T, number> = new Map()
-    const parent: Map<T, T> = new Map()
-    const inSCC: Set<T> = new Set() // do we need these data structures? logarithmic factor?
-
-    // node status life cycle:
-    // undefined -> ON_STACK -> PROCESSED -> POPPED
-    const nodeStatus: Map<T, NodeVisitStatus> = new Map()
-    const order: T[] = []
-
-    let time: number = 0
-
-    const sccNonSingletons: Set<T> = new Set()
-
     modifiedNodes.reverse()
-    modifiedNodes.forEach((v: T) => {
-      if (nodeStatus.get(v) !== undefined) {
-        return
+    modifiedNodes.forEach((v: T) => this.runDFS(v))
+    return this.postprocess(modifiedNodes, onCycle, operatingFunction)
+  }
+
+  private runDFS(v: T) {
+    if (this.nodeStatus.get(v) !== undefined) {
+      return
+    }
+
+    const DFSstack: T[] = [v]
+    const SCCstack: T[] = []
+
+    this.nodeStatus.set(v, NodeVisitStatus.ON_STACK)
+    while (DFSstack.length > 0) {
+      const u = DFSstack[DFSstack.length - 1]
+
+      switch (this.nodeStatus.get(u)!) {
+        case NodeVisitStatus.ON_STACK: {
+          this.handleOnStack(u, SCCstack, DFSstack)
+          break
+        }
+        case NodeVisitStatus.PROCESSED: { // leaving this DFS subtree
+          this.handleProcessed(u, SCCstack, DFSstack)
+          break
+        }
+        case NodeVisitStatus.POPPED: { // it's a 'shadow' copy, we already processed this vertex and can ignore it
+          DFSstack.pop()
+          break
+        }
       }
-      const DFSstack: T[] = [v]
-      const SCCstack: T[] = []
-      nodeStatus.set(v, NodeVisitStatus.ON_STACK)
-      while (DFSstack.length > 0) {
-        const u = DFSstack[DFSstack.length - 1]
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        switch (nodeStatus.get(u)!) {
-          case NodeVisitStatus.ON_STACK: {
-            entranceTime.set(u, time)
-            low.set(u, time)
-            SCCstack.push(u)
-            time++
-            this.adjacentNodes(u).forEach((t: T) => {
-              if (entranceTime.get(t) === undefined) {
-                DFSstack.push(t)
-                parent.set(t, u)
-                nodeStatus.set(t, NodeVisitStatus.ON_STACK)
-              }
-            })
-            nodeStatus.set(u, NodeVisitStatus.PROCESSED)
-            break
-          }
-          case NodeVisitStatus.PROCESSED: { // leaving this DFS subtree
-            let uLow: number
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            uLow = entranceTime.get(u)!
-            this.adjacentNodes(u).forEach((t: T) => { // Ta petla chyba jest niepotrzebna. Chiecko mogloby updatowac low[parent]
-              if (!inSCC.has(t)) {
-                if (parent.get(t) === u) {
-                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                  uLow = Math.min(uLow, low.get(t)!)
-                } else {
-                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                  uLow = Math.min(uLow, entranceTime.get(t)!)
-                }
-              }
-            })
-            low.set(u, uLow)
-            if (uLow === entranceTime.get(u)) {
-              const currentSCC: T[] = []
-              do {
-                currentSCC.push(SCCstack[SCCstack.length - 1])
-                SCCstack.pop()
-              } while (currentSCC[currentSCC.length - 1] !== u)
-              currentSCC.forEach((t) => {
-                inSCC.add(t)
-              })
-              order.push(...currentSCC)
-              if (currentSCC.length > 1) {
-                currentSCC.forEach((t) => {
-                  sccNonSingletons.add(t)
-                })
-              }
-            }
-            DFSstack.pop()
-            nodeStatus.set(u, NodeVisitStatus.POPPED)
-            break
-          }
-          case NodeVisitStatus.POPPED: { // it's a 'shadow' copy, we already processed this vertex and can ignore it
-            DFSstack.pop()
-            break
-          }
+    }
+  }
+
+  private handleOnStack(u: T, SCCstack: T[], DFSstack: T[]) {
+    this.entranceTime.set(u, this.time)
+    this.low.set(u, this.time)
+    SCCstack.push(u)
+    this.time++
+    this.adjacentNodes(u).forEach((t: T) => {
+      if (this.entranceTime.get(t) === undefined) {
+        DFSstack.push(t)
+        this.parent.set(t, u)
+        this.nodeStatus.set(t, NodeVisitStatus.ON_STACK)
+      }
+    })
+    this.nodeStatus.set(u, NodeVisitStatus.PROCESSED)
+  }
+
+  private handleProcessed(u: T, SCCstack: T[], DFSstack: T[]) {
+    let uLow: number
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    uLow = this.entranceTime.get(u)!
+    this.adjacentNodes(u).forEach((t: T) => { // Ta petla chyba jest niepotrzebna. Chiecko mogloby updatowac low[this.parent]
+      if (!this.inSCC.has(t)) {
+        if (this.parent.get(t) === u) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          uLow = Math.min(uLow, this.low.get(t)!)
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          uLow = Math.min(uLow, this.entranceTime.get(t)!)
         }
       }
     })
+    this.low.set(u, uLow)
+    if (uLow === this.entranceTime.get(u)) {
+      const currentSCC: T[] = []
+      do {
+        currentSCC.push(SCCstack[SCCstack.length - 1])
+        SCCstack.pop()
+      } while (currentSCC[currentSCC.length - 1] !== u)
+      currentSCC.forEach((t) => {
+        this.inSCC.add(t)
+      })
+      this.order.push(...currentSCC)
+      if (currentSCC.length > 1) {
+        currentSCC.forEach((t) => {
+          this.sccNonSingletons.add(t)
+        })
+      }
+    }
+    DFSstack.pop()
+    this.nodeStatus.set(u, NodeVisitStatus.POPPED)
+  }
 
+  private postprocess(modifiedNodes: T[], onCycle: (node: T) => void, operatingFunction: (node: T) => boolean) {
     const shouldBeUpdatedMapping = new Set(modifiedNodes)
     const sorted: T[] = []
     const cycled: T[] = []
-    order.reverse()
-    order.forEach((t: T) => {
+    this.order.reverse()
+    this.order.forEach((t: T) => {
       const adjacentNodes = this.adjacentNodes(t)
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      if (sccNonSingletons.has(t) || adjacentNodes.has(t)) {
+      if (this.sccNonSingletons.has(t) || adjacentNodes.has(t)) {
         cycled.push(t)
         onCycle(t)
         adjacentNodes.forEach((s: T) => shouldBeUpdatedMapping.add(s))

--- a/src/DependencyGraph/TopSort.ts
+++ b/src/DependencyGraph/TopSort.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright (c) 2023 Handsoncode. All rights reserved.
+ */
+
+export interface TopSortResult<T> {
+  sorted: T[],
+  cycled: T[],
+}
+
+enum NodeVisitStatus {
+  ON_STACK,
+  PROCESSED,
+  POPPED,
+}
+
+/**
+ * An algorithm class. Provides topological sorting of a graph.
+ */
+export class TopSort<T> {
+  constructor(
+    private edges: Map<T, Set<T>> = new Map()
+  ) {}
+
+  public adjacentNodes(node: T): Set<T> {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return this.edges.get(node)!
+  }
+
+  /**
+   * An iterative implementation of Tarjan's algorithm for finding strongly connected components.
+   * Returns vertices in order of topological sort, but vertices that are on cycles are kept separate.
+   *
+   * @param modifiedNodes - seed for computation. During engine init run, all of the vertices of grap. In recomputation run, changed vertices.
+   * @param operatingFunction - recomputes value of a node, and returns whether a change occured
+   * @param onCycle - action to be performed when node is on cycle
+   */
+  public getTopSortedWithSccSubgraphFrom(modifiedNodes: T[], operatingFunction: (node: T) => boolean, onCycle: (node: T) => void): TopSortResult<T> {
+    const entranceTime: Map<T, number> = new Map()
+    const low: Map<T, number> = new Map()
+    const parent: Map<T, T> = new Map()
+    const inSCC: Set<T> = new Set() // do we need these data structures? logarithmic factor?
+
+    // node status life cycle:
+    // undefined -> ON_STACK -> PROCESSED -> POPPED
+    const nodeStatus: Map<T, NodeVisitStatus> = new Map()
+    const order: T[] = []
+
+    let time: number = 0
+
+    const sccNonSingletons: Set<T> = new Set()
+
+    modifiedNodes.reverse()
+    modifiedNodes.forEach((v: T) => {
+      if (nodeStatus.get(v) !== undefined) {
+        return
+      }
+      const DFSstack: T[] = [v]
+      const SCCstack: T[] = []
+      nodeStatus.set(v, NodeVisitStatus.ON_STACK)
+      while (DFSstack.length > 0) {
+        const u = DFSstack[DFSstack.length - 1]
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        switch (nodeStatus.get(u)!) {
+          case NodeVisitStatus.ON_STACK: {
+            entranceTime.set(u, time)
+            low.set(u, time)
+            SCCstack.push(u)
+            time++
+            this.adjacentNodes(u).forEach((t: T) => {
+              if (entranceTime.get(t) === undefined) {
+                DFSstack.push(t)
+                parent.set(t, u)
+                nodeStatus.set(t, NodeVisitStatus.ON_STACK)
+              }
+            })
+            nodeStatus.set(u, NodeVisitStatus.PROCESSED)
+            break
+          }
+          case NodeVisitStatus.PROCESSED: { // leaving this DFS subtree
+            let uLow: number
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            uLow = entranceTime.get(u)!
+            this.adjacentNodes(u).forEach((t: T) => { // Ta petla chyba jest niepotrzebna. Chiecko mogloby updatowac low[parent]
+              if (!inSCC.has(t)) {
+                if (parent.get(t) === u) {
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  uLow = Math.min(uLow, low.get(t)!)
+                } else {
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  uLow = Math.min(uLow, entranceTime.get(t)!)
+                }
+              }
+            })
+            low.set(u, uLow)
+            if (uLow === entranceTime.get(u)) {
+              const currentSCC: T[] = []
+              do {
+                currentSCC.push(SCCstack[SCCstack.length - 1])
+                SCCstack.pop()
+              } while (currentSCC[currentSCC.length - 1] !== u)
+              currentSCC.forEach((t) => {
+                inSCC.add(t)
+              })
+              order.push(...currentSCC)
+              if (currentSCC.length > 1) {
+                currentSCC.forEach((t) => {
+                  sccNonSingletons.add(t)
+                })
+              }
+            }
+            DFSstack.pop()
+            nodeStatus.set(u, NodeVisitStatus.POPPED)
+            break
+          }
+          case NodeVisitStatus.POPPED: { // it's a 'shadow' copy, we already processed this vertex and can ignore it
+            DFSstack.pop()
+            break
+          }
+        }
+      }
+    })
+
+    const shouldBeUpdatedMapping = new Set(modifiedNodes)
+    const sorted: T[] = []
+    const cycled: T[] = []
+    order.reverse()
+    order.forEach((t: T) => {
+      const adjacentNodes = this.adjacentNodes(t)
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      if (sccNonSingletons.has(t) || adjacentNodes.has(t)) {
+        cycled.push(t)
+        onCycle(t)
+        adjacentNodes.forEach((s: T) => shouldBeUpdatedMapping.add(s))
+      } else {
+        sorted.push(t)
+        if (shouldBeUpdatedMapping.has(t) && operatingFunction(t)) {
+          adjacentNodes.forEach((s: T) => shouldBeUpdatedMapping.add(s))
+        }
+      }
+    })
+    return {sorted, cycled}
+  }
+}

--- a/src/DependencyGraph/TopSort.ts
+++ b/src/DependencyGraph/TopSort.ts
@@ -160,8 +160,3 @@ export class TopSort<T> {
     return {sorted, cycled}
   }
 }
-
-
-// TODO:
-// 1. experiment with ids -> 15% speedup
-// 2. focus on parsing date-time

--- a/src/DependencyGraph/TopSort.ts
+++ b/src/DependencyGraph/TopSort.ts
@@ -15,7 +15,7 @@ enum NodeVisitStatus {
 }
 
 /**
- * An algorithm class. Provides topological sorting of a graph.
+ * An algorithm class. Provides an iterative implementation of Tarjan's algorithm for finding strongly connected components
  */
 export class TopSort<T> {
   private entranceTime: number[] = []

--- a/src/DependencyGraph/TopSort.ts
+++ b/src/DependencyGraph/TopSort.ts
@@ -117,7 +117,6 @@ export class TopSort<T> {
   private handleProcessed(u: number, SCCstack: number[], DFSstack: number[]) {
     let uLow = this.entranceTime[u]
 
-    // TODO: Ta petla chyba jest niepotrzebna. Chiecko mogloby updatowac low[this.parent]
     this.getAdjacentNodeIds(u).forEach((t: number) => {
       if (this.inSCC[t]) {
         return
@@ -170,7 +169,10 @@ export class TopSort<T> {
     this.order.forEach((t: number) => {
       const adjacentNodes = this.getAdjacentNodeIds(t)
 
-      if (this.sccNonSingletons[t] || adjacentNodes.includes(t)) { // TODO: to jest potencjalnie czas kwadratowy
+      // The following line is a potential performance bottleneck.
+      // Array.includes() is O(n) operation, which makes the whole algorithm O(n^2).
+      // Idea for improvement: use Set<T>[] instead of number[][] for edgesSparseArray.
+      if (this.sccNonSingletons[t] || adjacentNodes.includes(t)) {
         cycled.push(this.nodesSparseArray[t])
         onCycle(this.nodesSparseArray[t])
         adjacentNodes.forEach((s: number) => shouldBeUpdatedMapping[s] = true)

--- a/src/DependencyGraph/TopSort.ts
+++ b/src/DependencyGraph/TopSort.ts
@@ -34,8 +34,9 @@ export class TopSort<T> {
 
   constructor(
     private nodesSparseArray: T[] = [],
-    private edgesSparseArray: number[][] = [], // may contain removed nodes
+    private edgesSparseArray: number[][] = [],
   ) {}
+
   /**
    * An iterative implementation of Tarjan's algorithm for finding strongly connected components.
    * Returns vertices in order of topological sort, but vertices that are on cycles are kept separate.
@@ -50,10 +51,16 @@ export class TopSort<T> {
     return this.postprocess(modifiedNodeIdsReversed, onCycle, operatingFunction)
   }
 
+  /**
+   * Returns adjacent nodes of a given node.
+   */
   private getAdjacentNodeIds(id: number): number[] {
     return this.edgesSparseArray[id].filter(adjacentId => adjacentId !== undefined && this.nodesSparseArray[adjacentId])
   }
 
+  /**
+   * Runs DFS starting from a given node.
+   */
   private runDFS(v: number) {
     if (this.nodeStatus[v] !== undefined) {
       return
@@ -83,6 +90,9 @@ export class TopSort<T> {
     }
   }
 
+  /**
+   * Handles a node that is on stack.
+   */
   private handleOnStack(u: number, SCCstack: number[], DFSstack: number[]) {
     this.entranceTime[u] = this.time
     this.low[u] = this.time
@@ -98,6 +108,9 @@ export class TopSort<T> {
     this.nodeStatus[u] = NodeVisitStatus.PROCESSED
   }
 
+  /**
+   * Handles a node that is already processed.
+   */
   private handleProcessed(u: number, SCCstack: number[], DFSstack: number[]) {
     let uLow: number
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -134,6 +147,9 @@ export class TopSort<T> {
     this.nodeStatus[u] = NodeVisitStatus.POPPED
   }
 
+  /**
+   * Postprocesses the result of Tarjan's algorithm.
+   */
   private postprocess(modifiedNodeIds: number[], onCycle: (node: T) => void, operatingFunction: (node: T) => boolean) {
     const shouldBeUpdatedMapping: boolean[] = []
     modifiedNodeIds.forEach((t: number) => {

--- a/src/DependencyGraph/index.ts
+++ b/src/DependencyGraph/index.ts
@@ -6,6 +6,7 @@
 export {DependencyGraph} from './DependencyGraph'
 export {AddressMapping} from './AddressMapping/AddressMapping'
 export {Graph} from './Graph'
+export {TopSort} from './TopSort'
 export {RangeMapping} from './RangeMapping'
 export {SheetMapping} from './SheetMapping'
 export {ArrayMapping} from './ArrayMapping'

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -4380,7 +4380,7 @@ export class HyperFormula implements TypedEmitter {
   private recomputeIfDependencyGraphNeedsIt(): ExportedChange[] {
     if (!this._evaluationSuspended) {
       const changes = this._crudOperations.getAndClearContentChanges()
-      const verticesToRecomputeFrom = Array.from(this.dependencyGraph.verticesToRecompute())
+      const verticesToRecomputeFrom = this.dependencyGraph.verticesToRecompute()
       this.dependencyGraph.clearRecentlyChangedVertices()
 
       if (verticesToRecomputeFrom.length > 0) {

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -4381,7 +4381,7 @@ export class HyperFormula implements TypedEmitter {
     if (!this._evaluationSuspended) {
       const changes = this._crudOperations.getAndClearContentChanges()
       const verticesToRecomputeFrom = this.dependencyGraph.verticesToRecompute()
-      this.dependencyGraph.clearRecentlyChangedVertices()
+      this.dependencyGraph.clearDirtyVertices()
 
       if (verticesToRecomputeFrom.length > 0) {
         changes.addAll(this.evaluator.partialRun(verticesToRecomputeFrom))

--- a/src/Operations.ts
+++ b/src/Operations.ts
@@ -248,7 +248,7 @@ export class Operations {
   public addSheet(name?: string) {
     const sheetId = this.sheetMapping.addSheet(name)
     const sheet: Sheet = []
-    this.dependencyGraph.addressMapping.autoAddSheet(sheetId, sheet, findBoundaries(sheet))
+    this.dependencyGraph.addressMapping.autoAddSheet(sheetId, findBoundaries(sheet))
     return this.sheetMapping.fetchDisplayName(sheetId)
   }
 
@@ -883,7 +883,7 @@ export class Operations {
         : this.copyOrFetchGlobalNamedExpressionVertex(expressionName, sourceVertex, addedGlobalNamedExpressions)
 
       if (targetScopeExpressionVertex !== sourceVertex) {
-        this.dependencyGraph.graph.softRemoveEdge(sourceVertex, vertex)
+        this.dependencyGraph.graph.removeEdgeIfExists(sourceVertex, vertex)
         this.dependencyGraph.graph.addEdge(targetScopeExpressionVertex, vertex)
       }
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -262,8 +262,6 @@ export class EvaluationSuspendedError extends Error {
 
 /**
  * Error thrown when translation is missing in translation package.
- *
- * TODO
  */
 export class MissingTranslationError extends Error {
   constructor(key: string) {

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -4,7 +4,7 @@
  */
 
 import {Config} from '../Config'
-import {secondsExtendedRegexp} from '../DateTimeDefault'
+import {TIME_FORMAT_SECONDS_ITEM_REGEXP} from '../DateTimeDefault'
 import {DateTimeHelper, numberToSimpleTime, SimpleDateTime, SimpleTime} from '../DateTimeHelper'
 import {RawScalarValue} from '../interpreter/InterpreterValue'
 import {Maybe} from '../Maybe'
@@ -130,7 +130,7 @@ export function defaultStringifyDuration(time: SimpleTime, formatArg: string): M
       }
 
       default: {
-        if (secondsExtendedRegexp.test(token.value)) {
+        if (TIME_FORMAT_SECONDS_ITEM_REGEXP.test(token.value)) {
           const fractionOfSecondPrecision = Math.max(token.value.length - 3, 0)
           result += `${time.seconds < 10 ? '0' : ''}${Math.floor(time.seconds * Math.pow(10, fractionOfSecondPrecision)) / Math.pow(10, fractionOfSecondPrecision)}`
           continue
@@ -217,7 +217,7 @@ export function defaultStringifyDateTime(dateTime: SimpleDateTime, formatArg: st
         break
       }
       default: {
-        if (secondsExtendedRegexp.test(token.value)) {
+        if (TIME_FORMAT_SECONDS_ITEM_REGEXP.test(token.value)) {
           const fractionOfSecondPrecision = token.value.length - 3
           result += `${dateTime.seconds < 10 ? '0' : ''}${Math.floor(dateTime.seconds * Math.pow(10, fractionOfSecondPrecision)) / Math.pow(10, fractionOfSecondPrecision)}`
           continue

--- a/test/address-mapping.spec.ts
+++ b/test/address-mapping.spec.ts
@@ -693,7 +693,7 @@ describe('AddressMapping', () => {
       [null, null, null],
       [null, null, '1'],
     ]
-    addressMapping.autoAddSheet(0, sheet, findBoundaries(sheet))
+    addressMapping.autoAddSheet(0, findBoundaries(sheet))
 
     expect(addressMapping.strategyFor(0)).toBeInstanceOf(SparseStrategy)
   })
@@ -704,7 +704,7 @@ describe('AddressMapping', () => {
       ['1', '1'],
       ['1', '1'],
     ]
-    addressMapping.autoAddSheet(0, sheet, findBoundaries(sheet))
+    addressMapping.autoAddSheet(0, findBoundaries(sheet))
 
     expect(addressMapping.strategyFor(0)).toBeInstanceOf(DenseStrategy)
   })

--- a/test/column-range.spec.ts
+++ b/test/column-range.spec.ts
@@ -64,7 +64,7 @@ describe('Column ranges', () => {
 
     engine.removeColumns(0, [1, 1])
 
-    expect(engine.graph.infiniteRanges.size).toBe(0)
+    expect(engine.graph.getInfiniteRanges().length).toBe(0)
   })
 
   it('should not move infinite range', () => {

--- a/test/crud-random.spec.ts
+++ b/test/crud-random.spec.ts
@@ -271,7 +271,7 @@ describe('large psuedo-random test', () => {
       verifyValues(engine)
     }
     randomCleanup(engine, rectangleFromCorner({x: 0, y: 0}, 2 * (n + 1) * sideX, 2 * sideY))
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 })

--- a/test/cruds/change-cell-content.spec.ts
+++ b/test/cruds/change-cell-content.spec.ts
@@ -159,7 +159,7 @@ describe('changing cell content', () => {
     expect(engine.getCellValue(adr('B1'))).toBe(1)
     engine.setCellContents(adr('B1'), [[null]])
     expect(engine.getCellValue(adr('B1'))).toBe(null)
-    expect(engine.graph.nodes).not.toContain(b1)
+    expect([ ...engine.graph.getNodes() ]).not.toContain(b1)
     expect(engine.graph.existsEdge(a1, b1)).toBe(false)
   })
 

--- a/test/cruds/cut-paste.spec.ts
+++ b/test/cruds/cut-paste.spec.ts
@@ -202,7 +202,7 @@ describe('Move cells', () => {
     engine.paste(adr('A2'))
 
     expect(engine.graph.edgesCount()).toBe(0)
-    expect(engine.graph.nodesCount()).toBe(1)
+    expect(engine.graph.getNodes().length).toBe(1)
     expect(engine.getCellValue(adr('A1'))).toBe(null)
     expect(engine.getCellValue(adr('A2'))).toBe(1)
   })
@@ -263,7 +263,7 @@ describe('Move cells', () => {
     expect(engine.graph.edgesCount()).toBe(
       2, // A2 -> B1, A2 -> B2
     )
-    expect(engine.graph.nodesCount()).toBe(
+    expect(engine.graph.getNodes().length).toBe(
       +2 // formulas
       + 1, // A2
     )
@@ -380,7 +380,7 @@ describe('moving ranges', () => {
 
     expect(source).toBeInstanceOf(EmptyCellVertex)
     expect(source.getCellValue()).toBe(EmptyValue)
-    expect(engine.graph.nodesCount()).toBe(
+    expect(engine.graph.getNodes().length).toBe(
       +2 // formulas
       + 1 // A2
       + 1 // A1 (Empty)
@@ -422,7 +422,7 @@ describe('moving ranges', () => {
     expect(a1).toBe(undefined)
     expect(a2).toBe(undefined)
 
-    expect(engine.graph.nodesCount()).toBe(
+    expect(engine.graph.getNodes().length).toBe(
       +2 // formulas
       + 2 // C1, C2
       + 1, // C1:C2 range

--- a/test/cruds/cut-paste.spec.ts
+++ b/test/cruds/cut-paste.spec.ts
@@ -11,7 +11,7 @@ import {
   expectEngineToBeTheSameAs,
   extractMatrixRange,
   extractRange,
-  extractReference,
+  extractReference, graphEdgesCount,
 } from '../testUtils'
 import {ExpectedValueOfTypeError} from '../../src/errors'
 
@@ -201,7 +201,7 @@ describe('Move cells', () => {
     engine.cut(AbsoluteCellRange.spanFrom(adr('A1'), 1, 1))
     engine.paste(adr('A2'))
 
-    expect(engine.graph.edgesCount()).toBe(0)
+    expect(graphEdgesCount(engine.graph)).toBe(0)
     expect(engine.graph.getNodes().length).toBe(1)
     expect(engine.getCellValue(adr('A1'))).toBe(null)
     expect(engine.getCellValue(adr('A2'))).toBe(1)
@@ -260,7 +260,7 @@ describe('Move cells', () => {
     const source = engine.addressMapping.getCell(adr('A1'))
     const target = engine.addressMapping.fetchCell(adr('A2'))
 
-    expect(engine.graph.edgesCount()).toBe(
+    expect(graphEdgesCount(engine.graph)).toBe(
       2, // A2 -> B1, A2 -> B2
     )
     expect(engine.graph.getNodes().length).toBe(
@@ -386,7 +386,7 @@ describe('moving ranges', () => {
       + 1 // A1 (Empty)
       + 1, // A1:A2 range
     )
-    expect(engine.graph.edgesCount()).toBe(
+    expect(graphEdgesCount(engine.graph)).toBe(
       +2 // A1 (Empty) -> A1:A2, A2 -> A1:A2
       + 1 // A1:A2 -> B1
       + 1, // A2 -> B2
@@ -427,7 +427,7 @@ describe('moving ranges', () => {
       + 2 // C1, C2
       + 1, // C1:C2 range
     )
-    expect(engine.graph.edgesCount()).toBe(
+    expect(graphEdgesCount(engine.graph)).toBe(
       +2 // C1 -> C1:C2, C2 -> C1:C2
       + 1 // C1:C2 -> B1
       + 1, // C2 -> B2

--- a/test/cruds/move-cells.spec.ts
+++ b/test/cruds/move-cells.spec.ts
@@ -305,7 +305,7 @@ describe('Move cells', () => {
     engine.moveCells(AbsoluteCellRange.spanFrom(adr('A1'), 1, 1), adr('A2'))
 
     expect(engine.graph.edgesCount()).toBe(0)
-    expect(engine.graph.nodesCount()).toBe(1)
+    expect(engine.graph.getNodes().length).toBe(1)
     expect(engine.getCellValue(adr('A1'))).toBe(null)
     expect(engine.getCellValue(adr('A2'))).toBe(1)
   })
@@ -362,7 +362,7 @@ describe('Move cells', () => {
     expect(engine.graph.edgesCount()).toBe(
       2, // A2 -> B1, A2 -> B2
     )
-    expect(engine.graph.nodesCount()).toBe(
+    expect(engine.graph.getNodes().length).toBe(
       +2 // formulas
       + 1, // A2
     )
@@ -512,7 +512,7 @@ describe('moving ranges', () => {
 
     expect(source).toBeInstanceOf(EmptyCellVertex)
     expect(source.getCellValue()).toBe(EmptyValue)
-    expect(engine.graph.nodesCount()).toBe(
+    expect(engine.graph.getNodes().length).toBe(
       +2 // formulas
       + 1 // A2
       + 1 // A1 (Empty)
@@ -553,7 +553,7 @@ describe('moving ranges', () => {
     expect(a1).toBe(undefined)
     expect(a2).toBe(undefined)
 
-    expect(engine.graph.nodesCount()).toBe(
+    expect(engine.graph.getNodes().length).toBe(
       +2 // formulas
       + 2 // C1, C2
       + 1, // C1:C2 range

--- a/test/cruds/move-cells.spec.ts
+++ b/test/cruds/move-cells.spec.ts
@@ -18,7 +18,7 @@ import {
   extractMatrixRange,
   extractRange,
   extractReference,
-  extractRowRange,
+  extractRowRange, graphEdgesCount,
   rowEnd,
   rowStart,
 } from '../testUtils'
@@ -304,7 +304,7 @@ describe('Move cells', () => {
 
     engine.moveCells(AbsoluteCellRange.spanFrom(adr('A1'), 1, 1), adr('A2'))
 
-    expect(engine.graph.edgesCount()).toBe(0)
+    expect(graphEdgesCount(engine.graph)).toBe(0)
     expect(engine.graph.getNodes().length).toBe(1)
     expect(engine.getCellValue(adr('A1'))).toBe(null)
     expect(engine.getCellValue(adr('A2'))).toBe(1)
@@ -359,7 +359,7 @@ describe('Move cells', () => {
     const source = engine.addressMapping.getCell(adr('A1'))
     const target = engine.addressMapping.fetchCell(adr('A2'))
 
-    expect(engine.graph.edgesCount()).toBe(
+    expect(graphEdgesCount(engine.graph)).toBe(
       2, // A2 -> B1, A2 -> B2
     )
     expect(engine.graph.getNodes().length).toBe(
@@ -518,7 +518,7 @@ describe('moving ranges', () => {
       + 1 // A1 (Empty)
       + 1, // A1:A2 range
     )
-    expect(engine.graph.edgesCount()).toBe(
+    expect(graphEdgesCount(engine.graph)).toBe(
       +2 // A1 (Empty) -> A1:A2, A2 -> A1:A2
       + 1 // A1:A2 -> B1
       + 1, // A2 -> B2
@@ -558,7 +558,7 @@ describe('moving ranges', () => {
       + 2 // C1, C2
       + 1, // C1:C2 range
     )
-    expect(engine.graph.edgesCount()).toBe(
+    expect(graphEdgesCount(engine.graph)).toBe(
       +2 // C1 -> C1:C2, C2 -> C1:C2
       + 1 // C1:C2 -> B1
       + 1, // C2 -> B2

--- a/test/cruds/removing-columns.spec.ts
+++ b/test/cruds/removing-columns.spec.ts
@@ -657,18 +657,18 @@ describe('Removing columns - graph', function() {
       ['1', '2', '3', '4'],
       ['1', '2', '3', '4'],
     ])
-    expect(engine.graph.nodesCount()).toBe(8)
+    expect(engine.graph.getNodes().length).toBe(8)
     engine.removeColumns(0, [0, 2])
-    expect(engine.graph.nodesCount()).toBe(4) // left two vertices in first column, two in last
+    expect(engine.graph.getNodes().length).toBe(4) // left two vertices in first column, two in last
   })
 
   it('works if there are empty cells removed', function() {
     const engine = HyperFormula.buildFromArray([
       ['1', null, '3'],
     ])
-    expect(engine.graph.nodesCount()).toBe(2)
+    expect(engine.graph.getNodes().length).toBe(2)
     engine.removeColumns(0, [1, 1])
-    expect(engine.graph.nodesCount()).toBe(2)
+    expect(engine.graph.getNodes().length).toBe(2)
   })
 })
 
@@ -884,7 +884,7 @@ describe('Removing columns - merge ranges', () => {
 
     verifyRangesInSheet(engine, 0, [])
     verifyValues(engine)
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 

--- a/test/cruds/removing-columns.spec.ts
+++ b/test/cruds/removing-columns.spec.ts
@@ -657,18 +657,18 @@ describe('Removing columns - graph', function() {
       ['1', '2', '3', '4'],
       ['1', '2', '3', '4'],
     ])
-    expect(engine.graph.nodes.size).toBe(8)
+    expect(engine.graph.nodesCount()).toBe(8)
     engine.removeColumns(0, [0, 2])
-    expect(engine.graph.nodes.size).toBe(4) // left two vertices in first column, two in last
+    expect(engine.graph.nodesCount()).toBe(4) // left two vertices in first column, two in last
   })
 
   it('works if there are empty cells removed', function() {
     const engine = HyperFormula.buildFromArray([
       ['1', null, '3'],
     ])
-    expect(engine.graph.nodes.size).toBe(2)
+    expect(engine.graph.nodesCount()).toBe(2)
     engine.removeColumns(0, [1, 1])
-    expect(engine.graph.nodes.size).toBe(2)
+    expect(engine.graph.nodesCount()).toBe(2)
   })
 })
 

--- a/test/cruds/removing-rows.spec.ts
+++ b/test/cruds/removing-rows.spec.ts
@@ -815,11 +815,11 @@ describe('Removing rows - range mapping', function() {
     ])
 
     const a1a3 = engine.rangeMapping.fetchRange(adr('A1'), adr('A3'))
-    expect(engine.graph.getDependencies(a1a3).length).toBe(2)
+    expect(engine.graph.reversedAdjacentNodes(a1a3).length).toBe(2)
     engine.removeRows(0, [0, 2])
     const a1a1 = engine.rangeMapping.fetchRange(adr('A1'), adr('A1'))
     expect(a1a1).toBe(a1a3)
-    expect(engine.graph.getDependencies(a1a1).length).toBe(1)
+    expect(engine.graph.reversedAdjacentNodes(a1a1).length).toBe(1)
   })
 })
 

--- a/test/cruds/removing-rows.spec.ts
+++ b/test/cruds/removing-rows.spec.ts
@@ -746,9 +746,9 @@ describe('Removing rows - graph', function() {
       ['1', '2'],
       ['3', '4'],
     ])
-    expect(engine.graph.nodes.size).toBe(4)
+    expect(engine.graph.nodesCount()).toBe(4)
     engine.removeRows(0, [0, 2])
-    expect(engine.graph.nodes.size).toBe(0)
+    expect(engine.graph.nodesCount()).toBe(0)
   })
 
   it('works if there are empty cells removed', function() {
@@ -757,9 +757,9 @@ describe('Removing rows - graph', function() {
       [null],
       ['3'],
     ])
-    expect(engine.graph.nodes.size).toBe(2)
+    expect(engine.graph.nodesCount()).toBe(2)
     engine.removeRows(0, [1, 1])
-    expect(engine.graph.nodes.size).toBe(2)
+    expect(engine.graph.nodesCount()).toBe(2)
   })
 })
 

--- a/test/cruds/removing-rows.spec.ts
+++ b/test/cruds/removing-rows.spec.ts
@@ -11,7 +11,7 @@ import {
   expectReferenceToHaveRefError,
   extractMatrixRange,
   extractRange,
-  extractReference,
+  extractReference, graphReversedAdjacentNodes,
   noSpace,
   verifyRangesInSheet,
   verifyValues,
@@ -815,11 +815,11 @@ describe('Removing rows - range mapping', function() {
     ])
 
     const a1a3 = engine.rangeMapping.fetchRange(adr('A1'), adr('A3'))
-    expect(engine.graph.reversedAdjacentNodes(a1a3).length).toBe(2)
+    expect(graphReversedAdjacentNodes(engine.graph, a1a3).length).toBe(2)
     engine.removeRows(0, [0, 2])
     const a1a1 = engine.rangeMapping.fetchRange(adr('A1'), adr('A1'))
     expect(a1a1).toBe(a1a3)
-    expect(engine.graph.reversedAdjacentNodes(a1a1).length).toBe(1)
+    expect(graphReversedAdjacentNodes(engine.graph, a1a1).length).toBe(1)
   })
 })
 

--- a/test/cruds/removing-rows.spec.ts
+++ b/test/cruds/removing-rows.spec.ts
@@ -746,9 +746,9 @@ describe('Removing rows - graph', function() {
       ['1', '2'],
       ['3', '4'],
     ])
-    expect(engine.graph.nodesCount()).toBe(4)
+    expect(engine.graph.getNodes().length).toBe(4)
     engine.removeRows(0, [0, 2])
-    expect(engine.graph.nodesCount()).toBe(0)
+    expect(engine.graph.getNodes().length).toBe(0)
   })
 
   it('works if there are empty cells removed', function() {
@@ -757,9 +757,9 @@ describe('Removing rows - graph', function() {
       [null],
       ['3'],
     ])
-    expect(engine.graph.nodesCount()).toBe(2)
+    expect(engine.graph.getNodes().length).toBe(2)
     engine.removeRows(0, [1, 1])
-    expect(engine.graph.nodesCount()).toBe(2)
+    expect(engine.graph.getNodes().length).toBe(2)
   })
 })
 
@@ -1027,7 +1027,7 @@ describe('Removing rows - merge ranges', () => {
 
     verifyRangesInSheet(engine, 0, [])
     verifyValues(engine)
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 

--- a/test/graph-builder.spec.ts
+++ b/test/graph-builder.spec.ts
@@ -80,7 +80,7 @@ describe('GraphBuilder', () => {
     expect(engine.graph.existsEdge(b1, a1b2)).toBe(true)
     expect(engine.graph.existsEdge(a1b2, a2)).toBe(true)
     expect(engine.graph.existsEdge(a1b2, a3)).toBe(true)
-    expect(engine.graph.nodesCount()).toBe(
+    expect(engine.graph.getNodes().length).toBe(
       4 + // for cells above
       1,  // for both ranges (reuse same ranges)
     )
@@ -111,7 +111,7 @@ describe('GraphBuilder', () => {
       ['1', '0', '=SUM(A1:B2)'],
     ])
 
-    expect(engine.graph.nodesCount()).toBe(
+    expect(engine.graph.getNodes().length).toBe(
       3 + // for cells above
       1 + // for range vertex
       2,  // for 2 EmptyCellVertex instances

--- a/test/graph-builder.spec.ts
+++ b/test/graph-builder.spec.ts
@@ -2,7 +2,7 @@ import {HyperFormula} from '../src'
 import {Config} from '../src/Config'
 import {EmptyCellVertex, ValueCellVertex} from '../src/DependencyGraph'
 import {SheetSizeLimitExceededError} from '../src/errors'
-import {adr, colEnd, colStart} from './testUtils'
+import {adr, colEnd, colStart, graphEdgesCount} from './testUtils'
 
 describe('GraphBuilder', () => {
   it('build sheet with simple number cell', () => {
@@ -99,7 +99,7 @@ describe('GraphBuilder', () => {
 
     expect(engine.graph.existsEdge(a3, a1a3)).toBe(true)
     expect(engine.graph.existsEdge(a1a2, a1a3)).toBe(true)
-    expect(engine.graph.edgesCount()).toBe(
+    expect(graphEdgesCount(engine.graph)).toBe(
       2 + // from cells to range(A1:A2)
       2 + // from A3 and range(A1:A2) to range(A1:A3)
       2, // from range vertexes to formulas
@@ -116,7 +116,7 @@ describe('GraphBuilder', () => {
       1 + // for range vertex
       2,  // for 2 EmptyCellVertex instances
     )
-    expect(engine.graph.edgesCount()).toBe(
+    expect(graphEdgesCount(engine.graph)).toBe(
       2 + // from cells to range vertex
       2 + // from EmptyCellVertex instances to range vertices
       1,  // from range to cell with SUM
@@ -136,7 +136,7 @@ describe('GraphBuilder', () => {
     expect(engine.graph.existsEdge(a2, a1a3)).toBe(true)
     expect(engine.graph.existsEdge(a2, a1a2)).toBe(true)
     expect(engine.graph.existsEdge(a1a2, a1a3)).toBe(false)
-    expect(engine.graph.edgesCount()).toBe(
+    expect(graphEdgesCount(engine.graph)).toBe(
       3 + // from 3 cells to range(A1:A2)
       2 + // from 2 cells to range(A1:A2)
       2, // from range vertexes to formulas

--- a/test/graph-garbage-collection.spec.ts
+++ b/test/graph-garbage-collection.spec.ts
@@ -8,9 +8,9 @@ describe('vertex counting', () => {
       ['1', '2'],
       ['3', '4']
     ])
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(4)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(4)
     engine.calculateFormula('=SUM(A1:B2)', 0)
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(4)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(4)
   })
 
   it('cruds', () => {
@@ -18,11 +18,11 @@ describe('vertex counting', () => {
       ['1', '2'],
       ['3', '4']
     ])
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(4)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(4)
     engine.setCellContents(adr('A1'), '=SUM(A2:B2)')
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(5)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(5)
     engine.setCellContents(adr('A1'), 1)
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(4)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(4)
   })
 })
 
@@ -75,7 +75,7 @@ describe('larger tests', () => {
         engine.setCellContents({sheet: 0, col: x, row: y}, null)
       }
     }
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 
@@ -92,7 +92,7 @@ describe('larger tests', () => {
     engine.setCellContents({sheet: 0, col: 1, row: 0}, null)
     engine.setCellContents({sheet: 0, col: 2, row: 0}, null)
     engine.setCellContents({sheet: 0, col: 3, row: 0}, null)
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 
@@ -106,7 +106,7 @@ describe('larger tests', () => {
 
     engine.setCellContents({sheet: 0, col: 0, row: 0}, null)
 
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 
@@ -123,7 +123,7 @@ describe('larger tests', () => {
     engine.setCellContents({sheet: 0, col: 3, row: 0}, null)
     engine.setCellContents({sheet: 0, col: 4, row: 0}, null)
 
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 
@@ -156,7 +156,7 @@ describe('larger tests', () => {
         engine.setCellContents({sheet: 0, col: x, row: y}, null)
       }
     }
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 })
@@ -175,7 +175,7 @@ describe('cruds', () => {
     engine.removeRows(0, [0, 2])
     engine.removeRows(0, [2, 2])
 
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 
@@ -192,7 +192,7 @@ describe('cruds', () => {
     engine.removeRows(0, [0, 2])
     engine.removeRows(0, [2, 2])
 
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 
@@ -208,7 +208,7 @@ describe('cruds', () => {
 
     engine.removeRows(0, [4, 2])
 
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 
@@ -229,7 +229,7 @@ describe('cruds', () => {
 
     engine.removeRows(0, [0, 6])
 
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 
@@ -250,7 +250,7 @@ describe('cruds', () => {
 
     engine.removeRows(0, [0, 6])
 
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 
@@ -269,7 +269,7 @@ describe('cruds', () => {
 
     engine.removeRows(0, [0, 6])
 
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 
@@ -292,7 +292,7 @@ describe('cruds', () => {
 
     engine.removeRows(0, [0, 6])
 
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 
@@ -329,7 +329,7 @@ describe('cruds', () => {
     engine.setCellContents(adr('A5'), null)
     engine.setCellContents(adr('A6'), null)
 
-    expect(engine.dependencyGraph.graph.nodesCount()).toBe(0)
+    expect(engine.dependencyGraph.graph.getNodes().length).toBe(0)
     expect(engine.dependencyGraph.rangeMapping.getMappingSize(0)).toBe(0)
   })
 

--- a/test/graph-vertex.spec.ts
+++ b/test/graph-vertex.spec.ts
@@ -12,6 +12,6 @@ describe('Graph with Vertex', () => {
     graph.addNode(v1)
     graph.addNode(v2)
 
-    expect(graph.nodesCount()).toBe(2)
+    expect(graph.getNodes().length).toBe(2)
   })
 })

--- a/test/graph-vertex.spec.ts
+++ b/test/graph-vertex.spec.ts
@@ -8,9 +8,9 @@ describe('Graph with Vertex', () => {
 
     const v1 = new ValueCellVertex("1'", "1'")
     const v2 = new ValueCellVertex('2', '2')
-    graph.addNode(v1)
-    graph.addNode(v1)
-    graph.addNode(v2)
+    graph.addNodeAndReturnId(v1)
+    graph.addNodeAndReturnId(v1)
+    graph.addNodeAndReturnId(v2)
 
     expect(graph.getNodes().length).toBe(2)
   })

--- a/test/graph-vertex.spec.ts
+++ b/test/graph-vertex.spec.ts
@@ -3,7 +3,7 @@ import {Graph, ValueCellVertex, Vertex} from '../src/DependencyGraph'
 const dummyGetDependenciesQuery: () => any[] = () => []
 
 describe('Graph with Vertex', () => {
-  it('#addNode works correctly with Vertex instances', () => {
+  it('#addNodeAndReturnId works correctly with Vertex instances', () => {
     const graph = new Graph<Vertex>(dummyGetDependenciesQuery)
 
     const v1 = new ValueCellVertex("1'", "1'")

--- a/test/graph.spec.ts
+++ b/test/graph.spec.ts
@@ -1,35 +1,40 @@
 import {Graph} from '../src/DependencyGraph'
 import {HyperFormula} from '../src'
+import {DependencyQuery} from '../src/DependencyGraph/Graph'
 
-const identifiableString = (id: number, str: string) => ({id, str})
+class IdentifiableString {
+  constructor(
+    public id: number,
+    public str: string) {}
+}
 
-const dummyGetDependenciesQuery: () => any[] = () => []
+const dummyDependencyQuery: DependencyQuery<any> = () => []
 
 describe('Basic Graph manipulation', () => {
   it('#addNode', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-    const node = identifiableString(0, 'foo')
+    const node = new IdentifiableString(0, 'foo')
     graph.addNode(node)
 
     expect(graph.nodesCount()).toBe(1)
   })
 
   it('#addNode for the second time', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-    const node = identifiableString(0, 'foo')
+    const node = new IdentifiableString(0, 'foo')
     graph.addNode(node)
     graph.addNode(node)
 
     expect(graph.nodesCount()).toBe(1)
   })
 
-  it('#addNode for the second time doesnt reset adjacent nodes', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
+  it('#addNode for the second time does not reset adjacent nodes', () => {
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-    const node0 = identifiableString(0, 'foo')
-    const node1 = identifiableString(1, 'bar')
+    const node0 = new IdentifiableString(0, 'foo')
+    const node1 = new IdentifiableString(1, 'bar')
     graph.addNode(node0)
     graph.addNode(node1)
     graph.addEdge(node0, node1)
@@ -40,25 +45,28 @@ describe('Basic Graph manipulation', () => {
   })
 
   it('#hasNode when there is node', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-    const node = identifiableString(0, 'foo')
+    const node = new IdentifiableString(0, 'foo')
     graph.addNode(node)
 
     expect(graph.hasNode(node)).toBe(true)
   })
 
   it('#hasNode when there is no node', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-    expect(graph.hasNode(identifiableString(0, 'foo'))).toBe(false)
+    const node = new IdentifiableString(0, 'foo')
+    graph.addNode(node)
+
+    expect(graph.hasNode(new IdentifiableString(1, 'foo'))).toBe(false)
   })
 
   it('#adjacentNodes', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-    const node0 = identifiableString(0, 'foo')
-    const node1 = identifiableString(1, 'bar')
+    const node0 = new IdentifiableString(0, 'foo')
+    const node1 = new IdentifiableString(1, 'bar')
     graph.addNode(node0)
     graph.addNode(node1)
     graph.addEdge(node0, node1)
@@ -67,10 +75,10 @@ describe('Basic Graph manipulation', () => {
   })
 
   it('#addEdge removes multiple edges', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-    const node0 = identifiableString(0, 'foo')
-    const node1 = identifiableString(1, 'bar')
+    const node0 = new IdentifiableString(0, 'foo')
+    const node1 = new IdentifiableString(1, 'bar')
     graph.addNode(node0)
     graph.addNode(node1)
     graph.addEdge(node0, node1)
@@ -80,29 +88,29 @@ describe('Basic Graph manipulation', () => {
   })
 
   it('#addEdge is raising an error when the origin node not present', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
-    const node = identifiableString(1, 'target')
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node = new IdentifiableString(1, 'target')
     graph.addNode(node)
 
     expect(() => {
-      graph.addEdge(identifiableString(0, 'origin'), node)
+      graph.addEdge(new IdentifiableString(0, 'origin'), node)
     }).toThrowError(/Unknown node/)
   })
 
   it('#addEdge is raising an error when the target node not present', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
-    const node = identifiableString(0, 'origin')
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node = new IdentifiableString(0, 'origin')
     graph.addNode(node)
 
     expect(() => {
-      graph.addEdge(node, identifiableString(1, 'target'))
+      graph.addEdge(node, new IdentifiableString(1, 'target'))
     }).toThrowError(/Unknown node/)
   })
 
   it('#existsEdge works', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
-    const node0 = identifiableString(0, 'foo')
-    const node1 = identifiableString(1, 'bar')
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node0 = new IdentifiableString(0, 'foo')
+    const node1 = new IdentifiableString(1, 'bar')
     graph.addNode(node0)
     graph.addNode(node1)
     graph.addEdge(node0, node1)
@@ -111,35 +119,35 @@ describe('Basic Graph manipulation', () => {
   })
 
   it('#existsEdge when there is origin node but no edge', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
-    const node = identifiableString(0, 'foo')
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node = new IdentifiableString(0, 'foo')
     graph.addNode(node)
 
-    expect(graph.existsEdge(node, identifiableString(1, 'bar'))).toBe(false)
+    expect(graph.existsEdge(node, new IdentifiableString(1, 'bar'))).toBe(false)
   })
 
   it('#existsEdge when there is no node', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-    expect(graph.existsEdge(identifiableString(0, 'foo'), identifiableString(1, 'bar'))).toBe(false)
+    expect(graph.existsEdge(new IdentifiableString(0, 'foo'), new IdentifiableString(1, 'bar'))).toBe(false)
   })
 
   it('#edgesCount when there is no nodes', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
     expect(graph.edgesCount()).toBe(0)
   })
 
   it('#edgesCount counts edges from all nodes', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
-    const node0 = identifiableString(0, 'bar1')
-    const node1 = identifiableString(1, 'bar2')
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node0 = new IdentifiableString(0, 'bar1')
+    const node1 = new IdentifiableString(1, 'bar2')
     graph.addNode(node0)
     graph.addNode(node1)
-    const node2 = identifiableString(2, 'first')
+    const node2 = new IdentifiableString(2, 'first')
     graph.addNode(node2)
     graph.addEdge(node2, node0)
-    const node3 = identifiableString(2, 'second')
+    const node3 = new IdentifiableString(2, 'second')
     graph.addNode(node3)
     graph.addEdge(node3, node0)
     graph.addEdge(node3, node1)
@@ -148,15 +156,15 @@ describe('Basic Graph manipulation', () => {
   })
 
   it('#topologicalSort for empty graph', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
     expect(graph.topSortWithScc().sorted).toEqual([])
     expect(graph.topSortWithScc().cycled).toEqual([])
   })
 
-  it('#topologicalSort node is included even if he is not connected to anything', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
-    const node = identifiableString(0, 'foo')
+  it('#topologicalSort node is included even if it is not connected to anything', () => {
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node = new IdentifiableString(0, 'foo')
     graph.addNode(node)
 
     expect(graph.topSortWithScc().sorted).toEqual([node])
@@ -164,9 +172,9 @@ describe('Basic Graph manipulation', () => {
   })
 
   it('#topologicalSort for simple graph', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
-    const node0 = identifiableString(0, 'foo')
-    const node1 = identifiableString(1, 'bar')
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node0 = new IdentifiableString(0, 'foo')
+    const node1 = new IdentifiableString(1, 'bar')
     graph.addNode(node0)
     graph.addNode(node1)
     graph.addEdge(node1, node0)
@@ -176,12 +184,12 @@ describe('Basic Graph manipulation', () => {
   })
 
   it('#topologicalSort for more complex graph', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
-    const node0 = identifiableString(0, 'x0')
-    const node1 = identifiableString(1, 'x1')
-    const node2 = identifiableString(2, 'x2')
-    const node3 = identifiableString(3, 'x3')
-    const node4 = identifiableString(4, 'x4')
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node0 = new IdentifiableString(0, 'x0')
+    const node1 = new IdentifiableString(1, 'x1')
+    const node2 = new IdentifiableString(2, 'x2')
+    const node3 = new IdentifiableString(3, 'x3')
+    const node4 = new IdentifiableString(4, 'x4')
     graph.addNode(node0)
     graph.addNode(node1)
     graph.addNode(node2)
@@ -197,11 +205,11 @@ describe('Basic Graph manipulation', () => {
   })
 
   it('#topologicalSort for not connected graph', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
-    const node0 = identifiableString(0, 'x0')
-    const node1 = identifiableString(1, 'x1')
-    const node2 = identifiableString(2, 'x2')
-    const node3 = identifiableString(3, 'x3')
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node0 = new IdentifiableString(0, 'x0')
+    const node1 = new IdentifiableString(1, 'x1')
+    const node2 = new IdentifiableString(2, 'x2')
+    const node3 = new IdentifiableString(3, 'x3')
     graph.addNode(node0)
     graph.addNode(node1)
     graph.addNode(node2)
@@ -214,9 +222,9 @@ describe('Basic Graph manipulation', () => {
   })
 
   it('#topologicalSort returns vertices on trivial cycle', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
-    const node0 = identifiableString(0, 'x0')
-    const node1 = identifiableString(1, 'x1')
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node0 = new IdentifiableString(0, 'x0')
+    const node1 = new IdentifiableString(1, 'x1')
     graph.addNode(node0)
     graph.addNode(node1)
     graph.addEdge(node0, node1)
@@ -227,10 +235,10 @@ describe('Basic Graph manipulation', () => {
   })
 
   it('#topologicalSort returns vertices on cycle', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
-    const node0 = identifiableString(0, 'x0')
-    const node1 = identifiableString(1, 'x1')
-    const node2 = identifiableString(2, 'x2')
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node0 = new IdentifiableString(0, 'x0')
+    const node1 = new IdentifiableString(1, 'x1')
+    const node2 = new IdentifiableString(2, 'x2')
     graph.addNode(node0)
     graph.addNode(node1)
     graph.addNode(node2)
@@ -243,8 +251,8 @@ describe('Basic Graph manipulation', () => {
   })
 
   it('#topologicalSort returns one-element cycle', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
-    const node = identifiableString(0, 'foo')
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node = new IdentifiableString(0, 'foo')
     graph.addNode(node)
     graph.addEdge(node, node)
 
@@ -255,7 +263,7 @@ describe('Basic Graph manipulation', () => {
 
 describe('Graph#getTopologicallySortedSubgraphFrom', () => {
   it('case without edges', () => {
-    const graph = new Graph<string>(dummyGetDependenciesQuery)
+    const graph = new Graph<string>(dummyDependencyQuery)
     const node0 = 'foo'
     const node1 = 'bar'
     graph.addNode(node0)
@@ -271,7 +279,7 @@ describe('Graph#getTopologicallySortedSubgraphFrom', () => {
   })
 
   it('case with obvious edge', () => {
-    const graph = new Graph<string>(dummyGetDependenciesQuery)
+    const graph = new Graph<string>(dummyDependencyQuery)
     const node0 = 'foo'
     const node1 = 'bar'
 
@@ -290,7 +298,7 @@ describe('Graph#getTopologicallySortedSubgraphFrom', () => {
   })
 
   it('it doesnt call other if didnt change', () => {
-    const graph = new Graph<string>(dummyGetDependenciesQuery)
+    const graph = new Graph<string>(dummyDependencyQuery)
     const node0 = 'foo'
     const node1 = 'bar'
 
@@ -308,7 +316,7 @@ describe('Graph#getTopologicallySortedSubgraphFrom', () => {
   })
 
   it('does call if some previous vertex marked as changed', () => {
-    const graph = new Graph<string>(dummyGetDependenciesQuery)
+    const graph = new Graph<string>(dummyDependencyQuery)
     const nodes = ['foo', 'bar', 'baz']
 
     nodes.forEach((n) => graph.addNode(n))
@@ -325,7 +333,7 @@ describe('Graph#getTopologicallySortedSubgraphFrom', () => {
   })
 
   it('returns cycled vertices', () => {
-    const graph = new Graph<string>(dummyGetDependenciesQuery)
+    const graph = new Graph<string>(dummyDependencyQuery)
     const nodes = ['foo', 'c0', 'c1', 'c2']
 
     nodes.forEach((n) => graph.addNode(n))
@@ -343,7 +351,7 @@ describe('Graph#getTopologicallySortedSubgraphFrom', () => {
   })
 
   it('doesnt call first one of the given vertices if its on cycle', () => {
-    const graph = new Graph<string>(dummyGetDependenciesQuery)
+    const graph = new Graph<string>(dummyDependencyQuery)
     const nodes = ['c0', 'c1', 'c2']
     nodes.forEach((n) => graph.addNode(n))
     graph.addEdge(nodes[0], nodes[1])
@@ -359,7 +367,7 @@ describe('Graph#getTopologicallySortedSubgraphFrom', () => {
   })
 
   it('returns cycled vertices even if they were not tried to be computed', () => {
-    const graph = new Graph<string>(dummyGetDependenciesQuery)
+    const graph = new Graph<string>(dummyDependencyQuery)
     const nodes = ['foo', 'c0', 'c1', 'c2']
     nodes.forEach((n) => graph.addNode(n))
     graph.addEdge(nodes[0], nodes[1])
@@ -378,9 +386,9 @@ describe('Graph#getTopologicallySortedSubgraphFrom', () => {
 
 describe('Graph cruds', () => {
   it('#removeEdge not existing edge', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
-    const node0 = identifiableString(0, 'x0')
-    const node1 = identifiableString(1, 'x1')
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node0 = new IdentifiableString(0, 'x0')
+    const node1 = new IdentifiableString(1, 'x1')
     graph.addNode(node0)
     graph.addNode(node1)
 
@@ -388,9 +396,9 @@ describe('Graph cruds', () => {
   })
 
   it('#removeEdge removes edge from graph', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
-    const node0 = identifiableString(0, 'x0')
-    const node1 = identifiableString(1, 'x1')
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node0 = new IdentifiableString(0, 'x0')
+    const node1 = new IdentifiableString(1, 'x1')
 
     graph.addNode(node0)
     graph.addNode(node1)
@@ -402,26 +410,6 @@ describe('Graph cruds', () => {
     graph.removeEdge(node0, node1)
     expect(graph.edgesCount()).toEqual(0)
     expect(graph.existsEdge(node0, node1)).toBe(false)
-  })
-
-  it('#removeIncomingEdges removes all edges incoming to given node', () => {
-    const graph = new Graph(dummyGetDependenciesQuery)
-    const node0 = identifiableString(0, 'x0')
-    const node1 = identifiableString(1, 'x1')
-    const node2 = identifiableString(1, 'x2')
-
-    graph.addNode(node0)
-    graph.addNode(node1)
-    graph.addNode(node2)
-
-    graph.addEdge(node1, node0)
-    graph.addEdge(node2, node0)
-    expect(graph.edgesCount()).toEqual(2)
-    expect(graph.existsEdge(node1, node0)).toBe(true)
-    expect(graph.existsEdge(node2, node0)).toBe(true)
-
-    graph.removeIncomingEdges(node0)
-    expect(graph.edgesCount()).toEqual(0)
   })
 
   it('tmp', () => {

--- a/test/graph.spec.ts
+++ b/test/graph.spec.ts
@@ -1,5 +1,4 @@
 import {Graph} from '../src/DependencyGraph'
-import {HyperFormula} from '../src'
 import {DependencyQuery} from '../src/DependencyGraph/Graph'
 
 class IdentifiableString {
@@ -10,14 +9,14 @@ class IdentifiableString {
 
 const dummyDependencyQuery: DependencyQuery<any> = () => []
 
-describe('Basic Graph manipulation', () => {
+describe('Graph class', () => {
   it('#addNode', () => {
     const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
     const node = new IdentifiableString(0, 'foo')
     graph.addNode(node)
 
-    expect(graph.nodesCount()).toBe(1)
+    expect(graph.getNodes().length).toBe(1)
   })
 
   it('#addNode for the second time', () => {
@@ -27,7 +26,7 @@ describe('Basic Graph manipulation', () => {
     graph.addNode(node)
     graph.addNode(node)
 
-    expect(graph.nodesCount()).toBe(1)
+    expect(graph.getNodes().length).toBe(1)
   })
 
   it('#addNode for the second time does not reset adjacent nodes', () => {
@@ -259,9 +258,35 @@ describe('Basic Graph manipulation', () => {
     expect(graph.topSortWithScc().sorted).toEqual([])
     expect(graph.topSortWithScc().cycled).toEqual([node])
   })
-})
 
-describe('Graph#getTopologicallySortedSubgraphFrom', () => {
+  it('#removeEdge not existing edge', () => {
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node0 = new IdentifiableString(0, 'x0')
+    const node1 = new IdentifiableString(1, 'x1')
+    graph.addNode(node0)
+    graph.addNode(node1)
+
+    expect(() => graph.removeEdge(node0, node1)).toThrowError('Edge does not exist')
+  })
+
+  it('#removeEdge removes edge from graph', () => {
+    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+    const node0 = new IdentifiableString(0, 'x0')
+    const node1 = new IdentifiableString(1, 'x1')
+
+    graph.addNode(node0)
+    graph.addNode(node1)
+
+    graph.addEdge(node0, node1)
+    expect(graph.edgesCount()).toEqual(1)
+    expect(graph.existsEdge(node0, node1)).toBe(true)
+
+    graph.removeEdge(node0, node1)
+    expect(graph.edgesCount()).toEqual(0)
+    expect(graph.existsEdge(node0, node1)).toBe(false)
+  })
+
+describe('getTopSortedWithSccSubgraphFrom', () => {
   it('case without edges', () => {
     const graph = new Graph<string>(dummyDependencyQuery)
     const node0 = 'foo'
@@ -383,41 +408,4 @@ describe('Graph#getTopologicallySortedSubgraphFrom', () => {
     expect(cycled).toEqual(['c0', 'c1', 'c2'])
   })
 })
-
-describe('Graph cruds', () => {
-  it('#removeEdge not existing edge', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node0 = new IdentifiableString(0, 'x0')
-    const node1 = new IdentifiableString(1, 'x1')
-    graph.addNode(node0)
-    graph.addNode(node1)
-
-    expect(() => graph.removeEdge(node0, node1)).toThrowError('Edge does not exist')
-  })
-
-  it('#removeEdge removes edge from graph', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node0 = new IdentifiableString(0, 'x0')
-    const node1 = new IdentifiableString(1, 'x1')
-
-    graph.addNode(node0)
-    graph.addNode(node1)
-
-    graph.addEdge(node0, node1)
-    expect(graph.edgesCount()).toEqual(1)
-    expect(graph.existsEdge(node0, node1)).toBe(true)
-
-    graph.removeEdge(node0, node1)
-    expect(graph.edgesCount()).toEqual(0)
-    expect(graph.existsEdge(node0, node1)).toBe(false)
-  })
-
-  it('tmp', () => {
-    const hf = HyperFormula.buildFromArray([], {
-      licenseKey: 'gpl-v3',
-    })
-
-    const data = Array(5).fill(0).map(() => Array(5).fill(0).map(() => 'A500000'))
-    hf.setSheetContent(0, data)
-  })
 })

--- a/test/graph.spec.ts
+++ b/test/graph.spec.ts
@@ -497,7 +497,7 @@ describe('Graph class', () => {
       graph.addNode(node)
       graph.markNodeAsVolatile(node)
 
-      expect(graph.getRecentlyChangedAndVolatile()).toEqual([node])
+      expect(graph.getDirtyAndVolatileNodes()).toEqual([node])
     })
 
     it('does nothing if node is not in a graph', () => {
@@ -505,7 +505,7 @@ describe('Graph class', () => {
       const node = new IdentifiableString(0, 'foo')
 
       graph.markNodeAsVolatile(node)
-      expect(graph.getRecentlyChangedAndVolatile()).toEqual([])
+      expect(graph.getDirtyAndVolatileNodes()).toEqual([])
     })
   })
 
@@ -516,8 +516,9 @@ describe('Graph class', () => {
 
       graph.addNode(node)
       graph.markNodeAsChangingWithStructure(node)
+      graph.markChangingWithStructureNodesAsDirty()
 
-      expect(graph.specialNodesStructuralChanges).toEqual(new Set([node]))
+      expect(graph.getDirtyAndVolatileNodes()).toEqual([node])
     })
 
     it('does nothing if node is not in a graph', () => {
@@ -525,19 +526,21 @@ describe('Graph class', () => {
       const node = new IdentifiableString(0, 'foo')
 
       graph.markNodeAsChangingWithStructure(node)
-      expect(graph.specialNodesStructuralChanges).toEqual(new Set([]))
+      graph.markChangingWithStructureNodesAsDirty()
+
+      expect(graph.getDirtyAndVolatileNodes()).toEqual([])
     })
   })
 
   describe('markNodeAsInfiniteRange', () => {
-    it('adds a node to infiniteRanges array', () => {
+    it('adds a node to the infinite ranges array', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node = new IdentifiableString(0, 'foo')
 
       graph.addNode(node)
       graph.markNodeAsInfiniteRange(node)
 
-      expect(graph.infiniteRanges).toEqual(new Set([node]))
+      expect(graph.getInfiniteRanges()).toEqual([node])
     })
 
     it('does nothing if node is not in a graph', () => {
@@ -545,7 +548,7 @@ describe('Graph class', () => {
       const node = new IdentifiableString(0, 'foo')
 
       graph.markNodeAsInfiniteRange(node)
-      expect(graph.infiniteRanges).toEqual(new Set([]))
+      expect(graph.getInfiniteRanges()).toEqual([])
     })
   })
 })

--- a/test/graph.spec.ts
+++ b/test/graph.spec.ts
@@ -489,24 +489,23 @@ describe('Graph class', () => {
     })
   })
 
-  describe('markNodeAsSpecial', () => {
-    it('adds a node to special nodes array', () => {
+  describe('markNodeAsVolatile', () => {
+    it('adds a node to volatile nodes array', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node = new IdentifiableString(0, 'foo')
 
       graph.addNode(node)
-      graph.markNodeAsSpecial(node)
+      graph.markNodeAsVolatile(node)
 
-      expect(graph.specialNodes).toEqual(new Set([node]))
+      expect(graph.getRecentlyChangedAndVolatile()).toEqual([node])
     })
 
     it('does nothing if node is not in a graph', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node = new IdentifiableString(0, 'foo')
 
-      graph.markNodeAsSpecial(node)
-      expect(graph.specialNodes).toEqual(new Set([]))
-
+      graph.markNodeAsVolatile(node)
+      expect(graph.getRecentlyChangedAndVolatile()).toEqual([])
     })
   })
 

--- a/test/graph.spec.ts
+++ b/test/graph.spec.ts
@@ -17,7 +17,7 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
       const node = new IdentifiableString(0, 'foo')
-      graph.addNode(node)
+      graph.addNodeAndReturnId(node)
 
       expect(graph.getNodes().length).toBe(1)
     })
@@ -26,8 +26,8 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
       const node = new IdentifiableString(0, 'foo')
-      graph.addNode(node)
-      graph.addNode(node)
+      graph.addNodeAndReturnId(node)
+      graph.addNodeAndReturnId(node)
 
       expect(graph.getNodes().length).toBe(1)
     })
@@ -37,14 +37,14 @@ describe('Graph class', () => {
 
       const node0 = new IdentifiableString(0, 'foo')
       const node1 = new IdentifiableString(1, 'bar')
-      graph.addNode(node0)
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
       expect(graph.adjacentNodes(node0)).toEqual(new Set([]))
 
       graph.addEdge(node0, node1)
       expect(graph.adjacentNodes(node0)).toEqual(new Set([node1]))
 
-      graph.addNode(node0)
+      graph.addNodeAndReturnId(node0)
 
       expect(graph.adjacentNodes(node0)).toEqual(new Set([node1]))
     })
@@ -55,7 +55,7 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
       const node = new IdentifiableString(0, 'foo')
-      graph.addNode(node)
+      graph.addNodeAndReturnId(node)
       graph.removeNode(node)
 
       expect(graph.getNodes().length).toBe(0)
@@ -79,7 +79,7 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
       const node = new IdentifiableString(0, 'foo')
-      graph.addNode(node)
+      graph.addNodeAndReturnId(node)
 
       expect(graph.hasNode(node)).toBe(true)
     })
@@ -88,7 +88,7 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
       const node = new IdentifiableString(0, 'foo')
-      graph.addNode(node)
+      graph.addNodeAndReturnId(node)
 
       expect(graph.hasNode(new IdentifiableString(1, 'foo'))).toBe(false)
     })
@@ -97,7 +97,7 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
       const node = new IdentifiableString(0, 'foo')
-      graph.addNode(node)
+      graph.addNodeAndReturnId(node)
       graph.removeNode(node)
 
       expect(graph.hasNode(node)).toBe(false)
@@ -110,8 +110,8 @@ describe('Graph class', () => {
 
       const node0 = new IdentifiableString(0, 'foo')
       const node1 = new IdentifiableString(1, 'bar')
-      graph.addNode(node0)
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
       graph.addEdge(node0, node1)
       graph.addEdge(node0, node1)
 
@@ -121,7 +121,7 @@ describe('Graph class', () => {
     it('throws error when the origin node is not present', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node = new IdentifiableString(1, 'target')
-      graph.addNode(node)
+      graph.addNodeAndReturnId(node)
 
       expect(() => {
         graph.addEdge(new IdentifiableString(0, 'origin'), node)
@@ -131,7 +131,7 @@ describe('Graph class', () => {
     it('throws error when the target node is not present', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node = new IdentifiableString(0, 'origin')
-      graph.addNode(node)
+      graph.addNodeAndReturnId(node)
 
       expect(() => {
         graph.addEdge(node, new IdentifiableString(1, 'target'))
@@ -144,7 +144,7 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node0 = new IdentifiableString(0, 'x0')
       const node1 = new IdentifiableString(1, 'x1')
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node1)
 
       expect(() => graph.removeEdge(node0, node1)).toThrowError(/Unknown node/)
     })
@@ -153,7 +153,7 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node0 = new IdentifiableString(0, 'x0')
       const node1 = new IdentifiableString(1, 'x1')
-      graph.addNode(node0)
+      graph.addNodeAndReturnId(node0)
 
       expect(() => graph.removeEdge(node0, node1)).toThrowError(/Unknown node/)
     })
@@ -162,8 +162,8 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node0 = new IdentifiableString(0, 'x0')
       const node1 = new IdentifiableString(1, 'x1')
-      graph.addNode(node0)
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
 
       expect(() => graph.removeEdge(node0, node1)).toThrowError('Edge does not exist')
     })
@@ -173,8 +173,8 @@ describe('Graph class', () => {
       const node0 = new IdentifiableString(0, 'x0')
       const node1 = new IdentifiableString(1, 'x1')
 
-      graph.addNode(node0)
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
       expect(graphEdgesCount(graph)).toEqual(0)
 
       graph.addEdge(node0, node1)
@@ -192,8 +192,8 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node0 = new IdentifiableString(0, 'foo')
       const node1 = new IdentifiableString(1, 'bar')
-      graph.addNode(node0)
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
       graph.addEdge(node0, node1)
 
       expect(graph.existsEdge(node0, node1)).toBe(true)
@@ -203,8 +203,8 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node0 = new IdentifiableString(0, 'foo')
       const node1 = new IdentifiableString(1, 'bar')
-      graph.addNode(node0)
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
 
       expect(graph.existsEdge(node0, node1)).toBe(false)
     })
@@ -222,8 +222,8 @@ describe('Graph class', () => {
 
       const node0 = new IdentifiableString(0, 'foo')
       const node1 = new IdentifiableString(1, 'bar')
-      graph.addNode(node0)
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
       graph.addEdge(node0, node1)
 
       expect(graph.adjacentNodes(node0)).toEqual(new Set([node1]))
@@ -234,8 +234,8 @@ describe('Graph class', () => {
 
       const node0 = new IdentifiableString(0, 'foo')
       const node1 = new IdentifiableString(1, 'bar')
-      graph.addNode(node0)
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
       graph.addEdge(node0, node1)
 
       expect(() => graph.adjacentNodes(new IdentifiableString(42, 'baz'))).toThrowError(/Unknown node/)
@@ -248,8 +248,8 @@ describe('Graph class', () => {
 
       const node0 = new IdentifiableString(0, 'foo')
       const node1 = new IdentifiableString(1, 'bar')
-      graph.addNode(node0)
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
       graph.addEdge(node0, node1)
 
       expect(graph.adjacentNodesCount(node0)).toEqual(1)
@@ -260,8 +260,8 @@ describe('Graph class', () => {
 
       const node0 = new IdentifiableString(0, 'foo')
       const node1 = new IdentifiableString(1, 'bar')
-      graph.addNode(node0)
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
       graph.addEdge(node0, node1)
 
       expect(() => graph.adjacentNodesCount(new IdentifiableString(42, 'baz'))).toThrowError(/Unknown node/)
@@ -279,7 +279,7 @@ describe('Graph class', () => {
     it('returns isolated vertices', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node = new IdentifiableString(0, 'foo')
-      graph.addNode(node)
+      graph.addNodeAndReturnId(node)
 
       expect(graph.topSortWithScc().sorted).toEqual([node])
       expect(graph.topSortWithScc().cycled).toEqual([])
@@ -289,8 +289,8 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node0 = new IdentifiableString(0, 'foo')
       const node1 = new IdentifiableString(1, 'bar')
-      graph.addNode(node0)
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
       graph.addEdge(node1, node0)
 
       expect(graph.topSortWithScc().sorted).toEqual([node1, node0])
@@ -304,11 +304,11 @@ describe('Graph class', () => {
       const node2 = new IdentifiableString(2, 'x2')
       const node3 = new IdentifiableString(3, 'x3')
       const node4 = new IdentifiableString(4, 'x4')
-      graph.addNode(node0)
-      graph.addNode(node1)
-      graph.addNode(node2)
-      graph.addNode(node3)
-      graph.addNode(node4)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
+      graph.addNodeAndReturnId(node2)
+      graph.addNodeAndReturnId(node3)
+      graph.addNodeAndReturnId(node4)
       graph.addEdge(node0, node2)
       graph.addEdge(node1, node2)
       graph.addEdge(node2, node3)
@@ -324,10 +324,10 @@ describe('Graph class', () => {
       const node1 = new IdentifiableString(1, 'x1')
       const node2 = new IdentifiableString(2, 'x2')
       const node3 = new IdentifiableString(3, 'x3')
-      graph.addNode(node0)
-      graph.addNode(node1)
-      graph.addNode(node2)
-      graph.addNode(node3)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
+      graph.addNodeAndReturnId(node2)
+      graph.addNodeAndReturnId(node3)
       graph.addEdge(node0, node2)
       graph.addEdge(node1, node3)
 
@@ -339,8 +339,8 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node0 = new IdentifiableString(0, 'x0')
       const node1 = new IdentifiableString(1, 'x1')
-      graph.addNode(node0)
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
       graph.addEdge(node0, node1)
       graph.addEdge(node1, node0)
 
@@ -353,9 +353,9 @@ describe('Graph class', () => {
       const node0 = new IdentifiableString(0, 'x0')
       const node1 = new IdentifiableString(1, 'x1')
       const node2 = new IdentifiableString(2, 'x2')
-      graph.addNode(node0)
-      graph.addNode(node1)
-      graph.addNode(node2)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
+      graph.addNodeAndReturnId(node2)
       graph.addEdge(node0, node1)
       graph.addEdge(node1, node2)
       graph.addEdge(node1, node1)
@@ -370,8 +370,8 @@ describe('Graph class', () => {
       const graph = new Graph<string>(dummyDependencyQuery)
       const node0 = 'foo'
       const node1 = 'bar'
-      graph.addNode(node0)
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
 
       const operatingFunction = jasmine.createSpy().and.returnValue(true)
       const onCycle = jasmine.createSpy()
@@ -387,8 +387,8 @@ describe('Graph class', () => {
       const node0 = 'foo'
       const node1 = 'bar'
 
-      graph.addNode(node0)
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
       graph.addEdge(node0, node1)
 
       const operatingFunction = jasmine.createSpy().and.returnValue(true)
@@ -406,8 +406,8 @@ describe('Graph class', () => {
       const node0 = 'foo'
       const node1 = 'bar'
 
-      graph.addNode(node0)
-      graph.addNode(node1)
+      graph.addNodeAndReturnId(node0)
+      graph.addNodeAndReturnId(node1)
       graph.addEdge(node0, node1)
 
       const operatingFunction = jasmine.createSpy().and.returnValue(false)
@@ -423,7 +423,7 @@ describe('Graph class', () => {
       const graph = new Graph<string>(dummyDependencyQuery)
       const nodes = ['foo', 'bar', 'baz']
 
-      nodes.forEach((n) => graph.addNode(n))
+      nodes.forEach((n) => graph.addNodeAndReturnId(n))
       graph.addEdge(nodes[0], nodes[2])
       graph.addEdge(nodes[1], nodes[2])
 
@@ -440,7 +440,7 @@ describe('Graph class', () => {
       const graph = new Graph<string>(dummyDependencyQuery)
       const nodes = ['foo', 'c0', 'c1', 'c2']
 
-      nodes.forEach((n) => graph.addNode(n))
+      nodes.forEach((n) => graph.addNodeAndReturnId(n))
       graph.addEdge(nodes[0], nodes[1])
       graph.addEdge(nodes[1], nodes[2])
       graph.addEdge(nodes[2], nodes[3])
@@ -458,7 +458,7 @@ describe('Graph class', () => {
     it('does not call operatingFunction callback for nodes that are on cycle', () => {
       const graph = new Graph<string>(dummyDependencyQuery)
       const nodes = ['c0', 'c1', 'c2']
-      nodes.forEach((n) => graph.addNode(n))
+      nodes.forEach((n) => graph.addNodeAndReturnId(n))
       graph.addEdge(nodes[0], nodes[1])
       graph.addEdge(nodes[1], nodes[2])
       graph.addEdge(nodes[2], nodes[0])
@@ -474,7 +474,7 @@ describe('Graph class', () => {
     it('detects a cycle consisting of nodes not included but reachable from the "modifiedNodes" array', () => {
       const graph = new Graph<string>(dummyDependencyQuery)
       const nodes = ['foo', 'c0', 'c1', 'c2']
-      nodes.forEach((n) => graph.addNode(n))
+      nodes.forEach((n) => graph.addNodeAndReturnId(n))
       graph.addEdge(nodes[0], nodes[1])
       graph.addEdge(nodes[1], nodes[2])
       graph.addEdge(nodes[2], nodes[3])
@@ -494,7 +494,7 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node = new IdentifiableString(0, 'foo')
 
-      graph.addNode(node)
+      graph.addNodeAndReturnId(node)
       graph.markNodeAsVolatile(node)
 
       expect(graph.getDirtyAndVolatileNodes()).toEqual([node])
@@ -514,7 +514,7 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node = new IdentifiableString(0, 'foo')
 
-      graph.addNode(node)
+      graph.addNodeAndReturnId(node)
       graph.markNodeAsChangingWithStructure(node)
       graph.markChangingWithStructureNodesAsDirty()
 
@@ -537,10 +537,10 @@ describe('Graph class', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node = new IdentifiableString(0, 'foo')
 
-      graph.addNode(node)
+      graph.addNodeAndReturnId(node)
       graph.markNodeAsInfiniteRange(node)
 
-      expect(graph.getInfiniteRanges()).toEqual([node])
+      expect(graph.getInfiniteRanges().map(({ node }) => node)).toEqual([node])
     })
 
     it('does nothing if node is not in a graph', () => {

--- a/test/graph.spec.ts
+++ b/test/graph.spec.ts
@@ -1,5 +1,6 @@
 import {Graph} from '../src/DependencyGraph'
 import {DependencyQuery} from '../src/DependencyGraph/Graph'
+import {graphEdgesCount} from './testUtils'
 
 class IdentifiableString {
   constructor(
@@ -131,29 +132,6 @@ describe('Graph class', () => {
     expect(graph.existsEdge(new IdentifiableString(0, 'foo'), new IdentifiableString(1, 'bar'))).toBe(false)
   })
 
-  it('#edgesCount when there is no nodes', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-
-    expect(graph.edgesCount()).toBe(0)
-  })
-
-  it('#edgesCount counts edges from all nodes', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node0 = new IdentifiableString(0, 'bar1')
-    const node1 = new IdentifiableString(1, 'bar2')
-    graph.addNode(node0)
-    graph.addNode(node1)
-    const node2 = new IdentifiableString(2, 'first')
-    graph.addNode(node2)
-    graph.addEdge(node2, node0)
-    const node3 = new IdentifiableString(2, 'second')
-    graph.addNode(node3)
-    graph.addEdge(node3, node0)
-    graph.addEdge(node3, node1)
-
-    expect(graph.edgesCount()).toBe(3)
-  })
-
   it('#topologicalSort for empty graph', () => {
     const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
@@ -278,11 +256,11 @@ describe('Graph class', () => {
     graph.addNode(node1)
 
     graph.addEdge(node0, node1)
-    expect(graph.edgesCount()).toEqual(1)
+    expect(graphEdgesCount(graph)).toEqual(1)
     expect(graph.existsEdge(node0, node1)).toBe(true)
 
     graph.removeEdge(node0, node1)
-    expect(graph.edgesCount()).toEqual(0)
+    expect(graphEdgesCount(graph)).toEqual(0)
     expect(graph.existsEdge(node0, node1)).toBe(false)
   })
 

--- a/test/graph.spec.ts
+++ b/test/graph.spec.ts
@@ -64,7 +64,7 @@ describe('Graph class', () => {
     it('throws error when node does not exist', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-      expect(() => graph.removeNode(new IdentifiableString(0, 'foo'))).toThrow(/Unknown node/)
+      expect(() => graph.removeNode(new IdentifiableString(0, 'foo'))).toThrowError(/Unknown node/)
     })
   })
 

--- a/test/graph.spec.ts
+++ b/test/graph.spec.ts
@@ -12,7 +12,7 @@ class IdentifiableString {
 const dummyDependencyQuery: DependencyQuery<any> = () => []
 
 describe('Graph class', () => {
-  describe('addNode', () => {
+  describe('addNodeAndReturnId', () => {
     it('adds a node to the empty graph', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 

--- a/test/graph.spec.ts
+++ b/test/graph.spec.ts
@@ -1,4 +1,5 @@
 import {Graph} from '../src/DependencyGraph'
+import {HyperFormula} from '../src'
 
 const identifiableString = (id: number, str: string) => ({id, str})
 
@@ -421,5 +422,14 @@ describe('Graph cruds', () => {
 
     graph.removeIncomingEdges(node0)
     expect(graph.edgesCount()).toEqual(0)
+  })
+
+  it('tmp', () => {
+    const hf = HyperFormula.buildFromArray([], {
+      licenseKey: 'gpl-v3',
+    })
+
+    const data = Array(5).fill(0).map(() => Array(1).fill(0).map(() => 'A500000'))
+    hf.setSheetContent(0, data)
   })
 })

--- a/test/graph.spec.ts
+++ b/test/graph.spec.ts
@@ -429,7 +429,7 @@ describe('Graph cruds', () => {
       licenseKey: 'gpl-v3',
     })
 
-    const data = Array(5).fill(0).map(() => Array(1).fill(0).map(() => 'A500000'))
+    const data = Array(5).fill(0).map(() => Array(5).fill(0).map(() => 'A500000'))
     hf.setSheetContent(0, data)
   })
 })

--- a/test/graph.spec.ts
+++ b/test/graph.spec.ts
@@ -5,385 +5,431 @@ import {graphEdgesCount} from './testUtils'
 class IdentifiableString {
   constructor(
     public id: number,
-    public str: string) {}
+    public str: string) {
+  }
 }
 
 const dummyDependencyQuery: DependencyQuery<any> = () => []
 
 describe('Graph class', () => {
-  it('#addNode', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+  describe('addNode', () => {
+    it('adds a node to the empty graph', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-    const node = new IdentifiableString(0, 'foo')
-    graph.addNode(node)
+      const node = new IdentifiableString(0, 'foo')
+      graph.addNode(node)
 
-    expect(graph.getNodes().length).toBe(1)
+      expect(graph.getNodes().length).toBe(1)
+    })
+
+    it('does not add duplicate nodes', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+
+      const node = new IdentifiableString(0, 'foo')
+      graph.addNode(node)
+      graph.addNode(node)
+
+      expect(graph.getNodes().length).toBe(1)
+    })
+
+    it('keeps existing edges when dealing with duplicates', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+
+      const node0 = new IdentifiableString(0, 'foo')
+      const node1 = new IdentifiableString(1, 'bar')
+      graph.addNode(node0)
+      graph.addNode(node1)
+      expect(graph.adjacentNodes(node0)).toEqual(new Set([]))
+
+      graph.addEdge(node0, node1)
+      expect(graph.adjacentNodes(node0)).toEqual(new Set([node1]))
+
+      graph.addNode(node0)
+
+      expect(graph.adjacentNodes(node0)).toEqual(new Set([node1]))
+    })
   })
 
-  it('#addNode for the second time', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+  describe('removeNode', () => {
+    it('removes a node if it exists', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-    const node = new IdentifiableString(0, 'foo')
-    graph.addNode(node)
-    graph.addNode(node)
+      const node = new IdentifiableString(0, 'foo')
+      graph.addNode(node)
+      graph.removeNode(node)
 
-    expect(graph.getNodes().length).toBe(1)
+      expect(graph.getNodes().length).toBe(0)
+    })
+
+    it('throws error when node does not exist', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+
+      expect(() => graph.removeNode(new IdentifiableString(0, 'foo'))).toThrow(/Unknown node/)
+    })
   })
 
-  it('#addNode for the second time does not reset adjacent nodes', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+  describe('hasNode', () => {
+    it('returns false when graph is empty', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-    const node0 = new IdentifiableString(0, 'foo')
-    const node1 = new IdentifiableString(1, 'bar')
-    graph.addNode(node0)
-    graph.addNode(node1)
-    graph.addEdge(node0, node1)
+      expect(graph.hasNode(new IdentifiableString(0, 'foo'))).toBe(false)
+    })
 
-    graph.addNode(node0)
+    it('returns true if node exists', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-    expect(graph.adjacentNodes(node0)).toEqual(new Set([node1]))
+      const node = new IdentifiableString(0, 'foo')
+      graph.addNode(node)
+
+      expect(graph.hasNode(node)).toBe(true)
+    })
+
+    it('returns false if node does not exist', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+
+      const node = new IdentifiableString(0, 'foo')
+      graph.addNode(node)
+
+      expect(graph.hasNode(new IdentifiableString(1, 'foo'))).toBe(false)
+    })
+
+    it('returns false if node was removed', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+
+      const node = new IdentifiableString(0, 'foo')
+      graph.addNode(node)
+      graph.removeNode(node)
+
+      expect(graph.hasNode(node)).toBe(false)
+    })
   })
 
-  it('#hasNode when there is node', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+  describe('addEdge', () => {
+    it('does not add duplicated edges', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-    const node = new IdentifiableString(0, 'foo')
-    graph.addNode(node)
+      const node0 = new IdentifiableString(0, 'foo')
+      const node1 = new IdentifiableString(1, 'bar')
+      graph.addNode(node0)
+      graph.addNode(node1)
+      graph.addEdge(node0, node1)
+      graph.addEdge(node0, node1)
 
-    expect(graph.hasNode(node)).toBe(true)
+      expect(graph.adjacentNodes(node0)).toEqual(new Set([node1]))
+    })
+
+    it('throws error when the origin node is not present', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node = new IdentifiableString(1, 'target')
+      graph.addNode(node)
+
+      expect(() => {
+        graph.addEdge(new IdentifiableString(0, 'origin'), node)
+      }).toThrowError(/Unknown node/)
+    })
+
+    it('throws error when the target node is not present', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node = new IdentifiableString(0, 'origin')
+      graph.addNode(node)
+
+      expect(() => {
+        graph.addEdge(node, new IdentifiableString(1, 'target'))
+      }).toThrowError(/Unknown node/)
+    })
   })
 
-  it('#hasNode when there is no node', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+  describe('removeEdge', () => {
+    it('throws error when edge does not exist', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node0 = new IdentifiableString(0, 'x0')
+      const node1 = new IdentifiableString(1, 'x1')
+      graph.addNode(node0)
+      graph.addNode(node1)
 
-    const node = new IdentifiableString(0, 'foo')
-    graph.addNode(node)
+      expect(() => graph.removeEdge(node0, node1)).toThrowError('Edge does not exist')
+    })
 
-    expect(graph.hasNode(new IdentifiableString(1, 'foo'))).toBe(false)
+    it('removes an edge it it exists', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node0 = new IdentifiableString(0, 'x0')
+      const node1 = new IdentifiableString(1, 'x1')
+
+      graph.addNode(node0)
+      graph.addNode(node1)
+      expect(graphEdgesCount(graph)).toEqual(0)
+
+      graph.addEdge(node0, node1)
+      expect(graphEdgesCount(graph)).toEqual(1)
+      expect(graph.existsEdge(node0, node1)).toBe(true)
+
+      graph.removeEdge(node0, node1)
+      expect(graphEdgesCount(graph)).toEqual(0)
+      expect(graph.existsEdge(node0, node1)).toBe(false)
+    })
   })
 
-  it('#adjacentNodes', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+  describe('existsEdge', () => {
+    it('returns true if edge is present in the graph', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node0 = new IdentifiableString(0, 'foo')
+      const node1 = new IdentifiableString(1, 'bar')
+      graph.addNode(node0)
+      graph.addNode(node1)
+      graph.addEdge(node0, node1)
 
-    const node0 = new IdentifiableString(0, 'foo')
-    const node1 = new IdentifiableString(1, 'bar')
-    graph.addNode(node0)
-    graph.addNode(node1)
-    graph.addEdge(node0, node1)
+      expect(graph.existsEdge(node0, node1)).toBe(true)
+    })
 
-    expect(graph.adjacentNodes(node0)).toEqual(new Set([node1]))
+    it('returns false if edge is not present', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node0 = new IdentifiableString(0, 'foo')
+      const node1 = new IdentifiableString(1, 'bar')
+      graph.addNode(node0)
+      graph.addNode(node1)
+
+      expect(graph.existsEdge(node0, node1)).toBe(false)
+    })
+
+    it('returns false if nodes are not present in the graph', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+
+      expect(graph.existsEdge(new IdentifiableString(0, 'foo'), new IdentifiableString(1, 'bar'))).toBe(false)
+    })
   })
 
-  it('#addEdge removes multiple edges', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+  describe('adjacentNodes', () => {
+    it('returns all target nodes adjacent to the given node', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-    const node0 = new IdentifiableString(0, 'foo')
-    const node1 = new IdentifiableString(1, 'bar')
-    graph.addNode(node0)
-    graph.addNode(node1)
-    graph.addEdge(node0, node1)
-    graph.addEdge(node0, node1)
+      const node0 = new IdentifiableString(0, 'foo')
+      const node1 = new IdentifiableString(1, 'bar')
+      graph.addNode(node0)
+      graph.addNode(node1)
+      graph.addEdge(node0, node1)
 
-    expect(graph.adjacentNodes(node0)).toEqual(new Set([node1]))
+      expect(graph.adjacentNodes(node0)).toEqual(new Set([node1]))
+    })
   })
 
-  it('#addEdge is raising an error when the origin node not present', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node = new IdentifiableString(1, 'target')
-    graph.addNode(node)
+  describe('topSortWithScc', () => {
+    it('works for empty graph', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
 
-    expect(() => {
-      graph.addEdge(new IdentifiableString(0, 'origin'), node)
-    }).toThrowError(/Unknown node/)
+      expect(graph.topSortWithScc().sorted).toEqual([])
+      expect(graph.topSortWithScc().cycled).toEqual([])
+    })
+
+    it('returns isolated vertices', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node = new IdentifiableString(0, 'foo')
+      graph.addNode(node)
+
+      expect(graph.topSortWithScc().sorted).toEqual([node])
+      expect(graph.topSortWithScc().cycled).toEqual([])
+    })
+
+    it('returns vertices in order corresponding to the edge direction', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node0 = new IdentifiableString(0, 'foo')
+      const node1 = new IdentifiableString(1, 'bar')
+      graph.addNode(node0)
+      graph.addNode(node1)
+      graph.addEdge(node1, node0)
+
+      expect(graph.topSortWithScc().sorted).toEqual([node1, node0])
+      expect(graph.topSortWithScc().cycled).toEqual([])
+    })
+
+    it('works for 4-edges acyclic graph', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node0 = new IdentifiableString(0, 'x0')
+      const node1 = new IdentifiableString(1, 'x1')
+      const node2 = new IdentifiableString(2, 'x2')
+      const node3 = new IdentifiableString(3, 'x3')
+      const node4 = new IdentifiableString(4, 'x4')
+      graph.addNode(node0)
+      graph.addNode(node1)
+      graph.addNode(node2)
+      graph.addNode(node3)
+      graph.addNode(node4)
+      graph.addEdge(node0, node2)
+      graph.addEdge(node1, node2)
+      graph.addEdge(node2, node3)
+      graph.addEdge(node4, node3)
+
+      expect(graph.topSortWithScc().sorted).toEqual([node0, node1, node2, node4, node3])
+      expect(graph.topSortWithScc().cycled).toEqual([])
+    })
+
+    it('works for a graph with multiple connected components', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node0 = new IdentifiableString(0, 'x0')
+      const node1 = new IdentifiableString(1, 'x1')
+      const node2 = new IdentifiableString(2, 'x2')
+      const node3 = new IdentifiableString(3, 'x3')
+      graph.addNode(node0)
+      graph.addNode(node1)
+      graph.addNode(node2)
+      graph.addNode(node3)
+      graph.addEdge(node0, node2)
+      graph.addEdge(node1, node3)
+
+      expect(graph.topSortWithScc().sorted).toEqual([node0, node1, node2, node3])
+      expect(graph.topSortWithScc().cycled).toEqual([])
+    })
+
+    it('detects cycles', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node0 = new IdentifiableString(0, 'x0')
+      const node1 = new IdentifiableString(1, 'x1')
+      graph.addNode(node0)
+      graph.addNode(node1)
+      graph.addEdge(node0, node1)
+      graph.addEdge(node1, node0)
+
+      expect(graph.topSortWithScc().sorted).toEqual([])
+      expect(new Set(graph.topSortWithScc().cycled)).toEqual(new Set([node0, node1]))
+    })
+
+    it('detects 1-node cycles', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node0 = new IdentifiableString(0, 'x0')
+      const node1 = new IdentifiableString(1, 'x1')
+      const node2 = new IdentifiableString(2, 'x2')
+      graph.addNode(node0)
+      graph.addNode(node1)
+      graph.addNode(node2)
+      graph.addEdge(node0, node1)
+      graph.addEdge(node1, node2)
+      graph.addEdge(node1, node1)
+
+      expect(graph.topSortWithScc().sorted).toEqual([node0, node2])
+      expect(graph.topSortWithScc().cycled).toEqual([node1])
+    })
   })
 
-  it('#addEdge is raising an error when the target node not present', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node = new IdentifiableString(0, 'origin')
-    graph.addNode(node)
+  describe('getTopSortedWithSccSubgraphFrom', () => {
+    it('calls the operatingFunction callback for sorted nodes', () => {
+      const graph = new Graph<string>(dummyDependencyQuery)
+      const node0 = 'foo'
+      const node1 = 'bar'
+      graph.addNode(node0)
+      graph.addNode(node1)
 
-    expect(() => {
-      graph.addEdge(node, new IdentifiableString(1, 'target'))
-    }).toThrowError(/Unknown node/)
+      const operatingFunction = jasmine.createSpy().and.returnValue(true)
+      const onCycle = jasmine.createSpy()
+
+      graph.getTopSortedWithSccSubgraphFrom([node0], operatingFunction, onCycle)
+
+      expect(operatingFunction).toHaveBeenCalledTimes(1)
+      expect(operatingFunction.calls.argsFor(0)).toContain(node0)
+    })
+
+    it('works for graph with an edge', () => {
+      const graph = new Graph<string>(dummyDependencyQuery)
+      const node0 = 'foo'
+      const node1 = 'bar'
+
+      graph.addNode(node0)
+      graph.addNode(node1)
+      graph.addEdge(node0, node1)
+
+      const operatingFunction = jasmine.createSpy().and.returnValue(true)
+      const onCycle = jasmine.createSpy()
+
+      graph.getTopSortedWithSccSubgraphFrom([node0], operatingFunction, onCycle)
+
+      expect(operatingFunction).toHaveBeenCalledTimes(2)
+      expect(operatingFunction.calls.argsFor(0)).toContain(node0)
+      expect(operatingFunction.calls.argsFor(1)).toContain(node1)
+    })
+
+    it('omits nodes not reachable from the "modifiedNodes" array', () => {
+      const graph = new Graph<string>(dummyDependencyQuery)
+      const node0 = 'foo'
+      const node1 = 'bar'
+
+      graph.addNode(node0)
+      graph.addNode(node1)
+      graph.addEdge(node0, node1)
+
+      const operatingFunction = jasmine.createSpy().and.returnValue(false)
+      const onCycle = jasmine.createSpy()
+
+      graph.getTopSortedWithSccSubgraphFrom([node0], operatingFunction, onCycle)
+
+      expect(operatingFunction).toHaveBeenCalledTimes(1)
+      expect(operatingFunction.calls.argsFor(0)).toContain(node0)
+    })
+
+    it('calls the operatingFunction for a node not included but reachable from the "modifiedNodes" array', () => {
+      const graph = new Graph<string>(dummyDependencyQuery)
+      const nodes = ['foo', 'bar', 'baz']
+
+      nodes.forEach((n) => graph.addNode(n))
+      graph.addEdge(nodes[0], nodes[2])
+      graph.addEdge(nodes[1], nodes[2])
+
+      const operatingFunction = jasmine.createSpy().and.callFake((node: string) => node === nodes[0])
+      const onCycle = jasmine.createSpy()
+
+      graph.getTopSortedWithSccSubgraphFrom([nodes[0], nodes[1]], operatingFunction, onCycle)
+
+      expect(operatingFunction).toHaveBeenCalledTimes(3)
+      expect(operatingFunction.calls.argsFor(2)).toContain(nodes[2])
+    })
+
+    it('calls onCycle callback for nodes that are on cycle', () => {
+      const graph = new Graph<string>(dummyDependencyQuery)
+      const nodes = ['foo', 'c0', 'c1', 'c2']
+
+      nodes.forEach((n) => graph.addNode(n))
+      graph.addEdge(nodes[0], nodes[1])
+      graph.addEdge(nodes[1], nodes[2])
+      graph.addEdge(nodes[2], nodes[3])
+      graph.addEdge(nodes[3], nodes[1])
+
+      const operatingFunction = jasmine.createSpy().and.returnValue(true)
+      const onCycle = jasmine.createSpy()
+      const cycled = graph.getTopSortedWithSccSubgraphFrom([nodes[0]], operatingFunction, onCycle).cycled
+
+      expect(operatingFunction).toHaveBeenCalledTimes(1)
+      expect(onCycle).toHaveBeenCalledTimes(3)
+      expect(cycled).toEqual(['c0', 'c1', 'c2'])
+    })
+
+    it('does not call operatingFunction callback for nodes that are on cycle', () => {
+      const graph = new Graph<string>(dummyDependencyQuery)
+      const nodes = ['c0', 'c1', 'c2']
+      nodes.forEach((n) => graph.addNode(n))
+      graph.addEdge(nodes[0], nodes[1])
+      graph.addEdge(nodes[1], nodes[2])
+      graph.addEdge(nodes[2], nodes[0])
+
+      const operatingFunction = jasmine.createSpy().and.returnValue(true)
+      const onCycle = jasmine.createSpy()
+      const cycled = graph.getTopSortedWithSccSubgraphFrom([nodes[0]], operatingFunction, onCycle).cycled
+
+      expect(operatingFunction).not.toHaveBeenCalled()
+      expect(cycled).toEqual(['c0', 'c1', 'c2'])
+    })
+
+    it('detects a cycle consisting of nodes not included but reachable from the "modifiedNodes" array', () => {
+      const graph = new Graph<string>(dummyDependencyQuery)
+      const nodes = ['foo', 'c0', 'c1', 'c2']
+      nodes.forEach((n) => graph.addNode(n))
+      graph.addEdge(nodes[0], nodes[1])
+      graph.addEdge(nodes[1], nodes[2])
+      graph.addEdge(nodes[2], nodes[3])
+      graph.addEdge(nodes[3], nodes[1])
+
+      const operatingFunction = jasmine.createSpy().and.returnValue(true)
+      const onCycle = jasmine.createSpy()
+      const cycled = graph.getTopSortedWithSccSubgraphFrom([nodes[0]], operatingFunction, onCycle).cycled
+
+      expect(operatingFunction).toHaveBeenCalledTimes(1)
+      expect(cycled).toEqual(['c0', 'c1', 'c2'])
+    })
   })
-
-  it('#existsEdge works', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node0 = new IdentifiableString(0, 'foo')
-    const node1 = new IdentifiableString(1, 'bar')
-    graph.addNode(node0)
-    graph.addNode(node1)
-    graph.addEdge(node0, node1)
-
-    expect(graph.existsEdge(node0, node1)).toBe(true)
-  })
-
-  it('#existsEdge when there is origin node but no edge', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node = new IdentifiableString(0, 'foo')
-    graph.addNode(node)
-
-    expect(graph.existsEdge(node, new IdentifiableString(1, 'bar'))).toBe(false)
-  })
-
-  it('#existsEdge when there is no node', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-
-    expect(graph.existsEdge(new IdentifiableString(0, 'foo'), new IdentifiableString(1, 'bar'))).toBe(false)
-  })
-
-  it('#topologicalSort for empty graph', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-
-    expect(graph.topSortWithScc().sorted).toEqual([])
-    expect(graph.topSortWithScc().cycled).toEqual([])
-  })
-
-  it('#topologicalSort node is included even if it is not connected to anything', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node = new IdentifiableString(0, 'foo')
-    graph.addNode(node)
-
-    expect(graph.topSortWithScc().sorted).toEqual([node])
-    expect(graph.topSortWithScc().cycled).toEqual([])
-  })
-
-  it('#topologicalSort for simple graph', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node0 = new IdentifiableString(0, 'foo')
-    const node1 = new IdentifiableString(1, 'bar')
-    graph.addNode(node0)
-    graph.addNode(node1)
-    graph.addEdge(node1, node0)
-
-    expect(graph.topSortWithScc().sorted).toEqual([node1, node0])
-    expect(graph.topSortWithScc().cycled).toEqual([])
-  })
-
-  it('#topologicalSort for more complex graph', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node0 = new IdentifiableString(0, 'x0')
-    const node1 = new IdentifiableString(1, 'x1')
-    const node2 = new IdentifiableString(2, 'x2')
-    const node3 = new IdentifiableString(3, 'x3')
-    const node4 = new IdentifiableString(4, 'x4')
-    graph.addNode(node0)
-    graph.addNode(node1)
-    graph.addNode(node2)
-    graph.addNode(node3)
-    graph.addNode(node4)
-    graph.addEdge(node0, node2)
-    graph.addEdge(node1, node2)
-    graph.addEdge(node2, node3)
-    graph.addEdge(node4, node3)
-
-    expect(graph.topSortWithScc().sorted).toEqual([node0, node1, node2, node4, node3])
-    expect(graph.topSortWithScc().cycled).toEqual([])
-  })
-
-  it('#topologicalSort for not connected graph', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node0 = new IdentifiableString(0, 'x0')
-    const node1 = new IdentifiableString(1, 'x1')
-    const node2 = new IdentifiableString(2, 'x2')
-    const node3 = new IdentifiableString(3, 'x3')
-    graph.addNode(node0)
-    graph.addNode(node1)
-    graph.addNode(node2)
-    graph.addNode(node3)
-    graph.addEdge(node0, node2)
-    graph.addEdge(node1, node3)
-
-    expect(graph.topSortWithScc().sorted).toEqual([node0, node1, node2, node3])
-    expect(graph.topSortWithScc().cycled).toEqual([])
-  })
-
-  it('#topologicalSort returns vertices on trivial cycle', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node0 = new IdentifiableString(0, 'x0')
-    const node1 = new IdentifiableString(1, 'x1')
-    graph.addNode(node0)
-    graph.addNode(node1)
-    graph.addEdge(node0, node1)
-    graph.addEdge(node1, node0)
-
-    expect(graph.topSortWithScc().sorted).toEqual([])
-    expect(new Set(graph.topSortWithScc().cycled)).toEqual(new Set([node0, node1]))
-  })
-
-  it('#topologicalSort returns vertices on cycle', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node0 = new IdentifiableString(0, 'x0')
-    const node1 = new IdentifiableString(1, 'x1')
-    const node2 = new IdentifiableString(2, 'x2')
-    graph.addNode(node0)
-    graph.addNode(node1)
-    graph.addNode(node2)
-    graph.addEdge(node0, node1)
-    graph.addEdge(node1, node2)
-    graph.addEdge(node1, node1)
-
-    expect(graph.topSortWithScc().sorted).toEqual([node0, node2])
-    expect(graph.topSortWithScc().cycled).toEqual([node1])
-  })
-
-  it('#topologicalSort returns one-element cycle', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node = new IdentifiableString(0, 'foo')
-    graph.addNode(node)
-    graph.addEdge(node, node)
-
-    expect(graph.topSortWithScc().sorted).toEqual([])
-    expect(graph.topSortWithScc().cycled).toEqual([node])
-  })
-
-  it('#removeEdge not existing edge', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node0 = new IdentifiableString(0, 'x0')
-    const node1 = new IdentifiableString(1, 'x1')
-    graph.addNode(node0)
-    graph.addNode(node1)
-
-    expect(() => graph.removeEdge(node0, node1)).toThrowError('Edge does not exist')
-  })
-
-  it('#removeEdge removes edge from graph', () => {
-    const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
-    const node0 = new IdentifiableString(0, 'x0')
-    const node1 = new IdentifiableString(1, 'x1')
-
-    graph.addNode(node0)
-    graph.addNode(node1)
-
-    graph.addEdge(node0, node1)
-    expect(graphEdgesCount(graph)).toEqual(1)
-    expect(graph.existsEdge(node0, node1)).toBe(true)
-
-    graph.removeEdge(node0, node1)
-    expect(graphEdgesCount(graph)).toEqual(0)
-    expect(graph.existsEdge(node0, node1)).toBe(false)
-  })
-
-describe('getTopSortedWithSccSubgraphFrom', () => {
-  it('case without edges', () => {
-    const graph = new Graph<string>(dummyDependencyQuery)
-    const node0 = 'foo'
-    const node1 = 'bar'
-    graph.addNode(node0)
-    graph.addNode(node1)
-
-    const fn = jasmine.createSpy().and.returnValue(true)
-    const fn2 = jasmine.createSpy()
-
-    graph.getTopSortedWithSccSubgraphFrom([node0], fn, fn2)
-
-    expect(fn).toHaveBeenCalledTimes(1)
-    expect(fn.calls.argsFor(0)).toContain(node0)
-  })
-
-  it('case with obvious edge', () => {
-    const graph = new Graph<string>(dummyDependencyQuery)
-    const node0 = 'foo'
-    const node1 = 'bar'
-
-    graph.addNode(node0)
-    graph.addNode(node1)
-    graph.addEdge(node0, node1)
-
-    const fn = jasmine.createSpy().and.returnValue(true)
-    const fn2 = jasmine.createSpy()
-
-    graph.getTopSortedWithSccSubgraphFrom([node0], fn, fn2)
-
-    expect(fn).toHaveBeenCalledTimes(2)
-    expect(fn.calls.argsFor(0)).toContain(node0)
-    expect(fn.calls.argsFor(1)).toContain(node1)
-  })
-
-  it('it doesnt call other if didnt change', () => {
-    const graph = new Graph<string>(dummyDependencyQuery)
-    const node0 = 'foo'
-    const node1 = 'bar'
-
-    graph.addNode(node0)
-    graph.addNode(node1)
-    graph.addEdge(node0, node1)
-
-    const fn = jasmine.createSpy().and.returnValue(false)
-    const fn2 = jasmine.createSpy()
-
-    graph.getTopSortedWithSccSubgraphFrom([node0], fn, fn2)
-
-    expect(fn).toHaveBeenCalledTimes(1)
-    expect(fn.calls.argsFor(0)).toContain(node0)
-  })
-
-  it('does call if some previous vertex marked as changed', () => {
-    const graph = new Graph<string>(dummyDependencyQuery)
-    const nodes = ['foo', 'bar', 'baz']
-
-    nodes.forEach((n) => graph.addNode(n))
-    graph.addEdge(nodes[0], nodes[2])
-    graph.addEdge(nodes[1], nodes[2])
-
-    const fn = jasmine.createSpy().and.callFake((node: string) => node === nodes[0])
-    const fn2 = jasmine.createSpy()
-
-    graph.getTopSortedWithSccSubgraphFrom([nodes[0], nodes[1]], fn, fn2)
-
-    expect(fn).toHaveBeenCalledTimes(3)
-    expect(fn.calls.argsFor(2)).toContain(nodes[2])
-  })
-
-  it('returns cycled vertices', () => {
-    const graph = new Graph<string>(dummyDependencyQuery)
-    const nodes = ['foo', 'c0', 'c1', 'c2']
-
-    nodes.forEach((n) => graph.addNode(n))
-    graph.addEdge(nodes[0], nodes[1])
-    graph.addEdge(nodes[1], nodes[2])
-    graph.addEdge(nodes[2], nodes[3])
-    graph.addEdge(nodes[3], nodes[1])
-
-    const fn = jasmine.createSpy().and.returnValue(true)
-    const fn2 = jasmine.createSpy()
-    const cycled = graph.getTopSortedWithSccSubgraphFrom([nodes[0]], fn, fn2).cycled
-
-    expect(fn).toHaveBeenCalledTimes(1)
-    expect(cycled).toEqual(['c0', 'c1', 'c2'])
-  })
-
-  it('doesnt call first one of the given vertices if its on cycle', () => {
-    const graph = new Graph<string>(dummyDependencyQuery)
-    const nodes = ['c0', 'c1', 'c2']
-    nodes.forEach((n) => graph.addNode(n))
-    graph.addEdge(nodes[0], nodes[1])
-    graph.addEdge(nodes[1], nodes[2])
-    graph.addEdge(nodes[2], nodes[0])
-
-    const fn = jasmine.createSpy().and.returnValue(true)
-    const fn2 = jasmine.createSpy()
-    const cycled = graph.getTopSortedWithSccSubgraphFrom([nodes[0]], fn, fn2).cycled
-
-    expect(fn).not.toHaveBeenCalled()
-    expect(cycled).toEqual(['c0', 'c1', 'c2'])
-  })
-
-  it('returns cycled vertices even if they were not tried to be computed', () => {
-    const graph = new Graph<string>(dummyDependencyQuery)
-    const nodes = ['foo', 'c0', 'c1', 'c2']
-    nodes.forEach((n) => graph.addNode(n))
-    graph.addEdge(nodes[0], nodes[1])
-    graph.addEdge(nodes[1], nodes[2])
-    graph.addEdge(nodes[2], nodes[3])
-    graph.addEdge(nodes[3], nodes[1])
-
-    const fn = jasmine.createSpy().and.returnValue(true)
-    const fn2 = jasmine.createSpy()
-    const cycled = graph.getTopSortedWithSccSubgraphFrom([nodes[0]], fn, fn2).cycled
-
-    expect(fn).toHaveBeenCalledTimes(1)
-    expect(cycled).toEqual(['c0', 'c1', 'c2'])
-  })
-})
 })

--- a/test/graph.spec.ts
+++ b/test/graph.spec.ts
@@ -140,6 +140,24 @@ describe('Graph class', () => {
   })
 
   describe('removeEdge', () => {
+    it('throws error when source node does not exist', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node0 = new IdentifiableString(0, 'x0')
+      const node1 = new IdentifiableString(1, 'x1')
+      graph.addNode(node1)
+
+      expect(() => graph.removeEdge(node0, node1)).toThrowError(/Unknown node/)
+    })
+
+    it('throws error when target node does not exist', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node0 = new IdentifiableString(0, 'x0')
+      const node1 = new IdentifiableString(1, 'x1')
+      graph.addNode(node0)
+
+      expect(() => graph.removeEdge(node0, node1)).toThrowError(/Unknown node/)
+    })
+
     it('throws error when edge does not exist', () => {
       const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
       const node0 = new IdentifiableString(0, 'x0')
@@ -209,6 +227,44 @@ describe('Graph class', () => {
       graph.addEdge(node0, node1)
 
       expect(graph.adjacentNodes(node0)).toEqual(new Set([node1]))
+    })
+
+    it('throws error if the source node is not present in the graph', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+
+      const node0 = new IdentifiableString(0, 'foo')
+      const node1 = new IdentifiableString(1, 'bar')
+      graph.addNode(node0)
+      graph.addNode(node1)
+      graph.addEdge(node0, node1)
+
+      expect(() => graph.adjacentNodes(new IdentifiableString(42, 'baz'))).toThrowError(/Unknown node/)
+    })
+  })
+
+  describe('adjacentNodesCount', () => {
+    it('returns number of outgoing edges from a given node', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+
+      const node0 = new IdentifiableString(0, 'foo')
+      const node1 = new IdentifiableString(1, 'bar')
+      graph.addNode(node0)
+      graph.addNode(node1)
+      graph.addEdge(node0, node1)
+
+      expect(graph.adjacentNodesCount(node0)).toEqual(1)
+    })
+
+    it('throws error if the source node is not present in the graph', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+
+      const node0 = new IdentifiableString(0, 'foo')
+      const node1 = new IdentifiableString(1, 'bar')
+      graph.addNode(node0)
+      graph.addNode(node1)
+      graph.addEdge(node0, node1)
+
+      expect(() => graph.adjacentNodesCount(new IdentifiableString(42, 'baz'))).toThrowError(/Unknown node/)
     })
   })
 
@@ -430,6 +486,67 @@ describe('Graph class', () => {
 
       expect(operatingFunction).toHaveBeenCalledTimes(1)
       expect(cycled).toEqual(['c0', 'c1', 'c2'])
+    })
+  })
+
+  describe('markNodeAsSpecial', () => {
+    it('adds a node to special nodes array', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node = new IdentifiableString(0, 'foo')
+
+      graph.addNode(node)
+      graph.markNodeAsSpecial(node)
+
+      expect(graph.specialNodes).toEqual(new Set([node]))
+    })
+
+    it('does nothing if node is not in a graph', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node = new IdentifiableString(0, 'foo')
+
+      graph.markNodeAsSpecial(node)
+      expect(graph.specialNodes).toEqual(new Set([]))
+
+    })
+  })
+
+  describe('markNodeAsChangingWithStructure', () => {
+    it('adds a node to special nodes structural changes array', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node = new IdentifiableString(0, 'foo')
+
+      graph.addNode(node)
+      graph.markNodeAsChangingWithStructure(node)
+
+      expect(graph.specialNodesStructuralChanges).toEqual(new Set([node]))
+    })
+
+    it('does nothing if node is not in a graph', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node = new IdentifiableString(0, 'foo')
+
+      graph.markNodeAsChangingWithStructure(node)
+      expect(graph.specialNodesStructuralChanges).toEqual(new Set([]))
+    })
+  })
+
+  describe('markNodeAsInfiniteRange', () => {
+    it('adds a node to infiniteRanges array', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node = new IdentifiableString(0, 'foo')
+
+      graph.addNode(node)
+      graph.markNodeAsInfiniteRange(node)
+
+      expect(graph.infiniteRanges).toEqual(new Set([node]))
+    })
+
+    it('does nothing if node is not in a graph', () => {
+      const graph = new Graph<IdentifiableString>(dummyDependencyQuery)
+      const node = new IdentifiableString(0, 'foo')
+
+      graph.markNodeAsInfiniteRange(node)
+      expect(graph.infiniteRanges).toEqual(new Set([]))
     })
   })
 })

--- a/test/named-expressions.spec.ts
+++ b/test/named-expressions.spec.ts
@@ -695,7 +695,7 @@ describe('Named expressions - evaluation', () => {
 
     engine.setCellContents(adr('A1'), '=FOO+10')
 
-    const fooVertex = engine.dependencyGraph.fetchNamedExpressionVertex('FOO', 0)
+    const fooVertex = engine.dependencyGraph.fetchNamedExpressionVertex('FOO', 0).vertex
     const a1 = engine.dependencyGraph.fetchCell(adr('A1'))
     expect(engine.graph.existsEdge(fooVertex, a1)).toBe(true)
     expect(engine.getCellValue(adr('A1'))).toEqual(52)
@@ -716,7 +716,7 @@ describe('Named expressions - evaluation', () => {
 
     engine.addNamedExpression('FOO', '=42')
 
-    const fooVertex = engine.dependencyGraph.fetchNamedExpressionVertex('FOO', 0)
+    const fooVertex = engine.dependencyGraph.fetchNamedExpressionVertex('FOO', 0).vertex
     const a1 = engine.dependencyGraph.fetchCell(adr('A1'))
     expect(engine.graph.existsEdge(fooVertex, a1)).toBe(true)
     expect(engine.getCellValue(adr('A1'))).toEqual(42)
@@ -739,7 +739,7 @@ describe('Named expressions - evaluation', () => {
 
     engine.setCellContents(adr('A1'), null)
 
-    const fooVertex = engine.dependencyGraph.fetchNamedExpressionVertex('FOO', 0)
+    const fooVertex = engine.dependencyGraph.fetchNamedExpressionVertex('FOO', 0).vertex
     expect(engine.graph.adjacentNodes(fooVertex).size).toBe(0)
   })
 
@@ -761,7 +761,7 @@ describe('Named expressions - evaluation', () => {
 
     engine.setCellContents(adr('A1'), '=FOO+10')
 
-    const localFooVertex = engine.dependencyGraph.fetchNamedExpressionVertex('FOO', 0)!
+    const localFooVertex = engine.dependencyGraph.fetchNamedExpressionVertex('FOO', 0).vertex
     const globalFooVertex = engine.dependencyGraph.fetchCell(engine.dependencyGraph.namedExpressions.namedExpressionForScope('FOO')!.address)
     const a1 = engine.dependencyGraph.fetchCell(adr('A1'))
     expect(engine.graph.existsEdge(localFooVertex, a1)).toBe(true)
@@ -938,8 +938,8 @@ describe('Named expressions - cross scope', () => {
     expect(engine.getCellValue(adr('B1', 0))).toBe(null)
     expect(engine.getCellValue(adr('B1', 1))).toEqual('bar')
     // ensure edges are correct
-    const sourceScopeNEVertex = engine.dependencyGraph.fetchNamedExpressionVertex('expr', 0)
-    const targetScopeNEVertex = engine.dependencyGraph.fetchNamedExpressionVertex('expr', 1)
+    const sourceScopeNEVertex = engine.dependencyGraph.fetchNamedExpressionVertex('expr', 0).vertex
+    const targetScopeNEVertex = engine.dependencyGraph.fetchNamedExpressionVertex('expr', 1).vertex
     const targetFormulaVertex = engine.dependencyGraph.getCell(adr('B1', 1))!
     expect(engine.dependencyGraph.existsEdge(sourceScopeNEVertex, targetFormulaVertex)).toBe(false)
     expect(engine.dependencyGraph.existsEdge(targetScopeNEVertex, targetFormulaVertex)).toBe(true)
@@ -963,8 +963,8 @@ describe('Named expressions - cross scope', () => {
     expect(engine.getCellValue(adr('B1', 0))).toBe(null)
     expect(engine.getCellValue(adr('B1', 1))).toEqual('bar')
     // ensure edges are correct
-    const sourceScopeNEVertex = engine.dependencyGraph.fetchNamedExpressionVertex('expr', 0)
-    const targetScopeNEVertex = engine.dependencyGraph.fetchNamedExpressionVertex('expr', 1)
+    const sourceScopeNEVertex = engine.dependencyGraph.fetchNamedExpressionVertex('expr', 0).vertex
+    const targetScopeNEVertex = engine.dependencyGraph.fetchNamedExpressionVertex('expr', 1).vertex
     const targetFormulaVertex = engine.dependencyGraph.getCell(adr('B1', 1))!
     expect(engine.dependencyGraph.existsEdge(sourceScopeNEVertex, targetFormulaVertex)).toBe(false)
     expect(engine.dependencyGraph.existsEdge(targetScopeNEVertex, targetFormulaVertex)).toBe(true)
@@ -988,8 +988,8 @@ describe('Named expressions - cross scope', () => {
     expect(engine.getCellValue(adr('B1', 0))).toEqual('foo')
     expect(engine.getCellValue(adr('B1', 1))).toEqual('bar')
     // ensure edges are correct
-    const sourceScopeNEVertex = engine.dependencyGraph.fetchNamedExpressionVertex('expr', 0)
-    const targetScopeNEVertex = engine.dependencyGraph.fetchNamedExpressionVertex('expr', 1)
+    const sourceScopeNEVertex = engine.dependencyGraph.fetchNamedExpressionVertex('expr', 0).vertex
+    const targetScopeNEVertex = engine.dependencyGraph.fetchNamedExpressionVertex('expr', 1).vertex
     const targetFormulaVertex = engine.dependencyGraph.getCell(adr('B1', 1))!
     expect(engine.dependencyGraph.existsEdge(sourceScopeNEVertex, targetFormulaVertex)).toBe(false)
     expect(engine.dependencyGraph.existsEdge(targetScopeNEVertex, targetFormulaVertex)).toBe(true)

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -272,7 +272,6 @@ export function graphEdgesCount<T>(graph: Graph<T>): number {
 export function graphReversedAdjacentNodes<T>(graph: Graph<T>, node: T): T[] {
   const id = (graph as any).nodesIds.get(node)
 
-
   return (graph as any).nodesSparseArray.reduce((acc: number[], sourceNode: T, sourceId: number) =>
     sourceNode && (graph as any).edgesSparseArray[sourceId].includes(id)
       ? [ ...acc, sourceId ]

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -71,7 +71,7 @@ export const verifyRangesInSheet = (engine: HyperFormula, sheet: number, ranges:
   const rangeVerticesInMapping = Array.from(engine.rangeMapping.rangesInSheet(sheet))
     .map((vertex) => rangeAddr(vertex.range))
 
-  const rangeVerticesInGraph = Array.from(engine.graph.nodes.values()).filter(vertex => vertex instanceof RangeVertex)
+  const rangeVerticesInGraph = [ ...engine.graph.getNodes()].filter(vertex => vertex instanceof RangeVertex)
     .map(vertex => rangeAddr((vertex as RangeVertex).range))
 
   expectNoDuplicates(rangeVerticesInGraph)

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -268,3 +268,14 @@ export function graphEdgesCount<T>(graph: Graph<T>): number {
     node ? acc + (graph as any).cleanupAdjacentNodeIds(id).length : acc
   , 0)
 }
+
+export function graphReversedAdjacentNodes<T>(graph: Graph<T>, node: T): T[] {
+  const id = (graph as any).nodesIds.get(node)
+
+
+  return (graph as any).nodesSparseArray.reduce((acc: number[], sourceNode: T, sourceId: number) =>
+    sourceNode && (graph as any).edgesSparseArray[sourceId].includes(id)
+      ? [ ...acc, sourceId ]
+      : acc
+  , []).map((resultId: number) => (graph as any).nodesSparseArray[resultId])
+}

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -3,7 +3,7 @@ import {AbsoluteCellRange, AbsoluteColumnRange, AbsoluteRowRange} from '../src/A
 import {CellError, SimpleCellAddress, simpleCellAddress} from '../src/Cell'
 import {Config} from '../src/Config'
 import {DateTimeHelper} from '../src/DateTimeHelper'
-import {ArrayVertex, FormulaCellVertex, RangeVertex} from '../src/DependencyGraph'
+import {ArrayVertex, FormulaCellVertex, Graph, RangeVertex} from '../src/DependencyGraph'
 import {ErrorMessage} from '../src/error-message'
 import {defaultStringifyDateTime} from '../src/format/format'
 import {complex} from '../src/interpreter/ArithmeticHelper'
@@ -257,4 +257,14 @@ export function resetSpy(spy: any): void {
  */
 export function expectCellValueToEqualDate(engine: HyperFormula, cellAddress: SimpleCellAddress, expectedDateString: string) {
   expect(dateNumberToString(engine.getCellValue(cellAddress), new Config())).toEqual(expectedDateString)
+}
+
+/**
+ * Returns number of edges in graph
+ *
+ */
+export function graphEdgesCount<T>(graph: Graph<T>): number {
+  return (graph as any).nodesSparseArray.reduce((acc: number, node: T, id: number) =>
+    node ? acc + (graph as any).cleanupAdjacentNodeIds(id).length : acc
+  , 0)
 }

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -265,7 +265,7 @@ export function expectCellValueToEqualDate(engine: HyperFormula, cellAddress: Si
  */
 export function graphEdgesCount<T>(graph: Graph<T>): number {
   return (graph as any).nodesSparseArray.reduce((acc: number, node: T, id: number) =>
-    node ? acc + (graph as any).cleanupAdjacentNodeIds(id).length : acc
+    node ? acc + ((graph as any).fixEdgesArrayForNode(id) as number[]).length : acc
   , 0)
 }
 

--- a/test/volatile-functions.spec.ts
+++ b/test/volatile-functions.spec.ts
@@ -32,7 +32,7 @@ describe('Interpreter - function RAND', () => {
 
     engine.setCellContents(adr('A1'), '=RAND()')
 
-    const a1 = engine.addressMapping.getCell(adr('A1'))
+    const a1 = engine.addressMapping.getCell(adr('A1'))!
     expect(engine.dependencyGraph.verticesToRecompute()).toEqual([a1])
   })
 
@@ -53,7 +53,7 @@ describe('Interpreter - function RAND', () => {
 
     engine.moveCells(AbsoluteCellRange.spanFrom(adr('A1'), 1, 1), adr('A2'))
 
-    const a2 = engine.addressMapping.getCell(adr('A2'))
+    const a2 = engine.addressMapping.getCell(adr('A2'))!
     expect(engine.dependencyGraph.verticesToRecompute()).toEqual([a2])
   })
 })

--- a/test/volatile-functions.spec.ts
+++ b/test/volatile-functions.spec.ts
@@ -33,7 +33,7 @@ describe('Interpreter - function RAND', () => {
     engine.setCellContents(adr('A1'), '=RAND()')
 
     const a1 = engine.addressMapping.getCell(adr('A1'))
-    expect(engine.dependencyGraph.volatileVertices()).toEqual(new Set([a1]))
+    expect(engine.dependencyGraph.verticesToRecompute()).toEqual([a1])
   })
 
   it('volatile vertices should not be recomputed after removing from graph', () => {
@@ -43,7 +43,7 @@ describe('Interpreter - function RAND', () => {
 
     engine.setCellContents(adr('A1'), '35')
 
-    expect(engine.dependencyGraph.verticesToRecompute()).toEqual(new Set())
+    expect(engine.dependencyGraph.verticesToRecompute()).toEqual([])
   })
 
   it('volatile formula after moving is still volatile', () => {
@@ -54,6 +54,6 @@ describe('Interpreter - function RAND', () => {
     engine.moveCells(AbsoluteCellRange.spanFrom(adr('A1'), 1, 1), adr('A2'))
 
     const a2 = engine.addressMapping.getCell(adr('A2'))
-    expect(engine.dependencyGraph.volatileVertices()).toEqual(new Set([a2]))
+    expect(engine.dependencyGraph.verticesToRecompute()).toEqual([a2])
   })
 })


### PR DESCRIPTION
### Test case

A spreadsheet with 500k rows and 10 columns filled with string data. Total of 5M data cells, no formulas.

Script:
```ts
const hf = HyperFormula.buildFromArray([], {
  licenseKey: 'gpl-v3',
  maxRows: 500100,
  useStats: true,
  chooseAddressMappingPolicy: new AlwaysDense(),
})

const data = Array(500000).fill(0).map(() => Array(10).fill(0).map(() => 'A500000'))

var ty1 = (new Date()).getTime()
hf.setSheetContent(0, data)
var ty2 = (new Date()).getTime()
console.log(ty2 - ty1)
console.log(hf.getStats())
```

#### Ideas for improvement

- Function `getTopSortedWithSccSubgraphFrom`, which is the iterative implementation of the Tarjan algorithm that performs the topological sorting of the dependency graph and finds cycles (SCCs) in the graph. In this test case, the dependency graph is trivial; it contains only isolated nodes without any edges. It seems that it can be done more efficiently.
- Function `parseDateTimeFromConfigFormats`, which tries to parse all string data as date/time values. This test case contains no date/time values, so there might be some way of saving time by determining it quickly and avoiding running the heavy parsing operations.

### This PR focuses on optimizing topological sorting of the dependency graph

I made the Tarjan algorithm more efficient by changing the data structures it uses. Initially, the information about the graph nodes was stored in maps and sets with nodes as keys:

```ts
    const entranceTime: Map<T, number> = new Map()
    const low: Map<T, number> = new Map()
    const parent: Map<T, T> = new Map()
    const inSCC: Set<T> = new Set()
```
 
My approach was to use simple arrays indexed by integer ids and keep a single array of nodes as a mapping from id to node data.

```ts
  private nodes: T[] = []

  private entranceTime: number[] = []
  private low: number[] = []
  private parent: number[] = []
  private inSCC: boolean[] = []
```

### Results

Total time:
Before: **25923ms**
After: **11160ms**

Function `getTopSortedWithSccSubgraphFrom`:
Before: **51.6%**
After: **23.1%**

Profiler:
Before:
![image](https://github.com/handsontable/hyperformula/assets/2480086/1d26553f-a5f5-4dc4-9e5e-1f408e1f475c)

After:
![image](https://github.com/handsontable/hyperformula/assets/2480086/249b0a10-db02-4226-8a2f-6d908cd26ac2)

Profiler: Chrome Dev Tools

### Overall, I achieved the **56,02%** speed-up of HyperFormula for this use-case.

### How did you test your changes?
<!--- Describe in detail how you tested your changes. -->

- unit tests passed
- new unit tests for the Graph class

Comparison on our existing performance benchmarks on my PC:
```
                                     testName | before |  after
-----------------------------------------------------------------------
                                      Sheet A | 417.77 | 401.12
                                      Sheet B | 133.09 | 129.18
                                      Sheet T | 119.23 | 114.51
                                Column ranges | 292.47 | 408.56   <-- 40% slow-down
Sheet A:  change value, add/remove row/column |     23 |   27.2
 Sheet B: change value, add/remove row/column |    169 |  194.0
                   Column ranges - add column |  136.8 |  137.4
                Column ranges - without batch |  339.2 |  316.8
                        Column ranges - batch |    124 |   80.0
```

#### Column ranges benchmark

The 40% slow-down is observed only in Node environment. Running this benchmark in V8 yields similar results before and after applying the change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [x] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Related issues:
Fixes #876

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [ ] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [x] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [x] My change is compatible with Microsoft Excel.
- [x] My change is compatible with Google Sheets.
- [x] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
