### PR TITLE
docs: rewrite AI SDK landing page to model Exa's reference DX

### DIFF
--- a/docs/guide/ai-sdk.md
+++ b/docs/guide/ai-sdk.md
@@ -2,11 +2,27 @@
 
 Let LLMs safely read/write spreadsheets and compute formulas via a deterministic engine.
 
+::: tip Beta — coming soon
+The HyperFormula AI SDK is in early development. The API shown below is a preview and may change before the first release. [Sign up for beta access](https://2fmjvg.share-eu1.hsforms.com/2e6drCkuLTn-1RuiYB91eJA) to get notified and shape the design.
+:::
+
 ## What it does
 
-- **Evaluate formulas on the fly** —call `calculateFormula()` to evaluate any Excel-compatible formula without placing it in a cell.
-- **Read and write cells and ranges** —get or set individual cells and multi-cell ranges so an LLM can inspect, populate, or modify sheet data programmatically.
-- **Trace dependencies** —call `getCellDependents()` and `getCellPrecedents()` to understand which cells feed into a formula and what downstream values would change.
+- **Evaluate formulas on the fly** — run any Excel-compatible formula without placing it in a cell.
+- **Read and write cells and ranges** — let an agent inspect, populate, or modify sheet data programmatically.
+- **Trace dependencies** — surface precedents and dependents so the model can explain how a value is derived.
+
+## Install
+
+```bash
+npm install hyperformula
+```
+
+The SDK is framework-agnostic — the tool definitions are plain functions you can wire into any agent runtime (Vercel AI SDK, LangChain, OpenAI Agents SDK, MCP servers, or your own tool loop).
+
+## Setup
+
+No API key. HyperFormula runs locally — in the browser or in Node.js — and never sends data to a remote service. Calculations are deterministic: the same inputs always produce the same outputs.
 
 ## Quickstart
 
@@ -14,38 +30,86 @@ Let LLMs safely read/write spreadsheets and compute formulas via a deterministic
 import HyperFormula from 'hyperformula';
 import { createSpreadsheetTools } from 'hyperformula/ai';
 
-// 1. Create a HyperFormula instance with initial data
 const hf = HyperFormula.buildFromArray([
   ['Revenue', 100],
   ['Cost',     60],
   ['Profit', '=B1-B2'],
 ]);
 
-// 2. Create tools your LLM agent can call
+// Returns a map of tool definitions ready to pass to your agent runtime.
 const tools = createSpreadsheetTools(hf);
 
-// 3. Agent interaction examples
 tools.evaluate({ formula: '=IRR({-1000,300,400,500,200})' });
 // → 0.1189 — deterministic, no LLM math
-
-tools.setCellContents({ sheet: 0, col: 1, row: 0, value: 200 });
-tools.getRange({ sheet: 0, startCol: 0, startRow: 0, endCol: 1, endRow: 2 });
-// → [['Revenue', 200], ['Cost', 60], ['Profit', 140]]
-
-// Agent: "What drives the profit number?"
-tools.getDependents({ sheet: 0, col: 1, row: 0 });
-// → [{ sheet: 0, col: 1, row: 2 }] — Revenue flows into Profit
 ```
+
+## Example: Vercel AI SDK
+
+Wire the tools into [`generateText`](https://sdk.vercel.ai/docs) so the model can call them during a turn:
+
+```js
+import { generateText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import HyperFormula from 'hyperformula';
+import { createSpreadsheetTools } from 'hyperformula/ai';
+
+const hf = HyperFormula.buildFromArray([
+  ['Revenue', 100],
+  ['Cost',     60],
+  ['Profit', '=B1-B2'],
+]);
+
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools: createSpreadsheetTools(hf),
+  prompt: 'What drives the profit number, and what happens if revenue doubles?',
+});
+```
+
+The same `tools` object can be adapted to LangChain, OpenAI Agents SDK, or MCP — the underlying functions accept and return plain JSON.
 
 ## Use cases
 
-- **Explain a sheet** —ask an agent to summarize what a spreadsheet does, which cells are inputs, and how outputs are derived.
-- **Generate a what-if scenario** —let the model tweak assumptions (price, volume, rate) and observe how results change in real time.
-- **Validate and clean data** —have the agent scan ranges for errors, missing values, or inconsistencies and fix them with formulas or direct edits.
-- **Create formulas from natural language** —describe a calculation in plain English and let the model write and verify the correct Excel formula.
+- **Explain a sheet** — summarize what a spreadsheet does, which cells are inputs, and how outputs are derived.
+- **Generate a what-if scenario** — let the model tweak assumptions and observe how results change in real time.
+- **Validate and clean data** — scan ranges for errors, missing values, or inconsistencies and fix them with formulas or direct edits.
+- **Create formulas from natural language** — describe a calculation in plain English and let the model write and verify the correct Excel formula.
 
-## Beta access
+## Safety and guardrails
 
-::: tip
-[Sign up for beta access](https://2fmjvg.share-eu1.hsforms.com/2e6drCkuLTn-1RuiYB91eJA)
-:::
+Because HyperFormula is a pure calculation engine, the agent's blast radius is limited to the in-memory workbook you hand it. There is no filesystem, network, or shell access through the tools.
+
+Planned controls for the first beta:
+
+- **Permissions per tool** — opt in to read-only, write, or formula-evaluation tools individually.
+- **Range scoping** — restrict an agent to a named range, sheet, or address pattern.
+- **Operation limits** — cap the number of cell writes or formula evaluations per turn.
+- **Audit log** — every tool call returns a structured record of what changed.
+
+Persistence (saving the modified workbook back to your data store) stays in your application code — the SDK never writes outside the `HyperFormula` instance you pass in.
+
+## All options
+
+`createSpreadsheetTools(hf, options?)` returns a tool map. Planned options:
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `include` | `string[]` | Whitelist of tool names to expose (e.g. `['evaluate', 'getRange']`). |
+| `exclude` | `string[]` | Tools to hide from the agent. |
+| `readOnly` | `boolean` | Disable all mutating tools. |
+| `scope` | `{ sheet?: number; range?: SimpleCellRange }` | Restrict reads/writes to a sheet or range. |
+| `maxWritesPerCall` | `number` | Hard cap on cell writes per tool invocation. |
+
+The default tool set covers formula evaluation, single-cell and range reads, single-cell and range writes, and dependency tracing. The full surface will be documented alongside the first beta release.
+
+## TypeScript support
+
+Tool argument and return types are fully typed and re-exported from `hyperformula/ai`, so your agent runtime gets end-to-end type inference without extra `as` casts.
+
+## Links
+
+- [Sign up for beta access](https://2fmjvg.share-eu1.hsforms.com/2e6drCkuLTn-1RuiYB91eJA)
+- [HyperFormula on GitHub](https://github.com/handsontable/hyperformula)
+- [HyperFormula on npm](https://www.npmjs.com/package/hyperformula)
+- [Built-in functions](built-in-functions.md)
+- [Custom functions](custom-functions.md)


### PR DESCRIPTION
## Summary
- Restructure [docs/guide/ai-sdk.md](docs/guide/ai-sdk.md) to follow Exa's developer-reference layout: Install → Setup → Quickstart → Example → Use cases → Safety → All options → TypeScript → Links.
- Frame the SDK as framework-agnostic with Vercel AI SDK as the headline integration example.
- Mark the SDK as beta/preview to set expectations against the still-placeholder API surface, and add the Safety and guardrails section called out in the HF-53 brief.

Closes [HF-53](https://app.clickup.com/t/86c7upjar).

## Test plan
- [ ] `npm run docs:dev` and verify the page renders under Guide → Integrations → HyperFormula AI SDK.
- [ ] Confirm all internal links (built-in functions, custom functions) and external links (HubSpot beta form, GitHub, npm) resolve.
- [ ] Sanity-check that no other guide pages are affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior modifications; main risk is minor user confusion if previewed APIs/options diverge from implementation.
> 
> **Overview**
> Rewrites `docs/guide/ai-sdk.md` into a more complete landing page with a clear flow (*Install → Setup → Quickstart → Example → Use cases → Safety → Options → TS → Links*) and positions the AI SDK as **beta/preview**.
> 
> Adds a concrete Vercel AI SDK `generateText` integration snippet, expands messaging around local/deterministic execution, and introduces a new **Safety and guardrails** section plus a table of planned `createSpreadsheetTools` options and TypeScript typing notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 810de4b891f644a8810ee11efde97c8a098ec347. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->