### PR TITLE
fix address key bug in content changes

### DIFF
--- a/src/ContentChanges.ts
+++ b/src/ContentChanges.ts
@@ -62,10 +62,10 @@ export class ContentChanges {
     const value = change.value
     if (value instanceof SimpleRangeValue) {
       for (const cellAddress of value.effectiveAddressesFromData(address)) {
-        this.changes.delete(`${cellAddress.sheet},${cellAddress.col},${cellAddress.row}`)
+        this.changes.delete(addressKey(cellAddress))
       }
     }
-    this.changes.set(addressKey((address)), change)
+    this.changes.set(addressKey(address), change)
   }
 
   private addInterpreterValue(value: InterpreterValue, address: SimpleCellAddress, oldValue?: InterpreterValue) {


### PR DESCRIPTION
### Context
Fixes an issue where the wrong address key was being used (col, row) instead of (row, col).

### How did you test your changes?
Fixes a bug with an internal utility `ContentChanges`. A test would maybe involve an array formula, and a neighboring cell, and checking that the neighboring cell change is exported / not deleted as a result of the array formula change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Related issues:
1. Fixes https://github.com/handsontable/hyperformula/issues/1291

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [x] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [x] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [x] My change is compatible with Microsoft Excel.
- [x] My change is compatible with Google Sheets.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
