### PR TITLE
Fetch hyperformula-tests before running linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,18 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598 # https://github.com/actions/checkout/releases/tag/v2.0.0
+      - name: Checkout main repository
+        uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598 # https://github.com/actions/checkout/releases/tag/v2.0.0
+
+      - name: Checkout hyperformula-tests repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ssh-key: ${{ secrets.DEPLOY_TOKEN }}
+          repository: handsontable/hyperformula-tests
+          path: test/hyperformula-tests
+
+      - name: Fetch hyperformula-tests and sync branches
+        run: cd test && ./fetch-tests.sh
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

The lint GitHub Action did not check out the `hyperformula-tests` repository before running ESLint. As a result, lint errors inside files under `test/hyperformula-tests/` were silently skipped in CI and only surfaced when running `npm run lint` locally.

This PR aligns `.github/workflows/lint.yml` with `.github/workflows/test.yml` so the linter sees the same source tree as the test jobs.

## Changes

- `.github/workflows/lint.yml`
  - Add a `Checkout hyperformula-tests repository` step (using `DEPLOY_TOKEN`, target path `test/hyperformula-tests`).
  - Add a `Fetch hyperformula-tests and sync branches` step running `test/fetch-tests.sh`.
  - Name the existing main-repo checkout step for consistency with `test.yml`.