### PR TITLE
Change publish-docs workflow to use Node 20 instead of 22 due to the temporary npm issue

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   publish-docs:
     strategy:
       matrix:
-        node-version: [ '22' ]
+        node-version: [ '20' ]
         os: [ 'ubuntu-latest' ]
     name: publish-docs
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Context
<!--- Why are your changes required? What problem do they solve? -->

The `npm ci` command is failing on Node 22 even though yesterday it worked correctly (see the GH actions execution history). Because of that, the `publish-docs` workflow cannot deploy the new version of the docs. I'm downgrading this workflow to use Node 20 temporarily.