### PR TITLE
Docs: describe that `simpleCellRangeToString` does not work with column ranges and row ranges

### DIFF
--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -2880,6 +2880,8 @@ export class HyperFormula implements TypedEmitter {
   /**
    * Returns string representation of an absolute range in A1 notation or `undefined` if the sheet index is not present in the engine.
    *
+   * Note: This method is useful only for cell ranges; does not work with column ranges and row ranges.
+   *
    * @param {SimpleCellRange} cellRange - object representation of an absolute range
    * @param {number} sheetId - context used in case of missing sheet in the first argument
    *


### PR DESCRIPTION
### Context
<!--- Why are your changes required? What problem do they solve? -->

Issue #1375 should be fixed by making `simpleCellRangeToString` work with all types of ranges, but until we do it, I added a disclaimer to the docs.

### How did you test your changes?
<!--- Describe in detail how you tested your changes. -->

local docs build

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [x] Change to the documentation

### Related issues:

#1375

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [x] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [x] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [x] My change is compatible with Microsoft Excel.
- [x] My change is compatible with Google Sheets.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
