### PR TITLE
Fix typo in `tranposeArraySize` implementation

### DIFF
--- a/docs/guide/integration-with-angular.md
+++ b/docs/guide/integration-with-angular.md
@@ -8,7 +8,7 @@ more details.
 ## Demo
 
 <iframe
-     src="https://codesandbox.io/embed/github/handsontable/hyperformula-demos/tree/2.5.x/angular-demo?autoresize=1
+     src="https://codesandbox.io/embed/github/handsontable/hyperformula-demos/tree/2.4.x/angular-demo?autoresize=1
      &fontsize=11&hidenavigation=1&theme=light&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="handsontable/hyperformula-demos: angular-demo"

--- a/src/interpreter/plugin/MatrixPlugin.ts
+++ b/src/interpreter/plugin/MatrixPlugin.ts
@@ -260,7 +260,7 @@ export class MatrixPlugin extends FunctionPlugin implements FunctionPluginTypech
     if (ast.args.length !== 1) {
       return ArraySize.error()
     }
-    const metadata = this.metadata('MMULT')
+    const metadata = this.metadata('TRANSPOSE')
     const subChecks = ast.args.map((arg) => this.arraySizeForAst(arg, new InterpreterState(state.formulaAddress, state.arraysFlag || (metadata?.arrayFunction ?? false))))
 
     const [size] = subChecks


### PR DESCRIPTION
### Context
`transposeArraySize` should use the metadata of `"TRANSPOSE"`.

### How did you test your changes?
Untested.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [x] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [x] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [x] My change is compatible with Microsoft Excel.
- [x] My change is compatible with Google Sheets.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
