### PR TITLE
Increase font-weight for the text in the demos in the docs

### DIFF
--- a/docs/examples/advanced-usage/example1.css
+++ b/docs/examples/advanced-usage/example1.css
@@ -3,7 +3,7 @@
   color: #606c76;
   font-family: sans-serif;
   font-size: 14px;
-  font-weight: 300;
+  font-weight: 400;
   letter-spacing: .01em;
   line-height: 1.6;
   -webkit-box-sizing: border-box;

--- a/docs/examples/basic-operations/example1.css
+++ b/docs/examples/basic-operations/example1.css
@@ -3,7 +3,7 @@
   color: #606c76;
   font-family: sans-serif;
   font-size: 14px;
-  font-weight: 300;
+  font-weight: 400;
   letter-spacing: .01em;
   line-height: 1.6;
   -webkit-box-sizing: border-box;

--- a/docs/examples/basic-usage/example1.css
+++ b/docs/examples/basic-usage/example1.css
@@ -3,7 +3,7 @@
   color: #606c76;
   font-family: sans-serif;
   font-size: 14px;
-  font-weight: 300;
+  font-weight: 400;
   letter-spacing: .01em;
   line-height: 1.6;
   -webkit-box-sizing: border-box;

--- a/docs/examples/batch-operations/example1.css
+++ b/docs/examples/batch-operations/example1.css
@@ -3,7 +3,7 @@
   color: #606c76;
   font-family: sans-serif;
   font-size: 14px;
-  font-weight: 300;
+  font-weight: 400;
   letter-spacing: .01em;
   line-height: 1.6;
   -webkit-box-sizing: border-box;

--- a/docs/examples/clipboard-operations/example1.css
+++ b/docs/examples/clipboard-operations/example1.css
@@ -3,7 +3,7 @@
   color: #606c76;
   font-family: sans-serif;
   font-size: 14px;
-  font-weight: 300;
+  font-weight: 400;
   letter-spacing: .01em;
   line-height: 1.6;
   -webkit-box-sizing: border-box;

--- a/docs/examples/date-time/example1.css
+++ b/docs/examples/date-time/example1.css
@@ -3,7 +3,7 @@
   color: #606c76;
   font-family: sans-serif;
   font-size: 14px;
-  font-weight: 300;
+  font-weight: 400;
   letter-spacing: .01em;
   line-height: 1.6;
   -webkit-box-sizing: border-box;

--- a/docs/examples/demo/example1.css
+++ b/docs/examples/demo/example1.css
@@ -3,7 +3,7 @@
   color: #606c76;
   font-family: sans-serif;
   font-size: 14px;
-  font-weight: 300;
+  font-weight: 400;
   letter-spacing: .01em;
   line-height: 1.6;
   -webkit-box-sizing: border-box;

--- a/docs/examples/i18n/example1.css
+++ b/docs/examples/i18n/example1.css
@@ -3,7 +3,7 @@
   color: #606c76;
   font-family: sans-serif;
   font-size: 14px;
-  font-weight: 300;
+  font-weight: 400;
   letter-spacing: .01em;
   line-height: 1.6;
   -webkit-box-sizing: border-box;

--- a/docs/examples/localizing-functions/example1.css
+++ b/docs/examples/localizing-functions/example1.css
@@ -3,7 +3,7 @@
   color: #606c76;
   font-family: sans-serif;
   font-size: 14px;
-  font-weight: 300;
+  font-weight: 400;
   letter-spacing: .01em;
   line-height: 1.6;
   -webkit-box-sizing: border-box;

--- a/docs/examples/named-expressions/example1.css
+++ b/docs/examples/named-expressions/example1.css
@@ -3,7 +3,7 @@
   color: #606c76;
   font-family: sans-serif;
   font-size: 14px;
-  font-weight: 300;
+  font-weight: 400;
   letter-spacing: .01em;
   line-height: 1.6;
   -webkit-box-sizing: border-box;

--- a/docs/examples/sorting-data/example1.css
+++ b/docs/examples/sorting-data/example1.css
@@ -3,7 +3,7 @@
   color: #606c76;
   font-family: sans-serif;
   font-size: 14px;
-  font-weight: 300;
+  font-weight: 400;
   letter-spacing: .01em;
   line-height: 1.6;
   -webkit-box-sizing: border-box;

--- a/docs/examples/undo-redo/example1.css
+++ b/docs/examples/undo-redo/example1.css
@@ -3,7 +3,7 @@
   color: #606c76;
   font-family: sans-serif;
   font-size: 14px;
-  font-weight: 300;
+  font-weight: 400;
   letter-spacing: .01em;
   line-height: 1.6;
   -webkit-box-sizing: border-box;


### PR DESCRIPTION
### Context
<!--- Why are your changes required? What problem do they solve? -->

Changing the `font-weight` of the text in demos from `300` to `400`.

Motivated by discussion: https://handsoncode.slack.com/archives/C031GBX62SE/p1730895128146949

### How did you test your changes?
<!--- Describe in detail how you tested your changes. -->

local docs build

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [x] Change to the documentation

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [x] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [x] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [x] My change is compatible with Microsoft Excel.
- [x] My change is compatible with Google Sheets.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
