### PR TITLE
Add generic context option for custom function resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added a configuration option `context` that can be used to pass data to custom functions.
+
 ## [2.6.2] - 2024-02-15
 
 ### Changed

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -82,6 +82,14 @@ export interface ConfigParams {
    */
   chooseAddressMappingPolicy: ChooseAddressMapping,
   /**
+   * A generic context object that can be used to pass data to custom functions.
+   *
+   * @default {}
+   *
+   * @category Engine
+   */
+  context: unknown,
+  /**
    * Sets symbols that denote currency numbers.
    *
    * For more information, see the [Internationalization features guide](/guide/i18n-features.md).
@@ -494,6 +502,7 @@ export class Config implements ConfigParams, ParserConfig {
     currencySymbol: ['$'],
     caseSensitive: false,
     caseFirst: 'lower',
+    context: {},
     chooseAddressMappingPolicy: new AlwaysDense(),
     dateFormats: ['DD/MM/YYYY', 'DD/MM/YY'],
     decimalSeparator: '.',
@@ -596,6 +605,8 @@ export class Config implements ConfigParams, ParserConfig {
   public readonly currencySymbol: string[]
   /** @inheritDoc */
   public readonly undoLimit: number
+  /** @inheritDoc */
+  public readonly context: Record<string, unknown>
   /**
    * Built automatically based on translation package.
    *
@@ -623,6 +634,7 @@ export class Config implements ConfigParams, ParserConfig {
       caseSensitive,
       caseFirst,
       chooseAddressMappingPolicy,
+      context,
       currencySymbol,
       dateFormats,
       decimalSeparator,
@@ -709,6 +721,7 @@ export class Config implements ConfigParams, ParserConfig {
     this.maxColumns = configValueFromParam(maxColumns, 'number', 'maxColumns')
     this.currencySymbol = this.setupCurrencySymbol(currencySymbol)
     validateNumberToBeAtLeast(this.maxColumns, 'maxColumns', 1)
+    this.context = configValueFromParam(context, 'object', 'context')
 
     privatePool.set(this, {
       licenseKeyValidityState: checkLicenseKeyValidity(this.licenseKey)

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -84,7 +84,7 @@ export interface ConfigParams {
   /**
    * A generic context object that can be used to pass data to custom functions.
    *
-   * @default {}
+   * @default undefined
    *
    * @category Engine
    */
@@ -502,7 +502,7 @@ export class Config implements ConfigParams, ParserConfig {
     currencySymbol: ['$'],
     caseSensitive: false,
     caseFirst: 'lower',
-    context: {},
+    context: undefined,
     chooseAddressMappingPolicy: new AlwaysDense(),
     dateFormats: ['DD/MM/YYYY', 'DD/MM/YY'],
     decimalSeparator: '.',
@@ -606,7 +606,7 @@ export class Config implements ConfigParams, ParserConfig {
   /** @inheritDoc */
   public readonly undoLimit: number
   /** @inheritDoc */
-  public readonly context: Record<string, unknown>
+  public readonly context: unknown
   /**
    * Built automatically based on translation package.
    *

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -82,7 +82,7 @@ export interface ConfigParams {
    */
   chooseAddressMappingPolicy: ChooseAddressMapping,
   /**
-   * A generic context object that can be used to pass data to custom functions.
+   * A generic parameter that can be used to pass data to custom functions.
    *
    * @default undefined
    *

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -721,7 +721,7 @@ export class Config implements ConfigParams, ParserConfig {
     this.maxColumns = configValueFromParam(maxColumns, 'number', 'maxColumns')
     this.currencySymbol = this.setupCurrencySymbol(currencySymbol)
     validateNumberToBeAtLeast(this.maxColumns, 'maxColumns', 1)
-    this.context = configValueFromParam(context, 'object', 'context')
+    this.context = context
 
     privatePool.set(this, {
       licenseKeyValidityState: checkLicenseKeyValidity(this.licenseKey)

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -97,6 +97,14 @@ describe('Config', () => {
     expect(() => new Config({caseFirst: 'abcd'})).toThrowError('Expected one of \'upper\' \'lower\' \'false\' for config parameter: caseFirst')
   })
 
+  it('validation: context', () => {
+    expect(() => new Config({context: 'ABCD'})).toThrowError('Expected value of type: object for config parameter: context')
+    const context ={a: 1, b: 2}
+    const validConfig = {context}
+    const config = new Config(validConfig)
+    expect(config.context).toBe(context)
+  })
+
   it('should throw error when Function Translation cannot be found', () => {
     const config = new Config()
     const functionName = '0123456ABCDEFGH'

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -97,11 +97,9 @@ describe('Config', () => {
     expect(() => new Config({caseFirst: 'abcd'})).toThrowError('Expected one of \'upper\' \'lower\' \'false\' for config parameter: caseFirst')
   })
 
-  it('validation: context', () => {
-    expect(() => new Config({context: 'ABCD'})).toThrowError('Expected value of type: object for config parameter: context')
+  it('should return the specified context', () => {
     const context ={a: 1, b: 2}
-    const validConfig = {context}
-    const config = new Config(validConfig)
+    const config = new Config({context})
     expect(config.context).toBe(context)
   })
 

--- a/test/custom-functions.spec.ts
+++ b/test/custom-functions.spec.ts
@@ -191,7 +191,7 @@ class GreetingsPlugin extends FunctionPlugin {
       EXAMPLE_ARRAY_FUNCTION: 'EXAMPLE_ARRAY_FUNCTION',
     }
   }
-  
+
   greet(ast: ProcedureAst, state: InterpreterState) {
     return this.runFunction(
       ast.args,
@@ -216,6 +216,18 @@ class GreetingsPlugin extends FunctionPlugin {
         return SimpleRangeValue.onlyValues([[val, val], [val, val]])
       },
     )
+  }
+}
+
+class ContextPlugin extends FunctionPlugin {
+  public static implementedFunctions = {
+    'GETCONTEXT': {
+      method: 'getContext',
+    }
+  }
+
+  public getContext(ast: ProcedureAst, state: InterpreterState): unknown {
+    return this.config.context
   }
 }
 
@@ -550,5 +562,19 @@ describe('Custom function implemented with runFunction)', () => {
 
       engine.getCellValue(adr('A2'))
     }).toThrow(new Error('Function returning array cannot be vectorized.'))
+  })
+})
+
+describe('Context accessible within custom function', () => {
+  it('works', () => {
+    HyperFormula.registerFunctionPlugin(ContextPlugin)
+    HyperFormula.getLanguage('enGB').extendFunctions({GETCONTEXT: 'GETCONTEXT'})
+
+    const context = 'abc'
+    const engine = HyperFormula.buildFromArray([
+      ['=GETCONTEXT()'],
+    ], {context})
+
+    expect(engine.getCellValue(adr('A1'))).toEqual(context)
   })
 })


### PR DESCRIPTION
### Context
Enable pass-through of generic parameters to underlying custom functions via `context` option. Further discussion [here](https://github.com/handsontable/hyperformula/discussions/808).

### How did you test your changes?
Added tests; ran `npm run test`

### Types of changes
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [x] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Related issues:
1. Fixes #808

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [x] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [x] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [x] My change is compatible with Microsoft Excel.
- [x] My change is compatible with Google Sheets.
- [x] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
