### PR TITLE
Docs: remove CodeSandbox embedded demos and add links to working exa,ples in Stackblitz

### DIFF
--- a/docs/guide/custom-functions.md
+++ b/docs/guide/custom-functions.md
@@ -358,17 +358,11 @@ it('returns a VALUE error if the range argument contains a string', () => {
 
 ## Working demo
 
+Explore the full working example on [Stackblitz](https://stackblitz.com/github/handsontable/hyperformula-demos/tree/3.2.x/custom-functions?v=${$page.buildDateURIEncoded}).
+
 This demo contains the implementation of both the
 [`GREET`](#add-a-simple-custom-function) and
 [`DOUBLE_RANGE`](#advanced-custom-function-example) custom functions.
-
-<iframe
-  :src="`https://codesandbox.io/embed/github/handsontable/hyperformula-demos/tree/3.2.x/custom-functions?autoresize=1&fontsize=11&hidenavigation=1&theme=light&view=preview&v=${$page.buildDateURIEncoded}`"
-  style="width:100%; height:1070px; border:0; border-radius: 4px; overflow:hidden;"
-  title="handsontable/hyperformula-demos: react-demo"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts">
-</iframe>
 
 ## Function options
 

--- a/docs/guide/integration-with-angular.md
+++ b/docs/guide/integration-with-angular.md
@@ -6,10 +6,4 @@ For more details, see the [client-side installation](client-side-installation.md
 
 ## Demo
 
-<iframe
-  :src="`https://codesandbox.io/embed/github/handsontable/hyperformula-demos/tree/3.2.x/angular-demo?autoresize=1&fontsize=11&hidenavigation=1&theme=light&view=preview&v=${$page.buildDateURIEncoded}`"
-  style="width:100%; height:1070px; border:0; border-radius: 4px; overflow:hidden;"
-  title="handsontable/hyperformula-demos: react-demo"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts">
-</iframe>
+Explore the full working example on [Stackblitz](https://stackblitz.com/github/handsontable/hyperformula-demos/tree/3.2.x/angular-demo?v=${$page.buildDateURIEncoded}).

--- a/docs/guide/integration-with-react.md
+++ b/docs/guide/integration-with-react.md
@@ -6,10 +6,4 @@ For more details, see the [client-side installation](client-side-installation.md
 
 ## Demo
 
-<iframe
-  :src="`https://codesandbox.io/embed/github/handsontable/hyperformula-demos/tree/3.2.x/react-demo?autoresize=1&fontsize=11&hidenavigation=1&theme=light&view=preview&v=${$page.buildDateURIEncoded}`"
-  style="width:100%; height:1070px; border:0; border-radius: 4px; overflow:hidden;"
-  title="handsontable/hyperformula-demos: react-demo"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts">
-</iframe>
+Explore the full working example on [Stackblitz](https://stackblitz.com/github/handsontable/hyperformula-demos/tree/3.2.x/react-demo?v=${$page.buildDateURIEncoded}).

--- a/docs/guide/integration-with-svelte.md
+++ b/docs/guide/integration-with-svelte.md
@@ -6,10 +6,4 @@ For more details, see the [client-side installation](client-side-installation.md
 
 ## Demo
 
-<iframe
-  :src="`https://codesandbox.io/embed/github/handsontable/hyperformula-demos/tree/3.2.x/svelte-demo?autoresize=1&fontsize=11&hidenavigation=1&theme=light&view=preview&v=${$page.buildDateURIEncoded}`"
-  style="width:100%; height:1070px; border:0; border-radius: 4px; overflow:hidden;"
-  title="handsontable/hyperformula-demos: react-demo"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts">
-</iframe>
+Explore the full working example on [Stackblitz](https://stackblitz.com/github/handsontable/hyperformula-demos/tree/3.2.x/svelte-demo?v=${$page.buildDateURIEncoded}).

--- a/docs/guide/integration-with-vue.md
+++ b/docs/guide/integration-with-vue.md
@@ -31,14 +31,8 @@ This function prevents Vue from converting the HyperFormula instance into a reac
 
 ## Demo
 
+Explore the full working example on [Stackblitz](https://stackblitz.com/github/handsontable/hyperformula-demos/tree/3.2.x/vue-3-demo?v=${$page.buildDateURIEncoded}).
+
 ::: tip
 This demo uses the [Vue 3](https://v3.vuejs.org/) framework. If you are looking for an example using Vue 2, check out the [code on GitHub](https://github.com/handsontable/hyperformula-demos/tree/2.5.x/vue-demo).
 :::
-
-<iframe
-  :src="`https://codesandbox.io/embed/github/handsontable/hyperformula-demos/tree/3.2.x/vue-3-demo?autoresize=1&fontsize=11&hidenavigation=1&theme=light&view=preview&v=${$page.buildDateURIEncoded}`"
-  style="width:100%; height:1070px; border:0; border-radius: 4px; overflow:hidden;"
-  title="handsontable/hyperformula-demos: react-demo"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts">
-</iframe>


### PR DESCRIPTION
### Context
<!--- Why are your changes required? What problem do they solve? -->

Codesandbox embedded demos were buggy and of poor developer experience. I changed them to simple links to Stackblitz demos.

Affected demos:
- https://hyperformula.handsontable.com/guide/integration-with-react.html#demo
- https://hyperformula.handsontable.com/guide/integration-with-vue.html#demo
- https://hyperformula.handsontable.com/guide/integration-with-angular.html#demo
- https://hyperformula.handsontable.com/guide/integration-with-svelte.html#demo
- https://hyperformula.handsontable.com/guide/custom-functions.html#working-demo

### How did you test your changes?
<!--- Describe in detail how you tested your changes. -->

- local docs build
- tested on staging

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [x] Change to the documentation

### Related issues:
Fixes #1561 
ClickUp issue: https://app.clickup.com/t/9015210959/HF-73
