### PR TITLE
Return a `CellError` when operating on ranges with incompatible sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,7 +281,7 @@ For more information on this release, see:
 - **Breaking change**: Changed config options [#747](https://github.com/handsontable/hyperformula/issues/747):
 
 | before                | after                |
-| --------------------- | -------------------- |
+|-----------------------|----------------------|
 | matrixColumnSeparator | arrayColumnSeparator |
 | matrixRowSeparator    | arrayRowSeparator    |
 
@@ -290,14 +290,14 @@ For more information on this release, see:
 - **Breaking change**: Changed API methods [#747](https://github.com/handsontable/hyperformula/issues/747):
 
 | before             | after             |
-| ------------------ | ----------------- |
+|--------------------|-------------------|
 | matrixMapping      | arrrayMapping     |
 | isCellPartOfMatrix | isCellPartOfArray |
 
 - **Breaking change**: Changed Exceptions [#747](https://github.com/handsontable/hyperformula/issues/747):
 
 | before                       | after                       |
-| ---------------------------- | --------------------------- |
+|------------------------------|-----------------------------|
 | SourceLocationHasMatrixError | SourceLocationHasArrayError |
 | TargetLocationHasMatrixError | TargetLocationHasArrayError |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Fix an issue where operation on ranges of incompatible sizes resulted in runtime exception. [#1267](https://github.com/handsontable/hyperformula/issues/1267)
+- Fix an issue where operation on ranges with incompatible sizes resulted in a runtime exception. [#1267](https://github.com/handsontable/hyperformula/issues/1267)
 
 ## [2.6.0] - 2023-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Fix an issue where operation on ranges with incompatible sizes resulted in a runtime exception. [#1267](https://github.com/handsontable/hyperformula/issues/1267)
+- Fixed an issue where operation on ranges with incompatible sizes resulted in a runtime exception. [#1267](https://github.com/handsontable/hyperformula/issues/1267)
 
 ## [2.6.0] - 2023-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix an issue where operation on ranges of incompatible sizes resulted in runtime exception. [#1267](https://github.com/handsontable/hyperformula/issues/1267)
+
 ## [2.6.0] - 2023-09-19
 
 ### Added

--- a/src/Cell.ts
+++ b/src/Cell.ts
@@ -154,6 +154,10 @@ export class CellError {
   ) {
   }
 
+  /**
+   * Returns a CellError with a given message.
+   * @param {string} detailedMessage - message to be displayed
+   */
   public static parsingError(detailedMessage?: string): CellError {
     return new CellError(ErrorType.ERROR, `${ErrorMessage.ParseError}${detailedMessage ? ' ' + detailedMessage : ''}`)
   }
@@ -199,8 +203,13 @@ export const movedSimpleCellAddress = (address: SimpleCellAddress, toSheet: numb
 
 export const addressKey = (address: SimpleCellAddress) => `${address.sheet},${address.row},${address.col}`
 
-export function isSimpleCellAddress(obj: any): obj is SimpleCellAddress {
+/**
+ * Checks if given object is a simple cell address.
+ */
+export function isSimpleCellAddress(obj: unknown): obj is SimpleCellAddress {
   if (obj && (typeof obj === 'object' || typeof obj === 'function')) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     return 'col' in obj && typeof obj.col === 'number' && 'row' in obj && typeof obj.row === 'number' && 'sheet' in obj && typeof obj.sheet === 'number'
   } else {
     return false

--- a/src/Cell.ts
+++ b/src/Cell.ts
@@ -154,8 +154,8 @@ export class CellError {
   ) {
   }
 
-  public static parsingError() {
-    return new CellError(ErrorType.ERROR, ErrorMessage.ParseError)
+  public static parsingError(detailedMessage?: string): CellError {
+    return new CellError(ErrorType.ERROR, `${ErrorMessage.ParseError}${detailedMessage ? ' ' + detailedMessage : ''}`)
   }
 
   public attachRootVertex(vertex: FormulaVertex): CellError {

--- a/src/Cell.ts
+++ b/src/Cell.ts
@@ -207,13 +207,11 @@ export const addressKey = (address: SimpleCellAddress) => `${address.sheet},${ad
  * Checks if given object is a simple cell address.
  */
 export function isSimpleCellAddress(obj: unknown): obj is SimpleCellAddress {
-  if (obj && (typeof obj === 'object' || typeof obj === 'function')) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    return 'col' in obj && typeof obj.col === 'number' && 'row' in obj && typeof obj.row === 'number' && 'sheet' in obj && typeof obj.sheet === 'number'
-  } else {
-    return false
-  }
+  return obj
+    && (typeof obj === 'object' || typeof obj === 'function')
+    && typeof (obj as SimpleCellAddress)?.sheet === 'number'
+    && typeof (obj as SimpleCellAddress)?.col === 'number'
+    && typeof (obj as SimpleCellAddress)?.row === 'number'
 }
 
 export const absoluteSheetReference = (address: AddressWithSheet, baseAddress: SimpleCellAddress): number => {

--- a/src/DependencyGraph/ParsingErrorVertex.ts
+++ b/src/DependencyGraph/ParsingErrorVertex.ts
@@ -14,7 +14,8 @@ export class ParsingErrorVertex {
   }
 
   public getCellValue(): CellError {
-    return CellError.parsingError()
+    const firstNonemptyMessage = this.errors.map(error => error.message).find((msg) => msg)
+    return CellError.parsingError(firstNonemptyMessage)
   }
 
   public getFormula(): string {

--- a/src/DependencyGraph/ParsingErrorVertex.ts
+++ b/src/DependencyGraph/ParsingErrorVertex.ts
@@ -6,18 +6,30 @@
 import {CellError} from '../Cell'
 import {ParsingError} from '../parser/Ast'
 
+/**
+ * Represents a cell with a parsing error.
+ */
 export class ParsingErrorVertex {
+  /**
+   * Constructor
+   */
   constructor(
     public readonly errors: ParsingError[],
     public readonly rawInput: string
   ) {
   }
 
+  /**
+   * Returns the value of this cell.
+   */
   public getCellValue(): CellError {
     const firstNonemptyMessage = this.errors.map(error => error.message).find((msg) => msg)
     return CellError.parsingError(firstNonemptyMessage)
   }
 
+  /**
+   * Returns the formula of this cell.
+   */
   public getFormula(): string {
     return this.rawInput
   }

--- a/src/parser/Ast.ts
+++ b/src/parser/Ast.ts
@@ -56,6 +56,7 @@ export enum ParsingErrorType {
   StaticOffsetError = 'StaticOffsetError',
   StaticOffsetOutOfRangeError = 'StaticOffsetOutOfRangeError',
   RangeOffsetNotAllowed = 'RangeOffsetNotAllowed',
+  InvalidRangeSize = 'InvalidRangeSize',
 }
 
 export enum AstNodeType {

--- a/src/parser/Ast.ts
+++ b/src/parser/Ast.ts
@@ -50,6 +50,9 @@ export const parsingError = (type: ParsingErrorType, message: string) => ({
   type, message
 })
 
+/**
+ * Represents types of parsing errors.
+ */
 export enum ParsingErrorType {
   LexingError = 'LexingError',
   ParserError = 'ParsingError',

--- a/test/_setupFiles/jest/toEqualError.ts
+++ b/test/_setupFiles/jest/toEqualError.ts
@@ -13,10 +13,10 @@ export const toEqualError: ExpectExtendMap = {
   toEqualError(received: any, expected: any): CustomMatcherResult {
     let result = false
 
-    if (typeof received === 'object' && typeof expected === 'object') {
+    if (typeof received === 'object' && typeof expected === 'object' && received.message != null && expected.message != null && received.message.includes(expected.message)) {
       result = this.equals(
-        {...received, root: undefined, address: undefined},
-        {...expected, root: undefined, address: undefined}
+        {...received, message: undefined, root: undefined, address: undefined},
+        {...expected, message: undefined, root: undefined, address: undefined}
       )
     } else {
       result = this.equals(received, expected)

--- a/test/_setupFiles/matchers/toEqualError.ts
+++ b/test/_setupFiles/matchers/toEqualError.ts
@@ -16,10 +16,10 @@ export const toEqualErrorMatcher: CustomMatcherFactories = {
     return {
       compare: function(received: any, expected: any): CustomMatcherResult {
         let result
-        if (typeof received === 'object' && typeof expected === 'object') {
+        if (typeof received === 'object' && typeof expected === 'object' && received.message != null && expected.message != null && received.message.includes(expected.message)) {
           result = util.equals(
-            {...received, root: undefined, address: undefined},
-            {...expected, root: undefined, address: undefined}
+            {...received, message: undefined, root: undefined, address: undefined},
+            {...expected, message: undefined, root: undefined, address: undefined}
           )
         } else {
           result = util.equals(received, expected)

--- a/test/column-range.spec.ts
+++ b/test/column-range.spec.ts
@@ -80,4 +80,145 @@ describe('Column ranges', () => {
     expect(range.start).toEqual(colStart('A'))
     expect(range.end).toEqual(colEnd('B'))
   })
+
+  it('no infinite', () => {
+    const engine = HyperFormula.buildFromArray([[2, 3], [2, 42]], {useArrayArithmetic: true})
+    engine.setCellContents({ sheet: 0, row: 2, col: 2 }, "=A1:A2+A1:B1")
+
+    expect(engine.getSheetValues(0)).toEqual([[2, 3], [2, 42], [null, null, 4, 5], [null, null, 4, 5]])
+  })
+
+  it('one infinite', () => {
+    const engine = HyperFormula.buildFromArray([[2, 3], [2, 42]], {useArrayArithmetic: true})
+    engine.setCellContents({ sheet: 0, row: 2, col: 2 }, "=A:A+A1:B1")
+
+    expect(engine.getSheetValues(0)).toEqual([[2, 3], [2, 42], [null, null, 4, 5], [null, null, 4, 5]])
+  })
+
+  it('parsing error', () => {
+    const engine = HyperFormula.buildFromArray([[2, 3], [2, 42]], {useArrayArithmetic: true})
+    engine.setCellContents({ sheet: 0, row: 2, col: 2 }, "=+++")
+
+    expect(engine.getSheetValues(0)).toEqual([[2, 3], [2, 42], [null, null, 4, 5], [null, null, 4, 5]])
+  })
+
+  it('user', () => {
+    const engine = HyperFormula.buildFromSheets(
+      {
+        Sheet1: [["1"]]
+      },
+      {
+        licenseKey: "gpl-v3",
+        useArrayArithmetic: true
+      }
+    )
+    engine.setCellContents({ sheet: 0, row: 0, col: 0 }, "='Sheet1'!A:A+'Sheet1'!1:1")
+
+    expect(engine.getCellValue(adr('A1'))).toEqual('error')
+  })
+
+  it('user 0', () => {
+    const engine = HyperFormula.buildFromArray([['1']], {useArrayArithmetic: true})
+    engine.setCellContents({ sheet: 0, row: 0, col: 0 }, "='Sheet1'!A:A+'Sheet1'!1:1")
+
+    expect(engine.getCellValue(adr('A1'))).toEqual('error')
+  })
+
+  it('user 1', () => {
+    const engine = HyperFormula.buildFromArray([['1']], {useArrayArithmetic: true})
+    engine.setCellContents({ sheet: 0, row: 0, col: 0 }, "=A:A+1:1")
+
+    expect(engine.getCellValue(adr('A1'))).toEqual('error')
+  })
+
+  it('user 2', () => {
+    const engine = HyperFormula.buildFromArray([
+      ['1'],
+      ['2', "='Sheet1'!A:A+'Sheet1'!1:1"],
+    ], {useArrayArithmetic: true})
+
+    expect(engine.getCellValue(adr('B2'))).toEqual('error')
+  })
+
+  it('user 3', () => {
+    const engine = HyperFormula.buildFromArray([
+      ['1'],
+      ['2', '=A:A+1:1'],
+    ], {useArrayArithmetic: true})
+
+    expect(engine.getCellValue(adr('B2'))).toEqual('error')
+  })
+
+  it('user 3 mod', () => {
+    const engine = HyperFormula.buildFromArray([
+      ['1'],
+      ['=B:B+1:1'],
+    ], {useArrayArithmetic: true})
+
+    expect(engine.getCellValue(adr('A2'))).toEqual('error')
+  })
+
+  it('user 4', () => {
+    const engine = HyperFormula.buildFromArray([
+      ['1'],
+      ['2', '=A:A+A:A'],
+    ], {useArrayArithmetic: true})
+
+    expect(engine.getCellValue(adr('B2'))).toEqual('error')
+  })
+
+  it('user no array arithmetic', () => {
+    const engine = HyperFormula.buildFromSheets(
+      {
+        Sheet1: [["1"]]
+      },
+      {
+        licenseKey: "gpl-v3",
+      }
+    )
+    engine.setCellContents({ sheet: 0, row: 0, col: 0 }, "='Sheet1'!A:A+'Sheet1'!1:1")
+
+    expect(engine.getCellValue(adr('A1'))).toEqual('error')
+  })
+
+  it('user 0 no array arithmetic', () => {
+    const engine = HyperFormula.buildFromArray([['1']])
+    engine.setCellContents({ sheet: 0, row: 0, col: 0 }, "='Sheet1'!A:A+'Sheet1'!1:1")
+
+    expect(engine.getCellValue(adr('A1'))).toEqual('error')
+  })
+
+  it('user 1 no array arithmetic', () => {
+    const engine = HyperFormula.buildFromArray([['1']])
+    engine.setCellContents({ sheet: 0, row: 0, col: 0 }, "=A:A+1:1")
+
+    expect(engine.getCellValue(adr('A1'))).toEqual('error')
+  })
+
+  it('user 2 no array arithmetic', () => {
+    const engine = HyperFormula.buildFromArray([
+      ['1'],
+      ['2', "='Sheet1'!A:A+'Sheet1'!1:1"],
+    ])
+
+    expect(engine.getCellValue(adr('B2'))).toEqual('error')
+  })
+
+  it('user 3 no array arithmetic', () => {
+    const engine = HyperFormula.buildFromArray([
+      ['1'],
+      ['2', '=A:A+1:1'],
+    ])
+
+    expect(engine.getCellValue(adr('B2'))).toEqual('error')
+  })
+
+  it('user 4 no array arithmetic', () => {
+    const engine = HyperFormula.buildFromArray([
+      ['1'],
+      ['2', '=A:A+A:A'],
+    ])
+
+    expect(engine.getCellValue(adr('B2'))).toEqual('error')
+  })
 })

--- a/test/cruds/change-cell-content.spec.ts
+++ b/test/cruds/change-cell-content.spec.ts
@@ -6,14 +6,15 @@ import {
   InvalidAddressError,
   NoSheetWithIdError,
   SimpleCellAddress,
+  SheetSizeLimitExceededError,
+  ArraySize,
+  ExpectedValueOfTypeError,
 } from '../../src'
 import {AbsoluteCellRange} from '../../src/AbsoluteCellRange'
-import {ArraySize} from '../../src/ArraySize'
 import {simpleCellAddress} from '../../src/Cell'
 import {Config} from '../../src/Config'
 import {ArrayVertex, EmptyCellVertex, ValueCellVertex} from '../../src/DependencyGraph'
 import {ErrorMessage} from '../../src/error-message'
-import {SheetSizeLimitExceededError} from '../../src/errors'
 import {ColumnIndex} from '../../src/Lookup/ColumnIndex'
 import {
   adr,
@@ -27,7 +28,6 @@ import {
   rowEnd,
   rowStart
 } from '../testUtils'
-import {ExpectedValueOfTypeError} from '../../src/errors'
 
 describe('Changing cell content - checking if its possible', () => {
   it('address should have valid coordinates', () => {
@@ -498,7 +498,7 @@ describe('changing cell content', () => {
     expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.ERROR, ErrorMessage.ParseError))
   })
 
-  it('update dependecy value cell to parsing error ', () => {
+  it('update dependency value cell to parsing error ', () => {
     const sheet = [
       ['1', '=SUM(A1)'],
     ]

--- a/test/cruds/change-cell-content.spec.ts
+++ b/test/cruds/change-cell-content.spec.ts
@@ -1124,7 +1124,7 @@ describe('arrays', () => {
 
     expect(changes.length).toEqual(3)
     expect(changes).toContainEqual(new ExportedCellChange(adr('A2'), noSpace()))
-    expect(changes).toContainEqual(new ExportedCellChange(adr('B2'), detailedError(ErrorType.ERROR, ErrorMessage.ParseError)))
+    expect(changes).toContainEqual(new ExportedCellChange(adr('B2'), detailedError(ErrorType.ERROR, "Parsing error. Expecting token of type --> RParen <-- but found --> '' <--")))
     expect(changes).toContainEqual(new ExportedCellChange(adr('C2'), null))
   })
 

--- a/test/matchers.spec.ts
+++ b/test/matchers.spec.ts
@@ -25,7 +25,7 @@ describe('Matchers', () => {
     expect(
       new CellError(ErrorType.ERROR, 'a', dummyFormulaVertex())
     ).not.toEqualError(
-      new CellError(ErrorType.ERROR, '', dummyFormulaVertex())
+      new CellError(ErrorType.ERROR, 'b', dummyFormulaVertex())
     )
 
     expect(

--- a/test/ranges.spec.ts
+++ b/test/ranges.spec.ts
@@ -1,0 +1,63 @@
+import {DetailedCellError, ErrorType, HyperFormula} from '../src'
+import {adr, detailedError} from './testUtils'
+import {ErrorMessage} from '../src/error-message'
+
+describe('Ranges', () => {
+  describe('when operating on infinite ranges', () => {
+    describe('with array arithmetic on', () => {
+      it('returns a cell error, when operation results in an infinite column range not starting on index 0 (setCellContents)', () => {
+        const engine = HyperFormula.buildFromArray([[1, 2]], { useArrayArithmetic: true })
+        engine.setCellContents(adr('B2'), '=A:A+B1')
+
+        expect(engine.getCellValue(adr('B2'))).toEqualError(detailedError(ErrorType.ERROR, 'Invalid range size'))
+      })
+
+      it('returns a cell error, when operation results in a range with infinite width and infinite height (setCellContents)', () => {
+        const engine = HyperFormula.buildFromArray([['1']], { useArrayArithmetic: true })
+        engine.setCellContents(adr('B2'), '=A:A+1:1')
+
+        expect(engine.getCellValue(adr('B2'))).toEqualError(detailedError(ErrorType.ERROR, 'Invalid range size'))
+      })
+
+      it('returns a #SPILL error, when operation results in an infinite column range not starting on index 0', () => {
+        const engine = HyperFormula.buildFromArray([[1, 2], [null, '=A:A+B1']], { useArrayArithmetic: true })
+
+        expect(engine.getCellValue(adr('B2'))).toEqualError(detailedError(ErrorType.SPILL, ErrorMessage.NoSpaceForArrayResult))
+      })
+
+      it('returns a #SPILL error, when operation results in a range with infinite width and infinite height', () => {
+        const engine = HyperFormula.buildFromArray([[], [null, '=A:A+1:1']], { useArrayArithmetic: true })
+
+        expect(engine.getCellValue(adr('B2'))).toEqualError(detailedError(ErrorType.SPILL, ErrorMessage.NoSpaceForArrayResult))
+      })
+    })
+
+    describe('with array arithmetic off', () => {
+      it('???, when operation results in an infinite column range not starting on index 0 (setCellContents)', () => {
+        const engine = HyperFormula.buildFromArray([[1, 2]], { useArrayArithmetic: false })
+        engine.setCellContents(adr('B2'), '=A:A+B1')
+
+        expect(engine.getSheetValues(0)).toEqual([[1, 2], [null, 'wtf?']])
+      })
+
+      it('???, when operation results in a range with infinite width and infinite height (setCellContents)', () => {
+        const engine = HyperFormula.buildFromArray([['1']], { useArrayArithmetic: false })
+        engine.setCellContents(adr('B2'), '=A:A+1:1')
+
+        expect(engine.getSheetValues(0)).toEqual([[1], [null, 'wtf?']])
+      })
+
+      it('returns a #SPILL error, when operation results in an infinite column range not starting on index 0', () => {
+        const engine = HyperFormula.buildFromArray([[1, 2], [null, '=A:A+B1']], { useArrayArithmetic: true })
+
+        expect(engine.getCellValue(adr('B2'))).toEqualError(detailedError(ErrorType.SPILL, ErrorMessage.NoSpaceForArrayResult))
+      })
+
+      it('returns a #SPILL error, when operation results in a range with infinite width and infinite height', () => {
+        const engine = HyperFormula.buildFromArray([[], [null, '=A:A+1:1']], { useArrayArithmetic: true })
+
+        expect(engine.getCellValue(adr('B2'))).toEqualError(detailedError(ErrorType.SPILL, ErrorMessage.NoSpaceForArrayResult))
+      })
+    })
+  })
+})

--- a/test/ranges.spec.ts
+++ b/test/ranges.spec.ts
@@ -13,7 +13,7 @@ describe('Ranges', () => {
       })
 
       it('returns a cell error, when operation results in a range with infinite width and infinite height (setCellContents)', () => {
-        const engine = HyperFormula.buildFromArray([['1']], { useArrayArithmetic: true })
+        const engine = HyperFormula.buildFromArray([[1]], { useArrayArithmetic: true })
         engine.setCellContents(adr('B2'), '=A:A+1:1')
 
         expect(engine.getCellValue(adr('B2'))).toEqualError(detailedError(ErrorType.ERROR, 'Invalid range size'))
@@ -33,27 +33,27 @@ describe('Ranges', () => {
     })
 
     describe('with array arithmetic off', () => {
-      it('???, when operation results in an infinite column range not starting on index 0 (setCellContents)', () => {
-        const engine = HyperFormula.buildFromArray([[1, 2]], { useArrayArithmetic: false })
+      it('calculates the value according to the rules for array arithmetic mode disabled, when evaluating an operation on a column range and a single element (setCellContents)', () => {
+        const engine = HyperFormula.buildFromArray([[1, 2], [3]], { useArrayArithmetic: false })
         engine.setCellContents(adr('B2'), '=A:A+B1')
 
-        expect(engine.getSheetValues(0)).toEqual([[1, 2], [null, 'wtf?']])
+        expect(engine.getSheetValues(0)).toEqual([[1, 2], [3, 5]])
       })
 
-      it('???, when operation results in a range with infinite width and infinite height (setCellContents)', () => {
-        const engine = HyperFormula.buildFromArray([['1']], { useArrayArithmetic: false })
+      it('calculates the value according to the rules for array arithmetic mode disabled, when evaluating an operation on a column range and a row range (setCellContents)', () => {
+        const engine = HyperFormula.buildFromArray([[1, 2], [3]], { useArrayArithmetic: false })
         engine.setCellContents(adr('B2'), '=A:A+1:1')
 
-        expect(engine.getSheetValues(0)).toEqual([[1], [null, 'wtf?']])
+        expect(engine.getSheetValues(0)).toEqual([[1, 2], [3, 5]])
       })
 
-      it('returns a #SPILL error, when operation results in an infinite column range not starting on index 0', () => {
+      it('returns a #SPILL error, when evaluating an operation on a column range and a single element', () => {
         const engine = HyperFormula.buildFromArray([[1, 2], [null, '=A:A+B1']], { useArrayArithmetic: true })
 
         expect(engine.getCellValue(adr('B2'))).toEqualError(detailedError(ErrorType.SPILL, ErrorMessage.NoSpaceForArrayResult))
       })
 
-      it('returns a #SPILL error, when operation results in a range with infinite width and infinite height', () => {
+      it('returns a #SPILL error, when evaluating an operation on a column range and a row range', () => {
         const engine = HyperFormula.buildFromArray([[], [null, '=A:A+1:1']], { useArrayArithmetic: true })
 
         expect(engine.getCellValue(adr('B2'))).toEqualError(detailedError(ErrorType.SPILL, ErrorMessage.NoSpaceForArrayResult))

--- a/test/ranges.spec.ts
+++ b/test/ranges.spec.ts
@@ -1,4 +1,4 @@
-import {DetailedCellError, ErrorType, HyperFormula} from '../src'
+import {ErrorType, HyperFormula} from '../src'
 import {adr, detailedError} from './testUtils'
 import {ErrorMessage} from '../src/error-message'
 


### PR DESCRIPTION
### Context
<!--- Why are your changes required? What problem do they solve? -->

Before this PR, a range with invalid size resulted in a runtime exception. We decided that in such a case, we should return a `CellError` instead.

### How did you test your changes?
<!--- Describe in detail how you tested your changes. -->

- [x] unit tests passed
- [x] new unit tests added specific to this issue

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Related issues:
Fixes #1267 

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [x] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [x] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [x] My change is compatible with Microsoft Excel.
- [x] My change is compatible with Google Sheets.
- [x] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
