### PR TITLE
docs(api): fix getAllSheetsSerialized/getRangeSerialized JSDoc for number cells (HF-219)

### DIFF
--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -995,15 +995,19 @@ export class HyperFormula implements TypedEmitter {
   /**
    * Returns formulas or values of all sheets in a form of an object which property keys are strings and values are 2D arrays of [[RawCellContent]].
    *
+   * Each non-formula cell is serialized to the exact value it was set with, preserving its type.
+   * For example, a cell set with the string `'1'` is serialized as the string `'1'`, while a cell set with the number `1` is serialized as the number `1`.
+   *
    * @throws [[EvaluationSuspendedError]] when the evaluation is suspended
    *
    * @example
    * ```js
    * const hfInstance = HyperFormula.buildFromArray([
-   *  ['1', '2', '=A1+10'],
+   *  ['1', 2, '=A1+10'],
    * ]);
    *
-   * // should return all sheets serialized content: { Sheet1: [ [ 1, 2, '=A1+10' ] ] }
+   * // should return all sheets serialized content: { Sheet1: [ [ '1', 2, '=A1+10' ] ] }
+   * // note: the string '1' stays a string and the number 2 stays a number
    * const allSheetsSerialized = hfInstance.getAllSheetsSerialized();
    * ```
    *
@@ -2494,6 +2498,9 @@ export class HyperFormula implements TypedEmitter {
   /**
    * Returns serialized cells in given range.
    *
+   * Each non-formula cell is serialized to the exact value it was set with, preserving its type
+   * (e.g., a cell set with the string `'2'` is serialized as the string `'2'`, while a cell set with the number `2` is serialized as the number `2`).
+   *
    * @param {SimpleCellRange} source - rectangular range
    *
    * @throws [[ExpectedValueOfTypeError]] if source is of wrong type
@@ -2503,9 +2510,9 @@ export class HyperFormula implements TypedEmitter {
    * @example
    * ```js
    * const hfInstance = HyperFormula.buildFromArray([
-   *  ['=SUM(1, 2)', '2', '10'],
-   *  ['5', '6', '7'],
-   *  ['40', '30', '20'],
+   *  ['=SUM(1, 2)', 2, 10],
+   *  [5, 6, 7],
+   *  [40, 30, 20],
    * ]);
    *
    * // should return serialized cell content for the given range:


### PR DESCRIPTION
Fixes the `getAllSheetsSerialized` / `getRangeSerialized` JSDoc examples that wrongly implied numeric strings are serialized as numbers — serialization round-trips, preserving the exact input type. Mirrors #1654. Documentation-only (a single source file changed), so no CHANGELOG entry per the docs-only convention.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and example changes only; no runtime or serialization logic modified.
> 
> **Overview**
> **Documentation-only** updates to JSDoc for `getAllSheetsSerialized` and `getRangeSerialized` in `HyperFormula.ts`.
> 
> The docs now state that **non-formula cells keep the exact `RawCellContent` type they were set with** (string `'1'` vs number `1`), and the embedded examples were corrected so numeric literals are numbers in sample input/output instead of implying string digits are coerced to numbers on serialize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 691b8b1c68523e4e5d8fc6d2c4364ab680f3fbf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->