### PR TITLE
fix(metadata): guard getAvailableFunctions against invalid locale codes (HF-249)

### DIFF
--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -760,14 +760,32 @@ export class HyperFormula implements TypedEmitter {
   /**
    * Converts a HyperFormula language code (e.g. `'enGB'`, `'plPL'`) to a BCP-47 locale (e.g. `'en-GB'`, `'pl-PL'`)
    * so the function list collator is deterministic across hosts. Codes in the canonical `<ll><RR>` shape get a
-   * hyphen inserted; any other shape is passed through and left for `Intl.Collator` to interpret (it falls back to
-   * the default locale for an unrecognized tag, which is still applied consistently within a single call).
+   * hyphen inserted; any other shape is passed through unchanged. A structurally valid but unknown tag is accepted
+   * by `Intl.Collator`, but a structurally invalid tag (e.g. an underscore-style `'pt_BR'`) makes `Intl.Collator`
+   * throw a `RangeError`; that case is handled by [[createLocaleCollator]], not here.
    *
    * @param {string} languageCode - the HyperFormula language code
    */
   private static toBcp47Locale(languageCode: string): string {
     const match = /^([a-z]{2})([A-Z]{2})$/.exec(languageCode)
     return match !== null ? `${match[1]}-${match[2]}` : languageCode
+  }
+
+  /**
+   * Builds a collator for the given HyperFormula language code, using the BCP-47 form of the code so ordering is
+   * deterministic across hosts. `registerLanguage` does not constrain the shape of a language code, so a caller may
+   * register a structurally invalid one (e.g. an underscore-style `'pt_BR'`); such a tag makes `Intl.Collator`
+   * throw a `RangeError`, so we fall back to the environment default collator to keep the function list from
+   * crashing on a caller-registered, non-BCP-47 code.
+   *
+   * @param {string} languageCode - the HyperFormula language code
+   */
+  private static createLocaleCollator(languageCode: string): Intl.Collator {
+    try {
+      return new Intl.Collator(HyperFormula.toBcp47Locale(languageCode))
+    } catch (e) {
+      return new Intl.Collator()
+    }
   }
 
   /**
@@ -778,7 +796,7 @@ export class HyperFormula implements TypedEmitter {
    */
   private static buildAvailableFunctions(functionIds: string[], getPlugin: (id: string) => FunctionPluginDefinition | undefined, language: TranslationPackage, languageCode: string): FunctionListEntry[] {
     const translate = (id: string) => language.getMaybeFunctionTranslation(id)
-    const collator = new Intl.Collator(HyperFormula.toBcp47Locale(languageCode))
+    const collator = HyperFormula.createLocaleCollator(languageCode)
     return functionIds
       .map(id => {
         const resolved = HyperFormula.resolveFunctionMetadata(id, getPlugin(id))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context

Addresses a code-review finding on #1692: `getAvailableFunctions` can throw a `RangeError` for a caller-registered, malformed language code.

`buildAvailableFunctions` built its sort collator with `new Intl.Collator(toBcp47Locale(code))`. `toBcp47Locale` only hyphenates the canonical `<ll><RR>` shape and passes any other string through unchanged, and `registerLanguage` performs **no** shape validation on the code. `Intl.Collator` throws a `RangeError` on a *structurally invalid* language tag (it does **not** silently fall back to the default locale). So a caller who registers an underscore-style code such as `'pt_BR'` (or `'en_US'`, `'x'`, `'12'`) and then calls `getAvailableFunctions` (static **or** instance) crashes.

Built-in language codes are all safe, so this only affects consumer-registered malformed codes → important, not critical.

The `toBcp47Locale` JSDoc was also wrong: it claimed unrecognized tags "fall back to the default locale," which `Intl.Collator` does not do for invalid tags.

### Fix

- Extract `createLocaleCollator(languageCode)` which wraps the `Intl.Collator` construction in a `try/catch` and falls back to the environment-default collator (`new Intl.Collator()`) on `RangeError`, so listing functions never crashes on a non-BCP-47 code.
- Use it in `buildAvailableFunctions`.
- Correct the `toBcp47Locale` JSDoc to describe the real behavior (invalid tags throw; the throw is handled by `createLocaleCollator`).

`getFunctionDetails` is unaffected — it does not sort and never constructs a collator.

### How did you test your changes?

- Reproduced the crash before the fix: registering `'pt_BR'` then calling `getAvailableFunctions('pt_BR')` threw `RangeError: Incorrect locale information provided`.
- After the fix, `'pt_BR'`, `'en_US'`, `'x'`, and `'12'` each return the full, alphabetically-sorted 419-entry list; well-formed `'enGB'` is unchanged.
- Confirmed via Node that `new Intl.Collator('pt_BR'|'en_US'|'x'|'12')` throw while `'zz-ZZ'`/`'qqq'` do not.
- `tsc --noEmit` clean; `eslint src/HyperFormula.ts` 0 errors; `test/smoke.spec.ts` 4/4.

### Types of changes

- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Related issues:

1. Follow-up to #1692 (HF-249); targets that branch.

### Notes for reviewers

- Behavior on a malformed code is now "sort using the default collator" rather than throwing. The alternative (validating codes in `registerLanguage`) would be a broader, potentially breaking change, so it's intentionally out of scope here.
- A unit test for this belongs in the paired private suite (`hyperformula-tests`): register a `'pt_BR'`-style code and assert `getAvailableFunctions` returns a sorted list instead of throwing.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51ff732c-3307-42ef-aa24-7fb0dc332ce9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51ff732c-3307-42ef-aa24-7fb0dc332ce9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

