### PR TITLE
fix: respect defaultValue when arg is AstNodeType.EMPTY

### DIFF
--- a/src/interpreter/plugin/FunctionPlugin.ts
+++ b/src/interpreter/plugin/FunctionPlugin.ts
@@ -25,6 +25,7 @@ import {
 import {Interpreter} from '../Interpreter'
 import {InterpreterState} from '../InterpreterState'
 import {
+  EmptyValue,
   ExtendedNumber,
   FormatInfo,
   getRawValue,
@@ -451,7 +452,12 @@ export abstract class FunctionPlugin implements FunctionPluginTypecheck<Function
 
     for (let i = 0; i < argumentsMetadata.length; i++) {
       const argumentMetadata = argumentsMetadata[i]
-      const argumentValue = vectorizedArguments[i] !== undefined ? vectorizedArguments[i] : argumentMetadata?.defaultValue
+      const rawArg = vectorizedArguments[i]
+      const argumentValue = (rawArg === undefined)
+        ? argumentMetadata?.defaultValue
+        : (rawArg === EmptyValue && argumentMetadata?.defaultValue !== undefined)
+          ? argumentMetadata.defaultValue
+          : rawArg
 
       if (argumentValue === undefined) {
         coercedArguments.push(undefined)


### PR DESCRIPTION
## Problem

When a user writes an empty argument (e.g. `=VLOOKUP(2,A1:B3,2,)`), the parser
produces `AstNodeType.EMPTY` which evaluates to `EmptyValue` (a Symbol sentinel).

The guard in `FunctionPlugin.coerceArgumentsToRequiredTypes` checked only for
`undefined`, so `EmptyValue` passed through and was coerced to `0`/`false` instead
of using the parameter's declared `defaultValue`.

**Affected functions:** any plugin parameter with `defaultValue ≠ 0/false`
(e.g. `LOG` base=10, `VLOOKUP`/`HLOOKUP` sorted=true, `MATCH` matchType=1, `ADDRESS` abs=1).

## Fix

In `FunctionPlugin.coerceArgumentsToRequiredTypes`: when the runtime value is
`EmptyValue` **and** the parameter declares an explicit `defaultValue`, substitute
`defaultValue` instead of passing `EmptyValue` to type coercion.

## Tests

Regression tests in companion PR in `handsontable/hyperformula-tests`
(branch `fix/empty-default-value`): covers VLOOKUP, HLOOKUP, MATCH, ADDRESS, LOG.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared function-argument coercion used by all formula plugins, so behavior changes may surface broadly, but the change is narrow and gated to `EmptyValue` with an explicit `defaultValue`.
> 
> **Overview**
> Fixes argument coercion so explicitly empty arguments (parsed as `AstNodeType.EMPTY` → `EmptyValue`) are treated like “missing” when a parameter defines a `defaultValue`.
> 
> In `FunctionPlugin.coerceArgumentsToRequiredTypes`, `EmptyValue` now substitutes the corresponding `defaultValue` (when provided) before type coercion, preventing empty trailing args from being coerced into `0`/`false` for functions like `LOG`, `VLOOKUP/HLOOKUP`, `MATCH`, and `ADDRESS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f68ecd8a5c143d772288fe7e0ba0febc4f561820. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->