### PR TITLE
Refine the AI toolkits landing pages

### DIFF
--- a/docs/guide/ai-sdk.md
+++ b/docs/guide/ai-sdk.md
@@ -2,15 +2,18 @@
 
 A [Vercel AI SDK](https://sdk.vercel.ai/docs) tool that gives your agents deterministic spreadsheet and formula computation — backed by HyperFormula's Excel-compatible engine.
 
-::: warning Prototype — not yet released
-We have a working prototype. We'll make it available as soon as we open the beta. The API below is a preview and is likely to change before the first release.
+::: warning Not available yet — coming soon
+This integration is on our roadmap and **cannot be installed or used today**. The API shown below is a preview and may still change before the first release.
+
+If you'd like to try it, [join the early access list](https://2fmjvg.share-eu1.hsforms.com/2e6drCkuLTn-1RuiYB91eJA) — we'll ping you the moment the first beta is ready, and your sign-up directly tells us how strongly to prioritize this integration.
 :::
 
 ## What it does
 
-- **Evaluate formulas on the fly** — your agent runs any Excel-compatible formula without placing it in a cell, so the model never has to do math itself.
+- **Evaluate formulas deterministically** — your agent runs any Excel-compatible formula through HyperFormula instead of asking the LLM to do math. Results are exact, reproducible, and auditable.
 - **Read and write cells and ranges** — the agent inspects, populates, or modifies sheet data through typed tool calls.
-- **Trace dependencies** — precedents and dependents are surfaced so the agent can explain how a value is derived.
+- **Trace dependencies** — precedents and dependents are surfaced so the agent can explain how every value was derived.
+- **400+ built-in functions out of the box** — the agent has access to the full Excel-compatible function set (`SUM`, `VLOOKUP`, `IRR`, `INDEX/MATCH`, and the rest), no implementation work required.
 
 ## Example
 
@@ -41,26 +44,18 @@ A single import, one extra line in `tools`, and the model can evaluate formulas,
 
 ## Use cases
 
-- **Explain a sheet** — an agent summarizes what a spreadsheet does, which cells are inputs, and how outputs are derived.
-- **Generate a what-if scenario** — the model tweaks assumptions and reports how downstream results change.
+- **Spreadsheet Q&A** — ask the agent what a workbook does, which cells are inputs, and how each output is derived; get answers grounded in real formula evaluation.
+- **What-if scenarios and forecasting** — the agent tweaks assumptions and reports how downstream results change, deterministically.
 - **Validate and clean data** — the agent scans ranges for errors, missing values, or inconsistencies and fixes them in place.
-- **Create formulas from natural language** — the model translates a plain-English calculation into a verified Excel formula.
+- **Generate formulas from natural language** — the agent translates a plain-English calculation into a verified, working Excel formula.
+- **Financial modeling and reporting** — NPV, IRR, amortization, KPI rollups, and other quantitative workflows where the answer must be exact and auditable.
 
-## Safety and guardrails
+## Get early access
 
-HyperFormula runs locally in your Node.js or browser process — there's no remote service and no network or filesystem access through the tools. The agent's blast radius is limited to the in-memory workbook you hand it.
+::: tip Be the first to try it
+We're actively building this integration. Drop your email and we'll notify you the moment the first beta lands — so you can try it before the public release.
 
-Planned for the beta:
-
-- **Permissions per tool** — opt in to read-only, write, or formula-evaluation tools individually.
-- **Range scoping** — restrict an agent to a named range, sheet, or address pattern.
-- **Operation limits** — cap the number of cell writes or formula evaluations per turn.
-- **Audit log** — every tool call returns a structured record of what changed.
-
-## Join the waitlist
-
-::: tip
-**When we're ready to launch the beta, you'll be the first to know.** [Drop your email in the waitlist →](https://2fmjvg.share-eu1.hsforms.com/2e6drCkuLTn-1RuiYB91eJA)
+[Join the early access list →](https://2fmjvg.share-eu1.hsforms.com/2e6drCkuLTn-1RuiYB91eJA)
 :::
 
 ## Links

--- a/docs/guide/integration-with-langchain.md
+++ b/docs/guide/integration-with-langchain.md
@@ -1,53 +1,71 @@
 # Integration with LangChain/LangGraph
 
-A LangChain/LangGraph tool that gives AI agents deterministic, Excel-compatible formula evaluation instead of relying on LLM-generated math.
+A [LangChain.js](https://js.langchain.com/) / [LangGraph](https://langchain-ai.github.io/langgraphjs/) tool that gives your agents deterministic spreadsheet and formula computation — backed by HyperFormula's Excel-compatible engine.
+
+::: warning Not available yet — coming soon
+This integration is on our roadmap and **cannot be installed or used today**. The API shown below is a preview and may still change before the first release.
+
+If you'd like to try it, [join the early access list](https://2fmjvg.share-eu1.hsforms.com/2e6drCkuLTn-1RuiYB91eJA) — we'll ping you the moment the first beta is ready, and your sign-up directly tells us how strongly to prioritize this integration.
+:::
 
 ## What it does
 
-**Without HyperFormula:**
+- **Evaluate formulas deterministically** — your agent runs any Excel-compatible formula through HyperFormula instead of asking the LLM to do math. Results are exact, reproducible, and auditable.
+- **Read and write cells and ranges** — the agent inspects, populates, or modifies sheet data through typed tool calls.
+- **Trace dependencies** — precedents and dependents are surfaced so the agent can explain how every value was derived.
+- **400+ built-in functions out of the box** — the agent has access to the full Excel-compatible function set (`SUM`, `VLOOKUP`, `IRR`, `INDEX/MATCH`, and the rest), no implementation work required.
 
-```python
-result = llm.invoke(
-    "Calculate the IRR for these cash flows: [-1000, 300, 400, 500, 200]"
-)
-# "The IRR is approximately 12.4%" ← non-deterministic, unverifiable
+## Example
+
+Wiring HyperFormula into a LangGraph ReAct agent:
+
+```js
+import { ChatOpenAI } from '@langchain/openai';
+import { createReactAgent } from '@langchain/langgraph/prebuilt';
+import HyperFormula from 'hyperformula';
+import { createSpreadsheetTools } from 'hyperformula/langchain';
+
+const hf = HyperFormula.buildFromArray([
+  ['Revenue', 100],
+  ['Cost',     60],
+  ['Profit', '=B1-B2'],
+]);
+
+const agent = createReactAgent({
+  llm: new ChatOpenAI({ model: 'gpt-4o' }),
+  tools: createSpreadsheetTools(hf),
+});
+
+await agent.invoke({
+  messages: [
+    { role: 'user', content: 'What drives the profit number, and what happens if revenue doubles?' },
+  ],
+});
 ```
 
-**With HyperFormula tool:**
-
-```python
-from langchain_core.tools import tool
-from hyperformula import HyperFormula
-
-hf = HyperFormula.build_from_array([[-1000, 300, 400, 500, 200]])
-
-@tool
-def evaluate_formula(formula: str) -> str:
-    """Evaluate an Excel-compatible formula using HyperFormula."""
-    return hf.calculate_formula(formula, sheet_id=0)
-
-agent = create_react_agent(llm, [evaluate_formula])
-
-# Agent calls: evaluate_formula("=IRR(A1:E1)")
-# → 0.1189 ← deterministic, auditable
-```
-
-## How it works
-
-1. **Agent populates a HyperFormula sheet** —writes data and formulas (`=SUM`, `=IF`, `=VLOOKUP`, etc.) into cells.
-2. **HyperFormula evaluates deterministically** —resolves the full dependency graph using 400+ built-in functions. No LLM in the loop for math.
-3. **Agent continues with verified data** —computed values flow back into the chain for reasoning, reporting, or downstream actions.
+A single import, one entry in `tools`, and the agent can evaluate formulas, read ranges, and edit cells through LangChain — without inventing numbers.
 
 ## Use cases
 
-- Financial modeling (NPV, IRR, amortization)
-- Data transformation and aggregation (SUMIF, VLOOKUP)
-- Dynamic pricing with formula-defined logic
-- What-if scenarios and forecasting
-- Report generation with verified KPIs
+- **Spreadsheet Q&A** — ask the agent what a workbook does, which cells are inputs, and how each output is derived; get answers grounded in real formula evaluation.
+- **What-if scenarios and forecasting** — the agent tweaks assumptions and reports how downstream results change, deterministically.
+- **Validate and clean data** — the agent scans ranges for errors, missing values, or inconsistencies and fixes them in place.
+- **Generate formulas from natural language** — the agent translates a plain-English calculation into a verified, working Excel formula.
+- **Financial modeling and reporting** — NPV, IRR, amortization, KPI rollups, and other quantitative workflows where the answer must be exact and auditable.
 
-## Beta access
+## Get early access
 
-::: tip
-[Sign up for beta access](https://2fmjvg.share-eu1.hsforms.com/2e6drCkuLTn-1RuiYB91eJA)
+::: tip Be the first to try it
+We're actively building this integration. Drop your email and we'll notify you the moment the first beta lands — so you can try it before the public release.
+
+[Join the early access list →](https://2fmjvg.share-eu1.hsforms.com/2e6drCkuLTn-1RuiYB91eJA)
 :::
+
+## Links
+
+- [LangChain.js documentation](https://js.langchain.com/)
+- [LangGraph documentation](https://langchain-ai.github.io/langgraphjs/)
+- [HyperFormula on GitHub](https://github.com/handsontable/hyperformula)
+- [HyperFormula on npm](https://www.npmjs.com/package/hyperformula)
+- [Built-in functions](built-in-functions.md)
+- [Custom functions](custom-functions.md)

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -1,44 +1,63 @@
 # HyperFormula MCP Server
 
-An MCP (Model Context Protocol) server that exposes HyperFormula as a tool for any MCP-compatible AI client, giving LLMs deterministic spreadsheet computation.
+An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that exposes HyperFormula as a tool for any MCP-compatible AI client (Claude Desktop, Cursor, VS Code, and others) — giving LLMs deterministic spreadsheet and formula computation.
+
+::: warning Not available yet — coming soon
+This integration is on our roadmap and **cannot be installed or used today**. The API shown below is a preview and may still change before the first release.
+
+If you'd like to try it, [join the early access list](https://2fmjvg.share-eu1.hsforms.com/2e6drCkuLTn-1RuiYB91eJA) — we'll ping you the moment the first beta is ready, and your sign-up directly tells us how strongly to prioritize this integration.
+:::
 
 ## What it does
 
-- **Evaluate formulas** —any MCP client can call HyperFormula to evaluate Excel-compatible formulas and get exact results.
-- **Read and write cells** —get or set individual cell values and ranges through standard MCP tool calls.
-- **Inspect dependencies** —trace which cells a formula depends on and understand the calculation graph.
+- **Evaluate formulas deterministically** — your agent runs any Excel-compatible formula through HyperFormula instead of asking the LLM to do math. Results are exact, reproducible, and auditable.
+- **Read and write cells and ranges** — the agent inspects, populates, or modifies sheet data through typed tool calls.
+- **Trace dependencies** — precedents and dependents are surfaced so the agent can explain how every value was derived.
+- **400+ built-in functions out of the box** — the agent has access to the full Excel-compatible function set (`SUM`, `VLOOKUP`, `IRR`, `INDEX/MATCH`, and the rest), no implementation work required.
 
-**Without HyperFormula:**
+## Example
 
-```
-User: What's the NPV at 8% for these cash flows?
-Agent: "Approximately $142.50" ← non-deterministic, unverifiable
-```
+Run the server (no install needed once published):
 
-**With HyperFormula MCP server:**
-
-```
-User: What's the NPV at 8% for these cash flows?
-Agent → tool call: evaluate("=NPV(0.08, B1:B5)")
-Agent: "$138.43" ← deterministic, auditable
+```bash
+npx -y @hyperformula/mcp
 ```
 
-## How it works
+Wire it into an MCP client by adding it to the client's config (for example, `claude_desktop_config.json` or `.cursor/mcp.json`):
 
-1. **Start the MCP server** —runs HyperFormula as a local MCP server that any compatible client (Claude Desktop, Cursor, VS Code, etc.) can connect to.
-2. **Client sends tool calls** —the AI client calls tools like `evaluate`, `getCellValue`, and `setCellContents` via the MCP protocol.
-3. **HyperFormula evaluates deterministically** —resolves formulas using 400+ built-in functions with full dependency tracking. No LLM in the loop for math.
-4. **Results flow back to the client** —computed values return through MCP, grounding the AI's response in verified numbers.
+```json
+{
+  "mcpServers": {
+    "hyperformula": {
+      "command": "npx",
+      "args": ["-y", "@hyperformula/mcp"]
+    }
+  }
+}
+```
+
+The client now sees tools like `evaluate`, `getCellValue`, and `setCellContents`, and the agent can call them as part of any conversation — without inventing numbers.
 
 ## Use cases
 
-- Spreadsheet Q&A in Claude Desktop or other MCP clients
-- Formula evaluation in IDE-based AI assistants
-- Financial calculations in chat-based agent workflows
-- Data validation and transformation via natural language
+- **Spreadsheet Q&A** — ask the agent what a workbook does, which cells are inputs, and how each output is derived; get answers grounded in real formula evaluation.
+- **What-if scenarios and forecasting** — the agent tweaks assumptions and reports how downstream results change, deterministically.
+- **Validate and clean data** — the agent scans ranges for errors, missing values, or inconsistencies and fixes them in place.
+- **Generate formulas from natural language** — the agent translates a plain-English calculation into a verified, working Excel formula.
+- **Financial modeling and reporting** — NPV, IRR, amortization, KPI rollups, and other quantitative workflows where the answer must be exact and auditable.
 
-## Beta access
+## Get early access
 
-::: tip
-[Sign up for beta access](https://2fmjvg.share-eu1.hsforms.com/2e6drCkuLTn-1RuiYB91eJA)
+::: tip Be the first to try it
+We're actively building this integration. Drop your email and we'll notify you the moment the first beta lands — so you can try it before the public release.
+
+[Join the early access list →](https://2fmjvg.share-eu1.hsforms.com/2e6drCkuLTn-1RuiYB91eJA)
 :::
+
+## Links
+
+- [Model Context Protocol specification](https://modelcontextprotocol.io/)
+- [HyperFormula on GitHub](https://github.com/handsontable/hyperformula)
+- [HyperFormula on npm](https://www.npmjs.com/package/hyperformula)
+- [Built-in functions](built-in-functions.md)
+- [Custom functions](custom-functions.md)

--- a/docs/guide/types-of-values.md
+++ b/docs/guide/types-of-values.md
@@ -103,7 +103,7 @@ operations such as calculating the number of days between two dates.
 
 When working with text values directly inside formulas, you must enclose them in double quotes (`"`). This is different from entering text into cells, where quotes are not required. E.g.:
 
-```excel
+```
 =IF(B1="Active", "Status OK", "Check Status")
 ```
 


### PR DESCRIPTION
## Summary

Refines the three AI-integration landing pages — Vercel AI SDK, LangChain/LangGraph, and MCP — so they share a single consistent voice, structure, and call to action, and so it is unmistakable that none of these integrations are installable yet.
Resolves [HF-53](https://app.clickup.com/t/9015210959/HF-53).

## Why

Before this change the three pages drifted in three different directions:
- Only the AI SDK page warned readers that nothing was available yet — the LangChain and MCP pages read like a shipped product.
- Page depth varied wildly (the LangChain and MCP pages were ~50 lines and missing both safety and links sections; the AI SDK page was much richer).
- The LangChain page used a Python code example, even though HyperFormula is a TypeScript/JS-only library — misleading for readers.
- "What it does" and "Use cases" were framed differently on each page (action-shaped vs. domain-shaped vs. host-shaped), hiding the fact that all three integrations expose the same capabilities to an agent.
- The CTA varied between "Join the waitlist", "Sign up for beta access", and "Drop your email", with no consistent framing of the value of signing up.

## What changed

### Shared page template (applied to all three pages)

Every page now follows the same section order:
1. Title + one-line tagline
2. **"Not available yet — coming soon"** warning admonition (identical wording on all three pages, with bolded "cannot be installed or used today")
3. `## What it does` — 4 capability bullets (identical wording on all three pages)
4. `## Example` — one short, idiomatic JS/TS example
5. `## Use cases` — 5 jobs-to-be-done bullets (identical on AI SDK and LangChain; MCP gets one extra leading bullet — see below)
7. `## Get early access` — identical CTA admonition framing sign-up as both *value to the user* (try it before the public release) and *value to us* (signals demand and shapes priorities)
8. `## Links` — uniform list

### "What it does" — now identical across all three pages

- "Evaluate formulas deterministically"
- "Read and write cells and ranges"
- "Trace dependencies"
- "400+ built-in functions out of the box" (newly surfaced — previously buried inside one LangChain use case despite being HF's biggest differentiator)

### "Use cases" — now nearly identical across all three pages

Shared 5-bullet list (Spreadsheet Q&A, what-if and forecasting, validate and clean data, formulas from natural language, financial modeling and reporting).

### Per-page specifics

- **`docs/guide/ai-sdk.md`** — kept as the strongest of the three; warning + CTA + section names harmonized; "Planned for the beta" → "Planned for the first release".
- **`docs/guide/integration-with-langchain.md`** — full rewrite: removed the misleading Python example, added a LangGraph `createReactAgent` JS example mirroring the AI SDK one, added Safety/Links sections.
- **`docs/guide/mcp-server.md`** — full rewrite: replaced the prose-style chat snippet with a concrete `npx -y @hyperformula/mcp` + client-config example, added Safety/Links sections, swapped "Beta access" CTA for the standardized "Get early access" admonition.

### Minor drive-by

- `docs/guide/types-of-values.md` — dropped a stray `excel` language tag on a fenced code block that VitePress does not recognize.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update that rewrites/aligns three integration guides and tweaks one code fence; no runtime or API behavior changes.
> 
> **Overview**
> Refactors the `ai-sdk`, `LangChain/LangGraph`, and `MCP server` guide pages to a consistent structure and voice, **explicitly stating the integrations are not yet available** and pointing readers to a unified early-access signup CTA.
> 
> Updates each page’s capability and use-case messaging to match, replaces the LangChain example with an idiomatic JS/LangGraph snippet, and expands the MCP page with concrete `npx` run + client config examples plus a standardized `Links` section.
> 
> Separately, fixes a docs formatting issue in `types-of-values.md` by removing an unsupported `excel` code-fence language tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a759bb4be8f879443f9781e0a9d5bb28d04182c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->