### PR TITLE
Describe Definition of Done for the code changes

### DIFF
--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -7,9 +7,12 @@ Random notes and things to know useful for maintainers and contributors.
 Each change to the production code (bugfixes, new features, improvements) must include these elements. They must be present in the pull request BEFORE requesting the code review.
 
 - changes to the production code
+  - including changes to all supported language packs in `src/i18n/languages` directory (if applicable)
 - automatic tests
   - for bugfixes: at least one test reproducing the bug
   - for new features: a set of tests describing the feature specification precisely
+  - pull requests from external contributors should include tests in `tests/` directory (they will be moved to the private repository by the internal team)
+  - internal team adds tests directly to the private repository (through a separate pull request)
 - updates to documentation related to the change
   - for breaking changes: a section in the migration guide
 - technical documentation in the form of the jsdoc comments (high-level description of the concepts used in the more complex code fragments)

--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -2,6 +2,20 @@
 
 Random notes and things to know useful for maintainers and contributors.
 
+## Definition of Done for the code changes
+
+Each change to the production code (bugfixes, new features, improvements) must include these elements. They must be present in the pull request BEFORE requesting the code review.
+
+- changes to the production code
+- automatic tests
+  - for bugfixes: at least one test reproducing the bug
+  - for new features: a set of tests describing the feature specification precisely
+- updates to documentation related to the change
+  - for breaking changes: a section in the migration guide
+- technical documentation in the form of the jsdoc comments (high-level description of the concepts used in the more complex code fragments)
+- changelog entry
+- pull request description
+
 ## Sources of the function translations
 
 HF supports internationalization and provides the localized function names for all built-in languages. When looking for the valid translations for the new functions, try these sources:


### PR DESCRIPTION
Adding `Definition of Done for the code changes` to the DEV_DOCS.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds contribution/process guidance; no runtime behavior or data/security impact.
> 
> **Overview**
> Adds a new **"Definition of Done"** section to `DEV_DOCS.md` describing what production-code PRs must include before review (code changes incl. i18n packs when relevant, tests expectations for internal vs. external contributors, related docs/migration guide updates, JSDoc/technical docs, changelog entry, and PR description).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d7351fc67451c647f9db8d79d8079fcbd816728. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->