### PR TITLE
[Revert hotfix] Bring back angular version to latest in the angular demo

### DIFF
--- a/docs/guide/integration-with-angular.md
+++ b/docs/guide/integration-with-angular.md
@@ -8,7 +8,7 @@ more details.
 ## Demo
 
 <iframe
-     src="https://codesandbox.io/embed/github/handsontable/hyperformula-demos/tree/2.4.x/angular-demo?autoresize=1
+     src="https://codesandbox.io/embed/github/handsontable/hyperformula-demos/tree/2.5.x/angular-demo?autoresize=1
      &fontsize=11&hidenavigation=1&theme=light&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="handsontable/hyperformula-demos: angular-demo"

--- a/docs/guide/integration-with-angular.md
+++ b/docs/guide/integration-with-angular.md
@@ -8,7 +8,7 @@ more details.
 ## Demo
 
 <iframe
-     src="https://codesandbox.io/embed/github/handsontable/hyperformula-demos/tree/2.5.x/angular-demo?autoresize=1
+     src="https://codesandbox.io/embed/github/handsontable/hyperformula-demos/tree/2.6.x/angular-demo?autoresize=1
      &fontsize=11&hidenavigation=1&theme=light&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="handsontable/hyperformula-demos: angular-demo"


### PR DESCRIPTION
Reverts handsontable/hyperformula#1282

Related: https://github.com/handsontable/hyperformula/issues/1281