### PR TITLE
Improve efficiency of the default date/time parsing methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@ and this project adheres to
 
 ### Added
 
-- Exported the `EmptyValue` symbol as a public API. This allows custom functions to handle empty cell values.
-  [#1232](https://github.com/handsontable/hyperformula/issues/1265)
+- Exported the `EmptyValue` symbol as a public API. This allows custom functions to handle empty cell values. [#1232](https://github.com/handsontable/hyperformula/issues/1265)
+
+### Changed
+
+- Improve efficiency of the default date/time parsing methods. [#876](https://github.com/handsontable/hyperformula/issues/876)
 
 ### Fixed
 
-- Fixed a bug where neighboring exported changes of an array formula were missing.
-  [#1291](https://github.com/handsontable/hyperformula/issues/1291)
+- Fixed a bug where neighboring exported changes of an array formula were missing. [#1291](https://github.com/handsontable/hyperformula/issues/1291)
 
 ## [2.5.0] - 2023-05-29
 

--- a/src/DateTimeDefault.ts
+++ b/src/DateTimeDefault.ts
@@ -237,7 +237,6 @@ function doesItLookLikeADateTimeQuickCheck(text: string): boolean {
   return QUICK_CHECK_REGEXP.test(text)
 }
 
-
 /**
  * Function memoization for improved performance.
  */

--- a/src/DateTimeDefault.ts
+++ b/src/DateTimeDefault.ts
@@ -167,22 +167,22 @@ function defaultParseToDate(dateItems: string[], dateFormat: Maybe<string>): May
   let year
   if (dateItems[longYearItem]) {
     const yearString = dateItems[longYearItem]
-    if (/^\d+$/.test(yearString)) {
-      year = Number(yearString)
-      if (year < 1000 || year > 9999) {
+    if (!/^\d+$/.test(yearString)) {
         return undefined
-      }
-    } else {
+    }
+
+    year = Number(yearString)
+    if (year < 1000 || year > 9999) {
       return undefined
     }
   } else {
     const yearString = dateItems[shortYearItem]
-    if (/^\d+$/.test(yearString)) {
-      year = Number(yearString)
-      if (year < 0 || year > 99) {
-        return undefined
-      }
-    } else {
+    if (!/^\d+$/.test(yearString)) {
+      return undefined
+    }
+
+    year = Number(yearString)
+    if (year < 0 || year > 99) {
       return undefined
     }
   }
@@ -191,14 +191,14 @@ function defaultParseToDate(dateItems: string[], dateFormat: Maybe<string>): May
   if (!/^\d+$/.test(monthString)) {
     return undefined
   }
-
   const month = Number(monthString)
+
   const dayString = dateItems[dayItem]
   if (!/^\d+$/.test(dayString)) {
     return undefined
   }
-
   const day = Number(dayString)
+
   return {year, month, day}
 }
 

--- a/src/DateTimeDefault.ts
+++ b/src/DateTimeDefault.ts
@@ -104,32 +104,29 @@ function defaultParseToTime(timeItems: string[], timeFormat: Maybe<string>): May
     return undefined
   }
 
-  const hourString = hourItem !== -1 ? timeItems[hourItem] : '0'
-  if (!/^\d+$/.test(hourString)) {
+  const secondsParsed = Number(timeItems[secondItem] ?? '0')
+  if (!Number.isFinite(secondsParsed)) {
     return undefined
   }
-  let hours = Number(hourString)
-  if (ampm !== undefined) {
-    if (hours < 0 || hours > 12) {
-      return undefined
-    }
-    hours = hours % 12
-    if (ampm) {
-      hours = hours + 12
-    }
+  const seconds = Math.round(secondsParsed * SECONDS_PRECISION) / SECONDS_PRECISION
+
+  const minutes = Number(timeItems[minuteItem] ?? '0')
+  if (!(Number.isFinite(minutes) && Number.isInteger(minutes))) {
+    return undefined
   }
 
-  const minuteString = minuteItem !== -1 ? timeItems[minuteItem] : '0'
-  if (!/^\d+$/.test(minuteString)) {
+  const hoursParsed = Number(timeItems[hourItem] ?? '0')
+  if (!(Number.isFinite(hoursParsed) && Number.isInteger(hoursParsed))) {
     return undefined
   }
-  const minutes = Number(minuteString)
 
-  const secondString = secondItem !== -1 ? timeItems[secondItem] : '0'
-  if (!/^\d+(\.\d+)?$/.test(secondString)) {
+  if (ampm !== undefined && (hoursParsed < 0 || hoursParsed > 12)) {
     return undefined
   }
-  const seconds = Math.round(Number(secondString) * SECONDS_PRECISION) / SECONDS_PRECISION
+
+  const hours = ampm !== undefined
+  ? hoursParsed % 12 + (ampm ? 12 : 0)
+  : hoursParsed
 
   return { hours, minutes, seconds }
 }
@@ -167,9 +164,7 @@ function defaultParseToDate(dateItems: string[], dateFormat: Maybe<string>): May
     return undefined
   }
 
-  const yearString = dateItems[longYearItem] ?? dateItems[shortYearItem]
-
-  const year = Number(yearString)
+  const year = Number(dateItems[longYearItem] ?? dateItems[shortYearItem])
   if (!(Number.isFinite(year) && Number.isInteger(year))) {
     return undefined
   }

--- a/src/DateTimeDefault.ts
+++ b/src/DateTimeDefault.ts
@@ -6,27 +6,57 @@
 import {DateTime, SimpleDate, SimpleTime} from './DateTimeHelper'
 import {Maybe} from './Maybe'
 
-export function defaultParseToDateTime(dateTimeString: string, dateFormat?: string, timeFormat?: string): Maybe<DateTime> {
-  dateTimeString = dateTimeString.replace(/\s\s+/g, ' ').trim().toLowerCase()
-  let ampmtoken: Maybe<string> = dateTimeString.substring(dateTimeString.length - 2)
-  if (ampmtoken === 'am' || ampmtoken === 'pm') {
+export const TIME_FORMAT_SECONDS_ITEM_REGEXP = new RegExp('^ss(\\.(s+|0+))?$')
+
+const QUICK_CHECK_REGEXP = new RegExp('^[0-9/.\\-: ]+[ap]?m?$')
+const WHITESPACE_REGEXP = new RegExp('\\s+')
+const DATE_SEPARATOR_REGEXP = new RegExp('[ /.-]')
+const TIME_SEPARATOR = ':'
+const SECONDS_PRECISION = 1000
+const memoizedParseTimeFormat = memoize(parseTimeFormat)
+const memoizedParseDateFormat = memoize(parseDateFormat)
+
+/**
+ * Parses a DateTime value from a string if the string matches the given date format and time format.
+ *
+ * Idea for more readable implementation:
+ *   - divide string into parts by a regexp [date_regexp]? [time_regexp]? [ampm_regexp]?
+ *   - start by finding the time part, because it is unambiguous '([0-9]+:[0-9:.]+ ?[ap]?m?)$', before it is the date part
+ *   - OR split by spaces - last segment is ampm token, second to last is time (with or without ampm), rest is date
+ * If applied:
+ *   - date parsing might work differently after these changes but still according to the docs
+ *   - make sure to test edge cases like timeFormats: ['hh', 'ss.ss'] etc, string: '01-01-2019 AM', 'PM'
+ */
+export function defaultParseToDateTime(text: string, dateFormat: Maybe<string>, timeFormat: Maybe<string>): Maybe<DateTime> {
+  if (dateFormat === undefined && timeFormat === undefined) {
+    return undefined
+  }
+
+  let dateTimeString = text.replace(WHITESPACE_REGEXP, ' ').trim().toLowerCase()
+
+  if (!doesItLookLikeADateTimeQuickCheck(dateTimeString)) {
+    return undefined
+  }
+
+  let ampmToken: Maybe<string> = dateTimeString.substring(dateTimeString.length - 2)
+  if (ampmToken === 'am' || ampmToken === 'pm') {
     dateTimeString = dateTimeString.substring(0, dateTimeString.length - 2).trim()
   } else {
-    ampmtoken = dateTimeString.substring(dateTimeString.length - 1)
-    if (ampmtoken === 'a' || ampmtoken === 'p') {
+    ampmToken = dateTimeString.substring(dateTimeString.length - 1)
+    if (ampmToken === 'a' || ampmToken === 'p') {
       dateTimeString = dateTimeString.substring(0, dateTimeString.length - 1).trim()
     } else {
-      ampmtoken = undefined
+      ampmToken = undefined
     }
   }
-  const dateItems = dateTimeString.split(/[ /.-]/g)
-  if (dateItems.length >= 2 && dateItems[dateItems.length - 2].includes(':')) {
+  const dateItems = dateTimeString.split(DATE_SEPARATOR_REGEXP)
+  if (dateItems.length >= 2 && dateItems[dateItems.length - 2].includes(TIME_SEPARATOR)) {
     dateItems[dateItems.length - 2] = dateItems[dateItems.length - 2] + '.' + dateItems[dateItems.length - 1]
     dateItems.pop()
   }
-  const timeItems = dateItems[dateItems.length - 1].split(':')
-  if (ampmtoken !== undefined) {
-    timeItems.push(ampmtoken)
+  const timeItems = dateItems[dateItems.length - 1].split(TIME_SEPARATOR)
+  if (ampmToken !== undefined) {
+    timeItems.push(ampmToken)
   }
 
   if (dateItems.length === 1) {
@@ -46,21 +76,21 @@ export function defaultParseToDateTime(dateTimeString: string, dateFormat?: stri
   }
 }
 
-export const secondsExtendedRegexp = /^ss(\.(s+|0+))?$/
-
+/**
+ * Parses a time value from a string if the string matches the given time format.
+ */
 function defaultParseToTime(timeItems: string[], timeFormat: Maybe<string>): Maybe<SimpleTime> {
-  const precision = 1000
-
   if (timeFormat === undefined) {
     return undefined
   }
-  timeFormat = timeFormat.toLowerCase()
-  if (timeFormat.endsWith('am/pm')) {
-    timeFormat = timeFormat.substring(0, timeFormat.length - 5).trim()
-  } else if (timeFormat.endsWith('a/p')) {
-    timeFormat = timeFormat.substring(0, timeFormat.length - 3).trim()
-  }
-  const formatItems = timeFormat.split(':')
+
+  const {
+    itemsCount,
+    hourItem,
+    minuteItem,
+    secondItem,
+  } = memoizedParseTimeFormat(timeFormat)
+
   let ampm = undefined
   if (timeItems[timeItems.length - 1] === 'am' || timeItems[timeItems.length - 1] === 'a') {
     ampm = false
@@ -70,15 +100,11 @@ function defaultParseToTime(timeItems: string[], timeFormat: Maybe<string>): May
     timeItems.pop()
   }
 
-  if (timeItems.length !== formatItems.length) {
+  if (timeItems.length !== itemsCount) {
     return undefined
   }
 
-  const hourIndex = formatItems.indexOf('hh')
-  const minuteIndex = formatItems.indexOf('mm')
-  const secondIndex = formatItems.findIndex(item => secondsExtendedRegexp.test(item))
-
-  const hourString = hourIndex !== -1 ? timeItems[hourIndex] : '0'
+  const hourString = hourItem !== -1 ? timeItems[hourItem] : '0'
   if (!/^\d+$/.test(hourString)) {
     return undefined
   }
@@ -93,44 +119,49 @@ function defaultParseToTime(timeItems: string[], timeFormat: Maybe<string>): May
     }
   }
 
-  const minuteString = minuteIndex !== -1 ? timeItems[minuteIndex] : '0'
+  const minuteString = minuteItem !== -1 ? timeItems[minuteItem] : '0'
   if (!/^\d+$/.test(minuteString)) {
     return undefined
   }
   const minutes = Number(minuteString)
 
-  const secondString = secondIndex !== -1 ? timeItems[secondIndex] : '0'
+  const secondString = secondItem !== -1 ? timeItems[secondItem] : '0'
   if (!/^\d+(\.\d+)?$/.test(secondString)) {
     return undefined
   }
+  const seconds = Math.round(Number(secondString) * SECONDS_PRECISION) / SECONDS_PRECISION
 
-  const seconds = Math.round(Number(secondString) * precision) / precision
-
-  return {hours, minutes, seconds}
+  return { hours, minutes, seconds }
 }
 
+/**
+ * Parses a date value from a string if the string matches the given date format.
+ */
 function defaultParseToDate(dateItems: string[], dateFormat: Maybe<string>): Maybe<SimpleDate> {
   if (dateFormat === undefined) {
     return undefined
   }
-  const formatItems = dateFormat.toLowerCase().split(/[ /.-]/g)
-  if (dateItems.length !== formatItems.length) {
+  const {
+    itemsCount,
+    dayItem,
+    monthItem,
+    shortYearItem,
+    longYearItem,
+  } = memoizedParseDateFormat(dateFormat)
+
+  if (dateItems.length !== itemsCount) {
     return undefined
   }
-  const monthIndex = formatItems.indexOf('mm')
-  const dayIndex = formatItems.indexOf('dd')
-  const yearIndexLong = formatItems.indexOf('yyyy')
-  const yearIndexShort = formatItems.indexOf('yy')
-  if (!(monthIndex in dateItems) || !(dayIndex in dateItems) ||
-    (!(yearIndexLong in dateItems) && !(yearIndexShort in dateItems))) {
+  if (!(monthItem in dateItems) || !(dayItem in dateItems) ||
+    (!(longYearItem in dateItems) && !(shortYearItem in dateItems))) {
     return undefined
   }
-  if (yearIndexLong in dateItems && yearIndexShort in dateItems) {
+  if (longYearItem in dateItems && shortYearItem in dateItems) {
     return undefined
   }
   let year
-  if (yearIndexLong in dateItems) {
-    const yearString = dateItems[yearIndexLong]
+  if (longYearItem in dateItems) {
+    const yearString = dateItems[longYearItem]
     if (/^\d+$/.test(yearString)) {
       year = Number(yearString)
       if (year < 1000 || year > 9999) {
@@ -140,7 +171,7 @@ function defaultParseToDate(dateItems: string[], dateFormat: Maybe<string>): May
       return undefined
     }
   } else {
-    const yearString = dateItems[yearIndexShort]
+    const yearString = dateItems[shortYearItem]
     if (/^\d+$/.test(yearString)) {
       year = Number(yearString)
       if (year < 0 || year > 99) {
@@ -150,15 +181,77 @@ function defaultParseToDate(dateItems: string[], dateFormat: Maybe<string>): May
       return undefined
     }
   }
-  const monthString = dateItems[monthIndex]
+  const monthString = dateItems[monthItem]
   if (!/^\d+$/.test(monthString)) {
     return undefined
   }
   const month = Number(monthString)
-  const dayString = dateItems[dayIndex]
+  const dayString = dateItems[dayItem]
   if (!/^\d+$/.test(dayString)) {
     return undefined
   }
   const day = Number(dayString)
   return {year, month, day}
+}
+
+/**
+ * Parses a time format string into a format object.
+ */
+function parseTimeFormat(timeFormat: string): { itemsCount: number, hourItem: number, minuteItem: number, secondItem: number } {
+  const formatLowercase = timeFormat.toLowerCase().trim()
+  const formatWithoutAmPmItem = formatLowercase.endsWith('am/pm')
+    ? formatLowercase.substring(0, formatLowercase.length - 5)
+    : (formatLowercase.endsWith('a/p')
+      ? formatLowercase.substring(0, timeFormat.length - 3)
+      : formatLowercase)
+
+  const items = formatWithoutAmPmItem.trim().split(TIME_SEPARATOR)
+  return {
+    itemsCount: items.length,
+    hourItem: items.indexOf('hh'),
+    minuteItem: items.indexOf('mm'),
+    secondItem: items.findIndex(item => TIME_FORMAT_SECONDS_ITEM_REGEXP.test(item)),
+  }
+}
+
+/**
+ * Parses a date format string into a format object.
+ */
+function parseDateFormat(dateFormat: string): { itemsCount: number, dayItem: number, monthItem: number, shortYearItem: number, longYearItem: number } {
+  const items = dateFormat.toLowerCase().trim().split(DATE_SEPARATOR_REGEXP)
+
+  return {
+    itemsCount: items.length,
+    dayItem: items.indexOf('dd'),
+    monthItem: items.indexOf('mm'),
+    shortYearItem: items.indexOf('yy'),
+    longYearItem: items.indexOf('yyyy'),
+  }
+}
+
+/**
+ * If this function returns false, the string is not parsable as a date time. Otherwise, it might be.
+ * This is a quick check that is used to avoid running the more expensive parsing operations.
+ */
+function doesItLookLikeADateTimeQuickCheck(text: string): boolean {
+  return QUICK_CHECK_REGEXP.test(text)
+}
+
+
+/**
+ * Function memoization for improved performance.
+ */
+function memoize<T>(fn: (arg: string) => T) {
+  const memoizedResults: {[key: string]: T} = {}
+
+  return (arg: string) => {
+    const memoizedResult = memoizedResults[arg]
+    if (memoizedResult !== undefined) {
+      return memoizedResult
+    }
+
+    const result = fn(arg)
+    memoizedResults[arg] = result
+    return result
+  }
 }

--- a/src/DateTimeDefault.ts
+++ b/src/DateTimeDefault.ts
@@ -152,15 +152,20 @@ function defaultParseToDate(dateItems: string[], dateFormat: Maybe<string>): May
   if (dateItems.length !== itemsCount) {
     return undefined
   }
-  if (!(monthItem in dateItems) || !(dayItem in dateItems) ||
-    (!(longYearItem in dateItems) && !(shortYearItem in dateItems))) {
+
+  if (!dateItems[monthItem]
+    || !dateItems[dayItem]
+    || (!dateItems[longYearItem] && !dateItems[shortYearItem])
+  ) {
     return undefined
   }
-  if (longYearItem in dateItems && shortYearItem in dateItems) {
+
+  if (dateItems[longYearItem] && dateItems[shortYearItem]) {
     return undefined
   }
+
   let year
-  if (longYearItem in dateItems) {
+  if (dateItems[longYearItem]) {
     const yearString = dateItems[longYearItem]
     if (/^\d+$/.test(yearString)) {
       year = Number(yearString)
@@ -181,15 +186,18 @@ function defaultParseToDate(dateItems: string[], dateFormat: Maybe<string>): May
       return undefined
     }
   }
+
   const monthString = dateItems[monthItem]
   if (!/^\d+$/.test(monthString)) {
     return undefined
   }
+
   const month = Number(monthString)
   const dayString = dateItems[dayItem]
   if (!/^\d+$/.test(dayString)) {
     return undefined
   }
+
   const day = Number(dayString)
   return {year, month, day}
 }

--- a/src/DateTimeDefault.ts
+++ b/src/DateTimeDefault.ts
@@ -153,10 +153,13 @@ function defaultParseToDate(dateItems: string[], dateFormat: Maybe<string>): May
     return undefined
   }
 
-  if (!dateItems[monthItem]
-    || !dateItems[dayItem]
-    || (!dateItems[longYearItem] && !dateItems[shortYearItem])
-  ) {
+  const day = Number(dateItems[dayItem])
+  if (!(Number.isFinite(day) && Number.isInteger(day))) {
+    return undefined
+  }
+
+  const month = Number(dateItems[monthItem])
+  if (!(Number.isFinite(month) && Number.isInteger(month))) {
     return undefined
   }
 
@@ -164,42 +167,22 @@ function defaultParseToDate(dateItems: string[], dateFormat: Maybe<string>): May
     return undefined
   }
 
-  let year
-  if (dateItems[longYearItem]) {
-    const yearString = dateItems[longYearItem]
-    if (!/^\d+$/.test(yearString)) {
-        return undefined
-    }
+  const yearString = dateItems[longYearItem] ?? dateItems[shortYearItem]
 
-    year = Number(yearString)
-    if (year < 1000 || year > 9999) {
-      return undefined
-    }
-  } else {
-    const yearString = dateItems[shortYearItem]
-    if (!/^\d+$/.test(yearString)) {
-      return undefined
-    }
-
-    year = Number(yearString)
-    if (year < 0 || year > 99) {
-      return undefined
-    }
-  }
-
-  const monthString = dateItems[monthItem]
-  if (!/^\d+$/.test(monthString)) {
+  const year = Number(yearString)
+  if (!(Number.isFinite(year) && Number.isInteger(year))) {
     return undefined
   }
-  const month = Number(monthString)
 
-  const dayString = dateItems[dayItem]
-  if (!/^\d+$/.test(dayString)) {
+  if (dateItems[longYearItem] && (year < 1000 || year > 9999)) {
     return undefined
   }
-  const day = Number(dayString)
 
-  return {year, month, day}
+  if (dateItems[shortYearItem] && (year < 0 || year > 99)) {
+    return undefined
+  }
+
+  return { year, month, day }
 }
 
 /**

--- a/src/DateTimeHelper.ts
+++ b/src/DateTimeHelper.ts
@@ -229,10 +229,10 @@ export class DateTimeHelper {
   }
 
   private parseDateTimeFromFormats(dateTimeString: string, dateFormats: string[], timeFormats: string[]): Partial<{ dateTime: DateTime, dateFormat: string, timeFormat: string }> {
-    const dateFormatsIterate = dateFormats.length === 0 ? [undefined] : dateFormats
-    const timeFormatsIterate = timeFormats.length === 0 ? [undefined] : timeFormats
-    for (const dateFormat of dateFormatsIterate) {
-      for (const timeFormat of timeFormatsIterate) {
+    const dateFormatsArray = dateFormats.length === 0 ? [undefined] : dateFormats
+    const timeFormatsArray = timeFormats.length === 0 ? [undefined] : timeFormats
+    for (const dateFormat of dateFormatsArray) {
+      for (const timeFormat of timeFormatsArray) {
         const dateTime = this.parseSingleFormat(dateTimeString, dateFormat, timeFormat)
         if (dateTime !== undefined) {
           return {dateTime, timeFormat, dateFormat}
@@ -319,4 +319,3 @@ export function timeToNumber(time: SimpleTime): number {
 export function toBasisEU(date: SimpleDate): SimpleDate {
   return {year: date.year, month: date.month, day: Math.min(30, date.day)}
 }
-

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -4,7 +4,7 @@
  */
 
 import {Config} from '../Config'
-import {secondsExtendedRegexp} from '../DateTimeDefault'
+import {TIME_FORMAT_SECONDS_ITEM_REGEXP} from '../DateTimeDefault'
 import {DateTimeHelper, numberToSimpleTime, SimpleDateTime, SimpleTime} from '../DateTimeHelper'
 import {RawScalarValue} from '../interpreter/InterpreterValue'
 import {Maybe} from '../Maybe'
@@ -130,7 +130,7 @@ export function defaultStringifyDuration(time: SimpleTime, formatArg: string): M
       }
 
       default: {
-        if (secondsExtendedRegexp.test(token.value)) {
+        if (TIME_FORMAT_SECONDS_ITEM_REGEXP.test(token.value)) {
           const fractionOfSecondPrecision = Math.max(token.value.length - 3, 0)
           result += `${time.seconds < 10 ? '0' : ''}${Math.floor(time.seconds * Math.pow(10, fractionOfSecondPrecision)) / Math.pow(10, fractionOfSecondPrecision)}`
           continue
@@ -217,7 +217,7 @@ export function defaultStringifyDateTime(dateTime: SimpleDateTime, formatArg: st
         break
       }
       default: {
-        if (secondsExtendedRegexp.test(token.value)) {
+        if (TIME_FORMAT_SECONDS_ITEM_REGEXP.test(token.value)) {
           const fractionOfSecondPrecision = token.value.length - 3
           result += `${dateTime.seconds < 10 ? '0' : ''}${Math.floor(dateTime.seconds * Math.pow(10, fractionOfSecondPrecision)) / Math.pow(10, fractionOfSecondPrecision)}`
           continue

--- a/test/date.spec.ts
+++ b/test/date.spec.ts
@@ -265,14 +265,14 @@ describe('By default function parseDateTimeFromConfigFormats', () => {
   })
 
   it('parses a time value with AM/PM postfix', () => {
-    const dateHelper = new DateTimeHelper(new Config({ timeFormats: ['hh:mm', 'hh:mm am/pm'] }))
+    const dateHelper = new DateTimeHelper(new Config({ timeFormats: ['hh:mm am/pm'] }))
     const { dateTime: dateTimeWithPrefix } = dateHelper.parseDateTimeFromConfigFormats('01:01 pm')
     const { dateTime: dateTimeWithOutPrefix } = dateHelper.parseDateTimeFromConfigFormats('13:01')
     expect(dateTimeWithPrefix).toEqual(dateTimeWithOutPrefix)
   })
 
   it('parses a time value with A/P postfix', () => {
-    const dateHelper = new DateTimeHelper(new Config({ timeFormats: ['hh:mm', 'hh:mm a/p'] }))
+    const dateHelper = new DateTimeHelper(new Config({ timeFormats: ['hh:mm a/p'] }))
     const { dateTime: dateTimeWithPrefix } = dateHelper.parseDateTimeFromConfigFormats('01:01 p')
     const { dateTime: dateTimeWithOutPrefix } = dateHelper.parseDateTimeFromConfigFormats('13:01')
     expect(dateTimeWithPrefix).toEqual(dateTimeWithOutPrefix)

--- a/test/date.spec.ts
+++ b/test/date.spec.ts
@@ -215,6 +215,58 @@ describe('Date helpers, other zero date', () => {
   })
 })
 
+describe('By default function parseDateTimeFromConfigFormats', () => {
+  it('returns {} when dateFormats=[] and timeFormats=[]', () => {
+    const dateHelper = new DateTimeHelper(new Config({ dateFormats: [], timeFormats: [] }))
+    const parsedDate = dateHelper.parseDateTimeFromConfigFormats('01/01/2019')
+    expect(parsedDate).toEqual({})
+  })
+
+  it('returns {} when trying to parse date but dateFormats=[]', () => {
+    const dateHelper = new DateTimeHelper(new Config({ dateFormats: [] }))
+    const parsedDate = dateHelper.parseDateTimeFromConfigFormats('01/01/2019')
+    expect(parsedDate).toEqual({})
+  })
+
+  it('returns {} when trying to parse time but timeFormats=[]', () => {
+    const dateHelper = new DateTimeHelper(new Config({ timeFormats: [] }))
+    const parsedDate = dateHelper.parseDateTimeFromConfigFormats('01:01')
+    expect(parsedDate).toEqual({})
+  })
+
+  it('returns {} when trying to parse time but timeFormats=[]', () => {
+    const dateHelper = new DateTimeHelper(new Config({ timeFormats: [] }))
+    const parsedDate = dateHelper.parseDateTimeFromConfigFormats('01:01')
+    expect(parsedDate).toEqual({})
+  })
+
+  it('parses a time value with AM/PM postfix', () => {
+    const dateHelper = new DateTimeHelper(new Config({ timeFormats: ['hh:mm', 'hh:mm am'] }))
+    const { dateTime: dateTimeWithPrefix } = dateHelper.parseDateTimeFromConfigFormats('01:01 pm')
+    const { dateTime: dateTimeWithOutPrefix } = dateHelper.parseDateTimeFromConfigFormats('13:01')
+    expect(dateTimeWithPrefix).toEqual(dateTimeWithOutPrefix)
+  })
+
+  it('parses a time value with A/P postfix', () => {
+    const dateHelper = new DateTimeHelper(new Config({ timeFormats: ['hh:mm', 'hh:mm a'] }))
+    const { dateTime: dateTimeWithPrefix } = dateHelper.parseDateTimeFromConfigFormats('01:01 p')
+    const { dateTime: dateTimeWithOutPrefix } = dateHelper.parseDateTimeFromConfigFormats('13:01')
+    expect(dateTimeWithPrefix).toEqual(dateTimeWithOutPrefix)
+  })
+
+  it('returns the matching dateFormat', () => {
+    const dateHelper = new DateTimeHelper(new Config({ dateFormats: ['DD/MM/YY', 'DD/MM/YYYY'], timeFormats: ['hh:mm:ss', 'hh:mm'] }))
+    const { dateFormat } = dateHelper.parseDateTimeFromConfigFormats('01/01/2019')
+    expect(dateFormat).toEqual('DD/MM/YYYY')
+  })
+
+  it('returns the matching timeFormat', () => {
+    const dateHelper = new DateTimeHelper(new Config({ dateFormats: ['DD/MM/YY', 'DD/MM/YYYY'], timeFormats: ['hh:mm:ss', 'hh:mm'] }))
+    const { timeFormat } = dateHelper.parseDateTimeFromConfigFormats('01:01')
+    expect(timeFormat).toEqual('hh:mm')
+  })
+})
+
 describe('Custom date parsing', () => {
   function customParseDate(dateString: string, dateFormat?: string): Maybe<SimpleDate> {
     const momentDate = moment(dateString, dateFormat, true)

--- a/test/date.spec.ts
+++ b/test/date.spec.ts
@@ -240,15 +240,39 @@ describe('By default function parseDateTimeFromConfigFormats', () => {
     expect(parsedDate).toEqual({})
   })
 
+  it('returns {} when time format contains no day term', () => {
+    const dateHelper = new DateTimeHelper(new Config({ dateFormats: ['MM/YY'] }))
+    const parsedDate = dateHelper.parseDateTimeFromConfigFormats('12/12')
+    expect(parsedDate).toEqual({})
+  })
+
+  it('returns {} when time format contains no month term', () => {
+    const dateHelper = new DateTimeHelper(new Config({ dateFormats: ['DD/YY'] }))
+    const parsedDate = dateHelper.parseDateTimeFromConfigFormats('12/12')
+    expect(parsedDate).toEqual({})
+  })
+
+  it('returns {} when time format contains no year term', () => {
+    const dateHelper = new DateTimeHelper(new Config({ dateFormats: ['DD/MM'] }))
+    const parsedDate = dateHelper.parseDateTimeFromConfigFormats('12/12')
+    expect(parsedDate).toEqual({})
+  })
+
+  it('returns {} when time format contains both long year and short year term', () => {
+    const dateHelper = new DateTimeHelper(new Config({ dateFormats: ['DD/MM/YY/YYYY'] }))
+    const parsedDate = dateHelper.parseDateTimeFromConfigFormats('12/12/12/12')
+    expect(parsedDate).toEqual({})
+  })
+
   it('parses a time value with AM/PM postfix', () => {
-    const dateHelper = new DateTimeHelper(new Config({ timeFormats: ['hh:mm', 'hh:mm am'] }))
+    const dateHelper = new DateTimeHelper(new Config({ timeFormats: ['hh:mm', 'hh:mm am/pm'] }))
     const { dateTime: dateTimeWithPrefix } = dateHelper.parseDateTimeFromConfigFormats('01:01 pm')
     const { dateTime: dateTimeWithOutPrefix } = dateHelper.parseDateTimeFromConfigFormats('13:01')
     expect(dateTimeWithPrefix).toEqual(dateTimeWithOutPrefix)
   })
 
   it('parses a time value with A/P postfix', () => {
-    const dateHelper = new DateTimeHelper(new Config({ timeFormats: ['hh:mm', 'hh:mm a'] }))
+    const dateHelper = new DateTimeHelper(new Config({ timeFormats: ['hh:mm', 'hh:mm a/p'] }))
     const { dateTime: dateTimeWithPrefix } = dateHelper.parseDateTimeFromConfigFormats('01:01 p')
     const { dateTime: dateTimeWithOutPrefix } = dateHelper.parseDateTimeFromConfigFormats('13:01')
     expect(dateTimeWithPrefix).toEqual(dateTimeWithOutPrefix)


### PR DESCRIPTION
### Test case

A spreadsheet with 500k rows and 10 columns filled with string data. Total of 5M data cells, no formulas, no date/time values.

Script:
```ts
const hf = HyperFormula.buildFromArray([], {
  licenseKey: 'gpl-v3',
  maxRows: 500100,
  useStats: true,
  chooseAddressMappingPolicy: new AlwaysDense(),
})

const data = Array(500000).fill(0).map(() => Array(10).fill(0).map(() => 'A500000'))

var ty1 = (new Date()).getTime()
hf.setSheetContent(0, data)
var ty2 = (new Date()).getTime()
console.log(ty2 - ty1)
console.log(hf.getStats())
```

#### Ideas for improvement

- Function `getTopSortedWithSccSubgraphFrom` (total time **42.7%**), which is the iterative implementation of the Tarjan algorithm that performs the topological sorting of the dependency graph and finds cycles (SCCs) in the graph. In this test case, the dependency graph is trivial; it contains only isolated nodes without any edges. It seems that it can be done more efficiently.
- Function `parseDateTimeFromConfigFormats` (total time **21.2%**), which tries to parse all string data as date/time values. This test case contains no date/time values, so there might be some way of saving time by determining it quickly and avoiding running the heavy parsing operations.

### This PR focuses on optimizing date/time parsing functions

1. Date format string and time format string (provided in the engine's configuration) need to be pre-processed before using them to parse date/time values from the input strings. I extracted this pre-processing code and applied memorization to it so that it is being run only once per configured format instead of once for every data cell in the spreadsheet.
2. I introduced a quick regexp check to detect early the strings that certainly couldn't be parsed to date/time values and avoid running expensive parsing operations.

### Results

Total time:
Before: **32264ms**
After: **26391ms**

Function `parseDateTimeFromConfigFormats`:
Before: **21.2%**
After: **6.3%**

Profiler:
Before:
![before](https://github.com/handsontable/hyperformula/assets/2480086/fefe2c39-bec7-446e-9428-638395f78b0a)

After:
![after](https://github.com/handsontable/hyperformula/assets/2480086/d63619f8-1ede-4508-a8c8-1c1645109ac2)

Profiler: Chrome Dev Tools

### This result corresponds to **~16%** speed-up of HyperFormula for this use-case.

### How did you test your changes?
<!--- Describe in detail how you tested your changes. -->

- correctness verified by the full suite of unit tests
- verified the improvement on the test case described above
- run regular performance benchmarks (results included in this PR as a comment below)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [x] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Related issues:
1. #876 

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [ ] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [x] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [x] My change is compatible with Microsoft Excel.
- [x] My change is compatible with Google Sheets.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
