### PR TITLE
docs: fix SSR section framing in React integration guide

### DIFF
--- a/docs/guide/integration-with-react.md
+++ b/docs/guide/integration-with-react.md
@@ -75,7 +75,7 @@ In development, React runs effects twice (mount → unmount → mount) to surfac
 
 ## Server-side rendering (Next.js App Router)
 
-The component above is already SSR-safe — the engine is constructed in `useEffect`, which never runs on the server. If you still want to skip the initial bundle on the server (it is a few hundred kB), wrap it in a client-only dynamic import.
+The component above is already SSR-safe — the engine is constructed in `useEffect`, which never runs on the server. If you still want to keep HyperFormula out of the initial JS bundle sent to the browser (it is a few hundred kB), wrap it in a client-only dynamic import.
 
 In the App Router, `dynamic(..., { ssr: false })` is only allowed inside a client component. Put the dynamic call in a `'use client'` wrapper and import the wrapper from your server page:
 


### PR DESCRIPTION
## Summary

- Reframes the SSR section to clarify that the benefit of `dynamic(..., { ssr: false })` is keeping HyperFormula out of the **initial JS bundle sent to the browser**, not skipping the server-side render itself (which is already a non-issue since `useEffect` never runs on the server).

## Test Plan

- [ ] Review the updated wording in `docs/guide/integration-with-react.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or API impact.
> 
> **Overview**
> Updates one sentence in the React integration guide’s SSR section so it no longer suggests `dynamic(..., { ssr: false })` is mainly about avoiding server render. The text now states the goal is keeping **HyperFormula out of the initial JS bundle sent to the browser** (still noting the library is a few hundred kB), which matches the earlier point that `useEffect` already makes the pattern SSR-safe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46d1d61652c027de7643c2a6dc0344f1b21a1ee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->