### PR TITLE
Fix Netlify publish dir so /docs/ is reachable

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   command = "npm run docs:build"
-  publish = "docs/.vuepress/dist/docs"
+  publish = "docs/.vuepress/dist"
 
 [build.environment]
   NODE_VERSION = "18"


### PR DESCRIPTION
## Summary
Follow-up to #1663. The Netlify deploy succeeded but `https://hyperformula-docs.netlify.app/docs/` returns 404.

Root cause: with `base: '/docs/'`, VuePress emits assets and internal links under `/docs/...` and writes the build to `docs/.vuepress/dist/docs/`. Setting `publish = "docs/.vuepress/dist/docs"` made Netlify serve those files at `/`, so the page rendered but every internal `/docs/...` reference 404'd. The publish dir must be the **parent** of the base path so the on-disk `docs/` subdirectory becomes the URL `/docs/`.

Change: `publish = "docs/.vuepress/dist"` in `netlify.toml`.

## Test plan
- [ ] Netlify deploys successfully.
- [ ] `https://hyperformula-docs.netlify.app/docs/` renders the docs home (no 404).
- [ ] Sub-pages like `/docs/guide/demo.html` load with assets and CSS intact.
- [ ] `/sitemap.xml` is reachable and entries point at `https://hyperformula.handsontable.com/docs/...`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that affects where Netlify serves built docs from; primary risk is misconfiguration leading to broken/404 docs paths.
> 
> **Overview**
> Fixes the Netlify deployment config by changing the `publish` directory from `docs/.vuepress/dist/docs` to `docs/.vuepress/dist`, ensuring the built `docs/` subdirectory is served at `/docs/` and internal asset/link paths resolve correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be5594b279e2edbc67776df9700ebc9e11712d8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->