### PR TITLE
docs: reframe AI SDK page as Vercel integration with prototype status

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -216,7 +216,7 @@ module.exports = {
             ['/guide/integration-with-vue', 'Integration with Vue'],
             ['/guide/integration-with-angular', 'Integration with Angular'],
             ['/guide/integration-with-svelte', 'Integration with Svelte'],
-            ['/guide/ai-sdk', 'HyperFormula AI SDK'],
+            ['/guide/ai-sdk', 'Integration with Vercel AI SDK'],
             ['/guide/integration-with-langchain', 'Integration with LangChain'],
             ['/guide/mcp-server', 'HyperFormula MCP Server'],
           ]

--- a/docs/guide/ai-sdk.md
+++ b/docs/guide/ai-sdk.md
@@ -1,51 +1,72 @@
-# HyperFormula AI SDK
+# HyperFormula AI SDK for Vercel
 
-Let LLMs safely read/write spreadsheets and compute formulas via a deterministic engine.
+A [Vercel AI SDK](https://sdk.vercel.ai/docs) tool that gives your agents deterministic spreadsheet and formula computation — backed by HyperFormula's Excel-compatible engine.
+
+::: warning Prototype — not yet released
+We have a working prototype. We'll make it available as soon as we open the beta. The API below is a preview and is likely to change before the first release.
+:::
 
 ## What it does
 
-- **Evaluate formulas on the fly** —call `calculateFormula()` to evaluate any Excel-compatible formula without placing it in a cell.
-- **Read and write cells and ranges** —get or set individual cells and multi-cell ranges so an LLM can inspect, populate, or modify sheet data programmatically.
-- **Trace dependencies** —call `getCellDependents()` and `getCellPrecedents()` to understand which cells feed into a formula and what downstream values would change.
+- **Evaluate formulas on the fly** — your agent runs any Excel-compatible formula without placing it in a cell, so the model never has to do math itself.
+- **Read and write cells and ranges** — the agent inspects, populates, or modifies sheet data through typed tool calls.
+- **Trace dependencies** — precedents and dependents are surfaced so the agent can explain how a value is derived.
 
-## Quickstart
+## Example
+
+Using HyperFormula as a tool inside the Vercel AI SDK:
 
 ```js
+import { generateText } from 'ai';
+import { openai } from '@ai-sdk/openai';
 import HyperFormula from 'hyperformula';
 import { createSpreadsheetTools } from 'hyperformula/ai';
 
-// 1. Create a HyperFormula instance with initial data
+// Build a workbook your agent can reason about.
 const hf = HyperFormula.buildFromArray([
   ['Revenue', 100],
   ['Cost',     60],
   ['Profit', '=B1-B2'],
 ]);
 
-// 2. Create tools your LLM agent can call
-const tools = createSpreadsheetTools(hf);
-
-// 3. Agent interaction examples
-tools.evaluate({ formula: '=IRR({-1000,300,400,500,200})' });
-// → 0.1189 — deterministic, no LLM math
-
-tools.setCellContents({ sheet: 0, col: 1, row: 0, value: 200 });
-tools.getRange({ sheet: 0, startCol: 0, startRow: 0, endCol: 1, endRow: 2 });
-// → [['Revenue', 200], ['Cost', 60], ['Profit', 140]]
-
-// Agent: "What drives the profit number?"
-tools.getDependents({ sheet: 0, col: 1, row: 0 });
-// → [{ sheet: 0, col: 1, row: 2 }] — Revenue flows into Profit
+// Pass the spreadsheet tools straight into generateText.
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools: createSpreadsheetTools(hf),
+  prompt: 'What drives the profit number, and what happens if revenue doubles?',
+});
 ```
+
+A single import, one extra line in `tools`, and the model can evaluate formulas, read ranges, and edit cells through the SDK — without inventing numbers.
 
 ## Use cases
 
-- **Explain a sheet** —ask an agent to summarize what a spreadsheet does, which cells are inputs, and how outputs are derived.
-- **Generate a what-if scenario** —let the model tweak assumptions (price, volume, rate) and observe how results change in real time.
-- **Validate and clean data** —have the agent scan ranges for errors, missing values, or inconsistencies and fix them with formulas or direct edits.
-- **Create formulas from natural language** —describe a calculation in plain English and let the model write and verify the correct Excel formula.
+- **Explain a sheet** — an agent summarizes what a spreadsheet does, which cells are inputs, and how outputs are derived.
+- **Generate a what-if scenario** — the model tweaks assumptions and reports how downstream results change.
+- **Validate and clean data** — the agent scans ranges for errors, missing values, or inconsistencies and fixes them in place.
+- **Create formulas from natural language** — the model translates a plain-English calculation into a verified Excel formula.
 
-## Beta access
+## Safety and guardrails
+
+HyperFormula runs locally in your Node.js or browser process — there's no remote service and no network or filesystem access through the tools. The agent's blast radius is limited to the in-memory workbook you hand it.
+
+Planned for the beta:
+
+- **Permissions per tool** — opt in to read-only, write, or formula-evaluation tools individually.
+- **Range scoping** — restrict an agent to a named range, sheet, or address pattern.
+- **Operation limits** — cap the number of cell writes or formula evaluations per turn.
+- **Audit log** — every tool call returns a structured record of what changed.
+
+## Join the waitlist
 
 ::: tip
-[Sign up for beta access](https://2fmjvg.share-eu1.hsforms.com/2e6drCkuLTn-1RuiYB91eJA)
+**When we're ready to launch the beta, you'll be the first to know.** [Drop your email in the waitlist →](https://2fmjvg.share-eu1.hsforms.com/2e6drCkuLTn-1RuiYB91eJA)
 :::
+
+## Links
+
+- [Vercel AI SDK documentation](https://sdk.vercel.ai/docs)
+- [HyperFormula on GitHub](https://github.com/handsontable/hyperformula)
+- [HyperFormula on npm](https://www.npmjs.com/package/hyperformula)
+- [Built-in functions](built-in-functions.md)
+- [Custom functions](custom-functions.md)


### PR DESCRIPTION
## Summary
- Reframe [docs/guide/ai-sdk.md](docs/guide/ai-sdk.md) around a HyperFormula + Vercel AI SDK integration with a single integrated `generateText` example as the only code block.
- Mark the SDK as an unreleased prototype via a top-of-page warning callout, and add a prominent waitlist CTA with the existing HubSpot form.
- Rename the sidebar entry in [docs/.vuepress/config.js](docs/.vuepress/config.js) to "Integration with Vercel AI SDK".

Closes [HF-53](https://app.clickup.com/t/86c7upjar). Supersedes #1667.

## Test plan
- [ ] `npm run docs:dev`, open `/guide/ai-sdk`, confirm sidebar reads "Integration with Vercel AI SDK" and the prototype callout sits above the fold.
- [ ] Confirm the Vercel `generateText` snippet is the only code block and the page no longer carries Install / Setup / All options / TypeScript sections.
- [ ] Click the waitlist link and external links (Vercel docs, GitHub, npm); click internal links to built-in / custom functions guides.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes (sidebar label and guide content) with no runtime or API behavior impact.
> 
> **Overview**
> Reframes `docs/guide/ai-sdk.md` as **HyperFormula tools for the Vercel AI SDK**, adding a top-of-page *prototype/not-yet-released* warning, a single `generateText`-based example, updated use cases, and a waitlist CTA plus relevant links.
> 
> Renames the guide’s sidebar entry in `docs/.vuepress/config.js` from “HyperFormula AI SDK” to **“Integration with Vercel AI SDK”**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eb3e852deac008060102aba5ce5307401fe8e92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->