### PR TITLE
Use node 22 LTS in CI/CD scripts

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,7 +18,7 @@ jobs:
   audit:
     strategy:
       matrix:
-        node-version: [ '20' ]
+        node-version: [ '22' ]
         os: [ 'ubuntu-latest' ]
     name: audit
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,7 +18,7 @@ jobs:
   publish-docs:
     strategy:
       matrix:
-        node-version: [ '20' ]
+        node-version: [ '22' ]
         os: [ 'ubuntu-latest' ]
     name: build-docs
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [ 20, 22 ]
+        node-version: [ 20, 22, 24 ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         install-command: [ i, ci ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        node-version: [ '20' ]
+        node-version: [ '22' ]
         os: [ 'ubuntu-latest' ]
     name: lint
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -14,7 +14,7 @@ jobs:
   performance-test:
     strategy:
       matrix:
-        node-version: [ '20' ]
+        node-version: [ '22' ]
         os: [ 'ubuntu-latest' ]
     name: Test performance
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
   publish-docs:
     strategy:
       matrix:
-        node-version: [ '20' ]
+        node-version: [ '22' ]
         os: [ 'ubuntu-latest' ]
     name: publish-docs
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        node-version: [ '20' ]
+        node-version: [ '22' ]
         os: [ 'ubuntu-latest' ]
     name: unit-tests
     runs-on: ${{ matrix.os }}
@@ -37,7 +37,7 @@ jobs:
       - name: Run tests
         run: |
           npm run test:unit.ci -- --coverage
-          
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@6004246f47ab62d32be025ce173b241cd84ac58e # https://github.com/codecov/codecov-action/releases/tag/v1.0.13
         env:
@@ -46,7 +46,7 @@ jobs:
   browser-tests:
     strategy:
       matrix:
-        node-version: [ '20' ]
+        node-version: [ '22' ]
         os: [ 'ubuntu-latest' ]
     name: browser-tests
     runs-on: ${{ matrix.os }}

--- a/docs/guide/building.md
+++ b/docs/guide/building.md
@@ -38,7 +38,7 @@ format , builds ES6 version
 * `npm run bundle:languages` - builds the languages
 * `npm run bundle:typings` - generates TypeScript typing, only emits ‘.d.ts’ declaration files
 
-We use the Node 20 LTS in the build-chain and recommend this version for building. Note that for using (not building) HyperFormula, a wider range of Node versions is supported.
+We use the Node 22 LTS in the build-chain and recommend this version for building. Note that for using (not building) HyperFormula, a wider range of Node versions is supported.
 
 ## Verify the build
 


### PR DESCRIPTION
### Context
<!--- Why are your changes required? What problem do they solve? -->

Migrating from node 20 to 22

### How did you test your changes?
<!--- Describe in detail how you tested your changes. -->

- run test & build script locally
- run test & build script in GH actions

### Related issues:
1. Fixes #1187

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [ ] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [ ] My change is compatible with Microsoft Excel.
- [ ] My change is compatible with Google Sheets.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
