### PR TITLE
Fix IFS short-circuit evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Fixed the `IFS` function evaluating later condition/value pairs after the first true condition.
 - Fixed a memory leak in `LazilyTransformingAstService` where the transformations array grew unboundedly, causing increasing memory usage over time. [#1629](https://github.com/handsontable/hyperformula/issues/1629)
 - Fixed a memory leak in `UndoRedo` where `oldData` entries for evicted undo stack entries were never cleaned up, causing increasing memory usage over time. [#1629](https://github.com/handsontable/hyperformula/issues/1629)
 - Fixed the IRR function returning `#NUM!` error when the initial investment significantly exceeds the sum of returns. [#1628](https://github.com/handsontable/hyperformula/issues/1628)

--- a/src/interpreter/plugin/BooleanPlugin.ts
+++ b/src/interpreter/plugin/BooleanPlugin.ts
@@ -6,6 +6,7 @@
 import {CellError, ErrorType} from '../../Cell'
 import {ErrorMessage} from '../../error-message'
 import {ProcedureAst} from '../../parser'
+import {SimpleRangeValue} from '../../SimpleRangeValue'
 import {InterpreterState} from '../InterpreterState'
 import {InternalNoErrorScalarValue, InternalScalarValue, InterpreterValue} from '../InterpreterValue'
 import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
@@ -147,14 +148,58 @@ export class BooleanPlugin extends FunctionPlugin implements FunctionPluginTypec
    * @param state
    */
   public ifs(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
-    return this.runFunction(ast.args, state, this.metadata('IFS'), (...args) => {
-      for (let idx = 0; idx < args.length; idx += 2) {
-        if (args[idx]) {
-          return args[idx+1]
-        }
+    const metadata = this.metadata('IFS')
+    const argumentsMetadata = this.buildMetadataForEachArgumentValue(ast.args.length, metadata)
+
+    if (!this.isNumberOfArgumentValuesValid(argumentsMetadata, ast.args.length)) {
+      return new CellError(ErrorType.NA, ErrorMessage.WrongArgNumber)
+    }
+
+    for (let idx = 0; idx < ast.args.length; idx += 2) {
+      const condition = this.evaluateAst(ast.args[idx], state)
+
+      if (condition instanceof SimpleRangeValue && state.arraysFlag) {
+        return this.runFunction(ast.args, state, metadata, (...args: InterpreterValue[]) => this.evaluateIfsArguments(args))
       }
-      return new CellError(ErrorType.NA, ErrorMessage.NoConditionMet)
-    })
+
+      const coercedCondition = this.coerceToType(condition, argumentsMetadata[idx], state)
+      if (coercedCondition === undefined) {
+        return new CellError(ErrorType.VALUE, ErrorMessage.WrongType)
+      }
+      if (coercedCondition instanceof CellError) {
+        return coercedCondition
+      }
+      if (coercedCondition) {
+        const value = this.evaluateAst(ast.args[idx + 1], state)
+        if (value instanceof SimpleRangeValue && state.arraysFlag) {
+          return this.runFunction(ast.args, state, metadata, (...args: InterpreterValue[]) => this.evaluateIfsArguments(args))
+        }
+
+        const coercedValue = this.coerceToType(value, argumentsMetadata[idx + 1], state)
+        if (coercedValue === undefined) {
+          return new CellError(ErrorType.VALUE, ErrorMessage.WrongType)
+        }
+
+        return coercedValue as InterpreterValue
+      }
+    }
+
+    return new CellError(ErrorType.NA, ErrorMessage.NoConditionMet)
+  }
+
+  /**
+   * Preserves the previous vectorized IFS implementation for array arithmetic.
+   *
+   * @param {InterpreterValue[]} args evaluated IFS arguments
+   */
+  private evaluateIfsArguments(args: InterpreterValue[]): InterpreterValue {
+    for (let idx = 0; idx < args.length; idx += 2) {
+      if (args[idx]) {
+        return args[idx + 1]
+      }
+    }
+
+    return new CellError(ErrorType.NA, ErrorMessage.NoConditionMet)
   }
 
   /**

--- a/test/smoke.spec.ts
+++ b/test/smoke.spec.ts
@@ -56,6 +56,16 @@ describe('HyperFormula', () => {
     hf.destroy()
   })
 
+  it('should not evaluate IFS branches after the first true condition', () => {
+    const hf = HyperFormula.buildFromArray([
+      ['=IFS(TRUE(), 1, 1/0, 2)'],
+    ], {licenseKey: 'gpl-v3'})
+
+    expect(hf.getCellValue(adr('A1'))).toBe(1)
+
+    hf.destroy()
+  })
+
   it('should handle common spreadsheet functions', () => {
     const data = [
       [1, 2, 3, 4, 5],


### PR DESCRIPTION
### Context

`IFS` should stop evaluating condition/value pairs once it finds the first true condition. This matches Microsoft Excel and Google Sheets behavior.

For example, Excel returns `1` for:

`=IFS(TRUE(), 1, 1/0, 2)`

HyperFormula previously evaluated later arguments and returned an error.

### How did you test your changes?

- Added a smoke regression test for `=IFS(TRUE(), 1, 1/0, 2)`.
- Ran `npm run test:jest -- smoke`.
- Ran `npm run verify:typings`.
- Ran `npm run lint`.

### Related issues:

N/A

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [x] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard. N/A: OpenFormula 1.3 does not define IFS.
- [x] My change is compatible with Microsoft Excel.
- [x] My change is compatible with Google Sheets.
- [x] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are localized to `IFS` evaluation logic and add a regression test; main risk is subtle behavior differences in array arithmetic/vectorized cases.
> 
> **Overview**
> Fixes `IFS` to **short-circuit evaluation**: condition/value pairs are now evaluated sequentially and stop once the first true condition is found, avoiding errors from later branches (e.g. `1/0`).
> 
> Keeps the prior vectorized implementation for *array arithmetic* by falling back to `runFunction` when array/range arguments are detected, and adds a smoke regression test plus a CHANGELOG entry documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8987fa6ffc1201b63884cdca795858efc261c46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->