### PR TITLE
Fix: ADDRESS function ignores defaultValue when user provides empty value for an optional parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Fixed the IRR function returning `#NUM!` error when the initial investment significantly exceeds the sum of returns. [#1628](https://github.com/handsontable/hyperformula/issues/1628)
+- Fixed the ADDRESS function ignoring `defaultValue` when arguments are syntactically empty (e.g., `=ADDRESS(2,3,,FALSE())`). [#1632](https://github.com/handsontable/hyperformula/issues/1632)
 
 ## [3.2.0] - 2026-02-19
 

--- a/docs/guide/custom-functions.md
+++ b/docs/guide/custom-functions.md
@@ -423,6 +423,7 @@ You can set the following argument validation options:
 | `maxValue`                | Number                                    | If set: numerical arguments need to be less than or equal to `maxValue`.                                                                                                                                                                           |
 | `lessThan`                | Number                                    | If set: numerical argument needs to be less than `lessThan`.                                                                                                                                                                                       |
 | `greaterThan`             | Number                                    | If set: numerical argument needs to be greater than `greaterThan`.                                                                                                                                                                                 |
+| `emptyAsDefault`          | Boolean                                   | `true`: an empty argument (e.g., `=FUNC(1,,3)`) is treated as missing and falls back to `defaultValue`. By default (`false`), empty arguments are coerced to the zero-value for their type (`0`, `FALSE`, or `""`). Requires `defaultValue` to be set. |
 
 In your function plugin, in the static `implementedFunctions` property, add an
 array called `parameters`:

--- a/src/interpreter/plugin/AddressPlugin.ts
+++ b/src/interpreter/plugin/AddressPlugin.ts
@@ -26,8 +26,8 @@ export class AddressPlugin extends FunctionPlugin implements FunctionPluginTypec
       parameters: [
         {argumentType: FunctionArgumentType.NUMBER},
         {argumentType: FunctionArgumentType.NUMBER},
-        {argumentType: FunctionArgumentType.NUMBER, optionalArg: true, defaultValue: 1, minValue: 1, maxValue: 4},
-        {argumentType: FunctionArgumentType.BOOLEAN, optionalArg: true, defaultValue: true},
+        {argumentType: FunctionArgumentType.NUMBER, optionalArg: true, defaultValue: 1, minValue: 1, maxValue: 4, emptyAsDefault: true},
+        {argumentType: FunctionArgumentType.BOOLEAN, optionalArg: true, defaultValue: true, emptyAsDefault: true},
         {argumentType: FunctionArgumentType.STRING, optionalArg: true},
       ]
     },

--- a/src/interpreter/plugin/FunctionPlugin.ts
+++ b/src/interpreter/plugin/FunctionPlugin.ts
@@ -25,6 +25,7 @@ import {
 import {Interpreter} from '../Interpreter'
 import {InterpreterState} from '../InterpreterState'
 import {
+  EmptyValue,
   ExtendedNumber,
   FormatInfo,
   getRawValue,
@@ -231,6 +232,14 @@ export interface FunctionArgument {
    * If set, numerical arguments need to be greater than `greaterThan`.
    */
   greaterThan?: number,
+
+  /**
+   * If set to `true`, an empty argument (EmptyValue) is treated as if the argument
+   * was omitted — i.e., replaced by `defaultValue`. This matches Excel behavior for
+   * functions like ADDRESS where empty args use declared defaults instead of the
+   * zero-value for the type.
+   */
+  emptyAsDefault?: boolean,
 }
 
 export type PluginFunctionType = (ast: ProcedureAst, state: InterpreterState) => InterpreterValue
@@ -451,7 +460,12 @@ export abstract class FunctionPlugin implements FunctionPluginTypecheck<Function
 
     for (let i = 0; i < argumentsMetadata.length; i++) {
       const argumentMetadata = argumentsMetadata[i]
-      const argumentValue = vectorizedArguments[i] !== undefined ? vectorizedArguments[i] : argumentMetadata?.defaultValue
+      const rawArg = vectorizedArguments[i]
+      const argumentValue = rawArg === undefined
+        ? argumentMetadata?.defaultValue
+        : (rawArg === EmptyValue && argumentMetadata?.emptyAsDefault && argumentMetadata?.defaultValue !== undefined)
+          ? argumentMetadata.defaultValue
+          : rawArg
 
       if (argumentValue === undefined) {
         coercedArguments.push(undefined)

--- a/src/interpreter/plugin/FunctionPlugin.ts
+++ b/src/interpreter/plugin/FunctionPlugin.ts
@@ -234,10 +234,18 @@ export interface FunctionArgument {
   greaterThan?: number,
 
   /**
-   * If set to `true`, an empty argument (EmptyValue) is treated as if the argument
-   * was omitted — i.e., replaced by `defaultValue`. This matches Excel behavior for
-   * functions like ADDRESS where empty args use declared defaults instead of the
-   * zero-value for the type.
+   * If set to `true`, an empty argument is treated as if the argument was not
+   * provided at all — that is, it falls back to `defaultValue`.
+   *
+   * By default (`false`), an empty argument is coerced to the zero-value for its
+   * type (`0` for numbers, `FALSE` for booleans, `""` for strings).
+   *
+   * | Formula          | `emptyAsDefault: false` (default) | `emptyAsDefault: true`        |
+   * |------------------|-----------------------------------|-------------------------------|
+   * | `ADDRESS(2,3)`   | uses `defaultValue` for 3rd arg   | uses `defaultValue` for 3rd arg |
+   * | `ADDRESS(2,3,)`  | uses `0` for 3rd arg              | uses `defaultValue` for 3rd arg |
+   *
+   * Requires `defaultValue` to be set.
    */
   emptyAsDefault?: boolean,
 }

--- a/src/interpreter/plugin/FunctionPlugin.ts
+++ b/src/interpreter/plugin/FunctionPlugin.ts
@@ -25,7 +25,6 @@ import {
 import {Interpreter} from '../Interpreter'
 import {InterpreterState} from '../InterpreterState'
 import {
-  EmptyValue,
   ExtendedNumber,
   FormatInfo,
   getRawValue,
@@ -297,16 +296,17 @@ export abstract class FunctionPlugin implements FunctionPluginTypecheck<Function
     return this.arraySizePredictor.checkArraySizeForAst(ast, state)
   }
 
-  protected listOfScalarValues(asts: Ast[], state: InterpreterState): [InternalScalarValue, boolean][] {
-    const ret: [InternalScalarValue, boolean][] = []
+  protected listOfScalarValues(asts: Ast[], state: InterpreterState): [InternalScalarValue, boolean, boolean][] {
+    const ret: [InternalScalarValue, boolean, boolean][] = []
     for (const argAst of asts) {
+      const isSyntacticallyEmpty = argAst.type === AstNodeType.EMPTY
       const value = this.evaluateAst(argAst, state)
       if (value instanceof SimpleRangeValue) {
         for (const scalarValue of value.valuesFromTopLeftCorner()) {
-          ret.push([scalarValue, true])
+          ret.push([scalarValue, true, isSyntacticallyEmpty])
         }
       } else {
-        ret.push([value, false])
+        ret.push([value, false, isSyntacticallyEmpty])
       }
     }
     return ret
@@ -406,10 +406,10 @@ export abstract class FunctionPlugin implements FunctionPluginTypecheck<Function
     metadata: FunctionMetadata,
     functionImplementation: (...arg: any) => InterpreterValue,
   ): RawInterpreterValue => {
-    const evaluatedArguments: [InterpreterValue, boolean][] = this.evaluateArguments(args, state, metadata)
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    const argumentValues: InterpreterValue[] = evaluatedArguments.map(([value, _]: [InterpreterValue, boolean]) => value as InterpreterValue)
-    const argumentIgnorableFlags = evaluatedArguments.map(([_, ignorable]) => ignorable)
+    const evaluatedArguments = this.evaluateArguments(args, state, metadata)
+    const argumentValues: InterpreterValue[] = evaluatedArguments.map(([value]) => value)
+    const argumentIgnorableFlags = evaluatedArguments.map(([, ignorable]) => ignorable)
+    const syntacticallyEmptyFlags = evaluatedArguments.map(([, , empty]) => empty)
     const argumentMetadata = this.buildMetadataForEachArgumentValue(argumentValues.length, metadata)
     const isVectorizationOn = state.arraysFlag && !metadata.vectorizationForbidden
 
@@ -421,13 +421,13 @@ export abstract class FunctionPlugin implements FunctionPluginTypecheck<Function
 
     if (resultArrayHeight === 1 && resultArrayWidth === 1) {
       const vectorizedArguments = this.vectorizeAndBroadcastArgumentsIfNecessary(isVectorizationOn, argumentValues, argumentMetadata, 0, 0)
-      return this.calculateSingleCellOfResultArray(state, vectorizedArguments, argumentMetadata, argumentIgnorableFlags, functionImplementation, metadata.returnNumberType)
+      return this.calculateSingleCellOfResultArray(state, vectorizedArguments, argumentMetadata, argumentIgnorableFlags, syntacticallyEmptyFlags, functionImplementation, metadata.returnNumberType)
     }
 
     const resultArray: InternalScalarValue[][] = [ ...Array(resultArrayHeight).keys() ].map(row =>
       [ ...Array(resultArrayWidth).keys() ].map(col => {
         const vectorizedArguments = this.vectorizeAndBroadcastArgumentsIfNecessary(isVectorizationOn, argumentValues, argumentMetadata, row, col)
-        const result = this.calculateSingleCellOfResultArray(state, vectorizedArguments, argumentMetadata, argumentIgnorableFlags, functionImplementation, metadata.returnNumberType)
+        const result = this.calculateSingleCellOfResultArray(state, vectorizedArguments, argumentMetadata, argumentIgnorableFlags, syntacticallyEmptyFlags, functionImplementation, metadata.returnNumberType)
 
         if (result instanceof SimpleRangeValue) {
           throw new Error('Function returning array cannot be vectorized.')
@@ -445,10 +445,11 @@ export abstract class FunctionPlugin implements FunctionPluginTypecheck<Function
     vectorizedArguments: Maybe<InterpreterValue>[],
     argumentsMetadata: FunctionArgument[],
     argumentIgnorableFlags: boolean[],
+    syntacticallyEmptyFlags: boolean[],
     functionImplementation: (...arg: any) => InterpreterValue,
     returnNumberType: NumberType | undefined,
   ): RawInterpreterValue {
-    const coercedArguments = this.coerceArgumentsToRequiredTypes(state, vectorizedArguments, argumentsMetadata, argumentIgnorableFlags)
+    const coercedArguments = this.coerceArgumentsToRequiredTypes(state, vectorizedArguments, argumentsMetadata, argumentIgnorableFlags, syntacticallyEmptyFlags)
 
     if (coercedArguments instanceof CellError) {
       return coercedArguments
@@ -463,6 +464,7 @@ export abstract class FunctionPlugin implements FunctionPluginTypecheck<Function
     vectorizedArguments: Maybe<InterpreterValue>[],
     argumentsMetadata: FunctionArgument[],
     argumentIgnorableFlags: boolean[],
+    syntacticallyEmptyFlags: boolean[],
   ):  CellError | Maybe<InterpreterValue | complex | RawNoErrorScalarValue>[] {
     const coercedArguments: Maybe<InterpreterValue | complex | RawNoErrorScalarValue>[] = []
 
@@ -471,7 +473,7 @@ export abstract class FunctionPlugin implements FunctionPluginTypecheck<Function
       const rawArg = vectorizedArguments[i]
       const argumentValue = rawArg === undefined
         ? argumentMetadata?.defaultValue
-        : (rawArg === EmptyValue && argumentMetadata?.emptyAsDefault && argumentMetadata?.defaultValue !== undefined)
+        : (syntacticallyEmptyFlags[i] && argumentMetadata?.emptyAsDefault && argumentMetadata?.defaultValue !== undefined)
           ? argumentMetadata.defaultValue
           : rawArg
 
@@ -511,8 +513,10 @@ export abstract class FunctionPlugin implements FunctionPluginTypecheck<Function
     return argumentValue.data[targetRowNum]?.[targetColNum]
   }
 
-  protected evaluateArguments(args: Ast[], state: InterpreterState, metadata: FunctionMetadata): [InterpreterValue, boolean][] {
-    return metadata.expandRanges ? this.listOfScalarValues(args, state) : args.map((ast) => [this.evaluateAst(ast, state), false])
+  protected evaluateArguments(args: Ast[], state: InterpreterState, metadata: FunctionMetadata): [InterpreterValue, boolean, boolean][] {
+    return metadata.expandRanges
+      ? this.listOfScalarValues(args, state)
+      : args.map((ast) => [this.evaluateAst(ast, state), false, ast.type === AstNodeType.EMPTY])
   }
 
   protected buildMetadataForEachArgumentValue(numberOfArgumentValuesPassed: number, metadata: FunctionMetadata): FunctionArgument[] {


### PR DESCRIPTION
## Problem

When a user writes `=ADDRESS(1,1,)` or `=ADDRESS(1,1,1,)`, the empty argument
is coerced to `0`/`false` instead of using the parameter's declared `defaultValue`.

Excel 2021 and Google Sheets treat empty args as the zero-value for the type
(`0`/`FALSE`) for **all functions except ADDRESS**, where empty `absNum` and
`a1Style` use their declared defaults (1 and `true`).

Fixes #1632

## Fix

- Add `emptyAsDefault` opt-in flag to `FunctionArgument` interface
- In `coerceArgumentsToRequiredTypes`: when `rawArg === EmptyValue` AND
  `emptyAsDefault` is set AND `defaultValue` is declared → substitute `defaultValue`
- Apply `emptyAsDefault: true` only to ADDRESS `absNum` and `a1Style` parameters

## Tests

Regression tests in `handsontable/hyperformula-tests` (branch `fix/empty-default-value`):
- ADDRESS: isolated tests for empty `absNum`, empty `a1Style`, both empty
- LOG, MATCH, VLOOKUP, HLOOKUP: confirm empty → zero-value (not defaultValue)
- `optional-parameters.spec.ts`: confirms empty args use zero-value coercion (not defaultValue) when `emptyAsDefault` is not set



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `FunctionPlugin` argument evaluation/coercion to distinguish syntactically empty arguments, which could subtly affect coercion behavior across many functions if misapplied. Change is gated behind an opt-in `emptyAsDefault` flag and only enabled for `ADDRESS` parameters in this PR.
> 
> **Overview**
> Fixes `ADDRESS` so syntactically empty optional arguments (e.g. `=ADDRESS(2,3,,FALSE())`) use the parameter `defaultValue` instead of being coerced to the type’s zero-value.
> 
> Adds an opt-in `emptyAsDefault` flag to `FunctionArgument` and extends `FunctionPlugin`’s argument evaluation pipeline to track whether each argument was syntactically empty, allowing coercion to substitute `defaultValue` when `emptyAsDefault` is enabled. Documentation and changelog are updated to reflect the new option and the `ADDRESS` behavior fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c6fc7c8097bd45af74f645ba4e6355427c201b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->