### PR TITLE
docs(guide): named ranges in formulas + fix limitations pointer (HF-222)

### DIFF
--- a/docs/guide/known-limitations.md
+++ b/docs/guide/known-limitations.md
@@ -14,9 +14,7 @@ the full evaluation of expressions and condition statements. The
 most prominent example of this behavior is the "IF" function which
 returns a cycle error regardless of whether TRUE or FALSE causes
 a circular reference.
-* There is no data validation against named ranges. For example,
-you can't compare the arguments in a formula like this:
-=IF(firstRange>secondRange, TRUE, FALSE).
+* Named ranges behave differently depending on where they are used in a formula. For details, see [Using named ranges in formulas](named-expressions.md#using-named-ranges-in-formulas).
 * [Custom functions](custom-functions.md) don't automatically recalculate the size of their [result arrays](custom-functions.md#return-an-array-of-data) when the formula dependencies change.
 * There is no relative referencing in named ranges.
 * The library doesn't offer (at least not yet) the following features:

--- a/docs/guide/named-expressions.md
+++ b/docs/guide/named-expressions.md
@@ -95,9 +95,12 @@ A named expression that resolves to a range of cells behaves differently dependi
 - **As an operand of an operator** — the range is reduced to a single cell before the operation. In `=myRange + 1`, only the cell of the range that shares the formula's row (for a vertical range) or column (for a horizontal range) is used. If the formula's row or column falls outside the range, or the range is two-dimensional, the result is a `#VALUE!` error.
 - **As a bare reference** — `=myRange` on its own returns a `#VALUE!` error; a range cannot be placed directly into a single cell.
 
-The range is reduced before the operator runs, so `=SUM(myRange + 1)` receives a single value rather than adding 1 to every element.
+In the default mode the range is reduced before the operator runs, so `=SUM(myRange + 1)` adds 1 to that single reduced value rather than to every element (for a formula in row 1 of a vertical range, the result is `SUM(A1 + 1)`).
 
-When array arithmetic is enabled (`useArrayArithmetic: true`), named ranges still work as function arguments and aggregate correctly, but they do not spill: `=myRange + 1` returns a `#VALUE!` error rather than producing one result per element.
+When array arithmetic is enabled (`useArrayArithmetic: true`), named ranges still work as function arguments and aggregate correctly, but as an operand they behave differently from the default mode:
+
+- A bare `=myRange + 1` does not spill — it returns a `#VALUE!` error rather than producing one result per element.
+- Inside an aggregate the operator becomes element-wise. `=SUM(myRange + 1)` adds 1 to every element and then sums, so for `myRange` covering values `1..5` it returns `20` (`SUM(2, 3, 4, 5, 6)`), not the single reduced value of the default mode.
 
 ## Available methods
 

--- a/docs/guide/named-expressions.md
+++ b/docs/guide/named-expressions.md
@@ -87,6 +87,18 @@ hfInstance.setCellContents({sheet: 0, col: 2, row: 0}, [['=SUM(SalesData)']]);
 hfInstance.setCellContents({sheet: 0, col: 2, row: 1}, [['=SUM(SalesData) * TaxRate']]);
 ```
 
+## Using named ranges in formulas
+
+A named expression that resolves to a range of cells behaves differently depending on where it is used:
+
+- **As a function argument** — it works as expected. `=SUM(myRange)`, `=COUNT(myRange)`, and `=INDEX(myRange, 1, 1)` all operate on the full range.
+- **As an operand of an operator** — the range is reduced to a single cell before the operation. In `=myRange + 1`, only the cell of the range that shares the formula's row (for a vertical range) or column (for a horizontal range) is used. If the formula's row or column falls outside the range, or the range is two-dimensional, the result is a `#VALUE!` error.
+- **As a bare reference** — `=myRange` on its own returns a `#VALUE!` error; a range cannot be placed directly into a single cell.
+
+The range is reduced before the operator runs, so `=SUM(myRange + 1)` receives a single value rather than adding 1 to every element.
+
+When array arithmetic is enabled (`useArrayArithmetic: true`), named ranges still work as function arguments and aggregate correctly, but they do not spill: `=myRange + 1` returns a `#VALUE!` error rather than producing one result per element.
+
 ## Available methods
 
 These are the basic methods that can be used to add and manipulate named


### PR DESCRIPTION
Documents how a range-valued named expression behaves in a formula and fixes the inaccurate limitations bullet (HF-222).

- `named-expressions.md`: new **Using named ranges in formulas** section — behavior as function argument (full range), operator operand (implicit intersection → single cell; array mode → `#VALUE!`), and bare reference (`#VALUE!`).
- `known-limitations.md`: replaces the inaccurate top-level named-ranges bullet with a neutral pointer to that section.

Paired characterization tests: hyperformula-tests branch `hf-222-named-ranges` (matching branch for fetch-tests). Docs-only; no CHANGELOG.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact.
> 
> **Overview**
> Documents **how range-valued named expressions behave in formulas** and corrects a misleading limitations note.
> 
> **`named-expressions.md`** adds **Using named ranges in formulas**: full range when passed to functions; implicit intersection to one cell (or `#VALUE!`) when used with operators; `#VALUE!` for a bare range reference. It also contrasts default evaluation with **`useArrayArithmetic: true`** (e.g. `=SUM(myRange + 1)` vs element-wise sum).
> 
> **`known-limitations.md`** drops the inaccurate claim that named ranges can’t be used in comparisons like `=IF(firstRange>secondRange, …)` and points readers to the new section instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 284436779db581459228368560a09bae00c8d52c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->