### PR TITLE
Allow VLOOKUP over IF array tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Fixed lookup functions rejecting array tables produced by formulas such as `IF`.
 - Fixed a memory leak in `LazilyTransformingAstService` where the transformations array grew unboundedly, causing increasing memory usage over time. [#1629](https://github.com/handsontable/hyperformula/issues/1629)
 - Fixed a memory leak in `UndoRedo` where `oldData` entries for evicted undo stack entries were never cleaned up, causing increasing memory usage over time. [#1629](https://github.com/handsontable/hyperformula/issues/1629)
 - Fixed the IRR function returning `#NUM!` error when the initial investment significantly exceeds the sum of returns. [#1628](https://github.com/handsontable/hyperformula/issues/1628)

--- a/src/interpreter/plugin/BooleanPlugin.ts
+++ b/src/interpreter/plugin/BooleanPlugin.ts
@@ -6,6 +6,7 @@
 import {CellError, ErrorType} from '../../Cell'
 import {ErrorMessage} from '../../error-message'
 import {ProcedureAst} from '../../parser'
+import {SimpleRangeValue} from '../../SimpleRangeValue'
 import {InterpreterState} from '../InterpreterState'
 import {InternalNoErrorScalarValue, InternalScalarValue, InterpreterValue} from '../InterpreterValue'
 import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
@@ -135,6 +136,14 @@ export class BooleanPlugin extends FunctionPlugin implements FunctionPluginTypec
    * @param state
    */
   public conditionalIf(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    const conditionValue = this.evaluateAst(ast.args[0], state)
+    if (conditionValue instanceof SimpleRangeValue && conditionValue.isAdHoc() && conditionValue.numberOfElements() > 1) {
+      const vectorizedState = new InterpreterState(state.formulaAddress, true, state.formulaVertex)
+      return this.runFunction(ast.args, vectorizedState, this.metadata('IF'), (condition, arg2, arg3) => {
+        return condition ? arg2 : arg3
+      })
+    }
+
     return this.runFunction(ast.args, state, this.metadata('IF'), (condition, arg2, arg3) => {
       return condition ? arg2 : arg3
     })

--- a/src/interpreter/plugin/LookupPlugin.ts
+++ b/src/interpreter/plugin/LookupPlugin.ts
@@ -74,17 +74,11 @@ export class LookupPlugin extends FunctionPlugin implements FunctionPluginTypech
    */
   public vlookup(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
     return this.runFunction(ast.args, state, this.metadata('VLOOKUP'), (key: RawNoErrorScalarValue, rangeValue: SimpleRangeValue, index: number, sorted: boolean) => {
-      const range = rangeValue.range
-
-      if (range === undefined) {
-        return new CellError(ErrorType.VALUE, ErrorMessage.WrongType)
-      }
-
       if (index < 1) {
         return new CellError(ErrorType.VALUE, ErrorMessage.LessThanOne)
       }
 
-      if (index > range.width()) {
+      if (index > rangeValue.width()) {
         return new CellError(ErrorType.REF, ErrorMessage.IndexLarge)
       }
 
@@ -105,16 +99,11 @@ export class LookupPlugin extends FunctionPlugin implements FunctionPluginTypech
    */
   public hlookup(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
     return this.runFunction(ast.args, state, this.metadata('HLOOKUP'), (key: RawNoErrorScalarValue, rangeValue: SimpleRangeValue, index: number, sorted: boolean) => {
-      const range = rangeValue.range
-      if (range === undefined) {
-        return new CellError(ErrorType.VALUE, ErrorMessage.WrongType)
-      }
-
       if (index < 1) {
         return new CellError(ErrorType.VALUE, ErrorMessage.LessThanOne)
       }
 
-      if (index > range.height()) {
+      if (index > rangeValue.height()) {
         return new CellError(ErrorType.REF, ErrorMessage.IndexLarge)
       }
 

--- a/test/smoke.spec.ts
+++ b/test/smoke.spec.ts
@@ -1,4 +1,4 @@
-import {HyperFormula} from '../src'
+import {HyperFormula, Sheet} from '../src'
 import {SimpleCellAddress, simpleCellAddress} from '../src/Cell'
 
 const adr = (stringAddress: string, sheet: number = 0): SimpleCellAddress => {
@@ -100,6 +100,29 @@ describe('HyperFormula', () => {
     hf.removeRows(0, [1, 1])
 
     expect(hf.getCellValue(adr('A4'))).toBe(6)
+
+    hf.destroy()
+  })
+
+  it('should allow VLOOKUP over IF array-constructed table', () => {
+    const data: Sheet = Array.from({length: 112}, () => Array<null>(64).fill(null))
+
+    data[108][55] = 'K1'
+    data[109][55] = 'K2'
+    data[110][55] = 'K3'
+    data[111][55] = 'K4'
+
+    data[108][47] = 100
+    data[109][47] = 200
+    data[110][47] = 300
+    data[111][47] = 400
+
+    data[108][57] = 'K2'
+    data[108][63] = '=VLOOKUP(BF109,IF({1,0},BD109:BD112,AV109:AV112),2,0)'
+
+    const hf = HyperFormula.buildFromArray(data, {licenseKey: 'gpl-v3'})
+
+    expect(hf.getCellValue({sheet: 0, row: 108, col: 63})).toBe(200)
 
     hf.destroy()
   })


### PR DESCRIPTION
### Context

`VLOOKUP` and `HLOOKUP` should accept lookup tables produced by formulas, not only tables backed by a cell range.

For example, Microsoft Excel evaluates this formula to `200`:

`=VLOOKUP(BF109,IF({1,0},BD109:BD112,AV109:AV112),2,0)`

HyperFormula previously returned `#VALUE!` because lookup validation rejected array-backed `SimpleRangeValue`s.

### How did you test your changes?

- Added a smoke regression test for `VLOOKUP` over an `IF`-constructed array table.
- Ran `npm run test:jest -- smoke`.
- Ran `npm run verify:typings`.
- Ran `npm run lint`.

### Related issues:

N/A
### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [x] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [x] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [x] My change is compatible with Microsoft Excel.
- [x] My change is compatible with Google Sheets.
- [x] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes evaluation/vectorization behavior of `IF` and relaxes `VLOOKUP`/`HLOOKUP` validation to accept ad-hoc (formula-produced) ranges, which could affect array semantics and error cases for these core functions.
> 
> **Overview**
> Lookup functions now accept formula-produced array tables (e.g. `IF(...)` returning an ad-hoc `SimpleRangeValue`) instead of rejecting them with `#VALUE!`, by removing the requirement that the lookup table be backed by a concrete cell `range` and validating `index` against `rangeValue` dimensions.
> 
> `IF` is updated to *vectorize* when its condition evaluates to a multi-element ad-hoc range, enabling formulas like `=VLOOKUP(key,IF({1,0},rangeA,rangeB),...)` to produce a usable lookup table. A smoke regression test and changelog entry were added for this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 349df042173b70470cddeffb5f74bbc9a3a21ee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->