### PR TITLE
Docs: Explain `getSheetDimensions()` issue with empty rows and columns

### DIFF
--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -887,6 +887,8 @@ export class HyperFormula implements TypedEmitter {
    * Returns dimensions of a specified sheet.
    * The sheet dimensions is represented with numbers: width and height.
    *
+   * Note: Due to the memory optimizations, some of the empty bottom rows and rightmost columns are not counted to the dimensions.
+   *
    * @param {number} sheetId - sheet ID number
    *
    * @throws [[ExpectedValueOfTypeError]] if any of its basic type argument is of wrong type
@@ -1341,7 +1343,7 @@ export class HyperFormula implements TypedEmitter {
    * Note: This method may trigger dependency graph recalculation.
    *
    * @param {number} sheetId - ID of a sheet to operate on
-   * @param {number[]} newRowOrder - permutation of rows
+   * @param {number[]} newRowOrder - permutation of rows; array length must match the number of rows returned by [getSheetDimensions()](#getsheetdimensions)
    *
    * @fires [[valuesUpdated]] if recalculation was triggered by this change
    *
@@ -1506,7 +1508,7 @@ export class HyperFormula implements TypedEmitter {
    * Note: This method may trigger dependency graph recalculation.
    *
    * @param {number} sheetId - ID of a sheet to operate on
-   * @param {number[]} newColumnOrder - permutation of columns
+   * @param {number[]} newColumnOrder - permutation of columns; array length must match the number of columns returned by [getSheetDimensions()](#getsheetdimensions)
    *
    * @fires [[valuesUpdated]] if recalculation was triggered by this change
    *


### PR DESCRIPTION
### Context
<!--- Why are your changes required? What problem do they solve? -->

Improve API reference of:
- getSheetDimensions,
- setColumnOrder
- setRowOrder

Inspired by the discussion in issue https://github.com/handsontable/hyperformula/issues/1471

### How did you test your changes?
<!--- Describe in detail how you tested your changes. -->

local docs build

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [x] Change to the documentation

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [x] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [x] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [x] My change is compatible with Microsoft Excel.
- [x] My change is compatible with Google Sheets.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
