### PR TITLE
docs(guide): update support page (HF-128)

### DIFF
--- a/docs/src/content/docs/guide/support.md
+++ b/docs/src/content/docs/guide/support.md
@@ -5,25 +5,27 @@ title: "Support"
 
 ## Community support
 
-If you have an issue or a question, you can use GitHub to ask the
-community for help.
+**Got a question or feature request?**
+Join over 3000 other developers on our [community forum](https://forum.handsontable.com/).
 
-[Create an issue](https://github.com/handsontable/hyperformula/issues/new/choose)
+**Found a bug?**
+[Create an issue](https://github.com/handsontable/hyperformula/issues/new?template=bug_report.yaml) in GitHub.
 
 ## Premium support
 
-We provide support to companies using HyperFormula to enrich their
-mission-critical applications. We can help you at every stage of
-your development. Our experts have been supporting enterprises since
-2012 and know exactly how to respond to individual needs.
+We offer 3 different levels of support, designed to fit your business needs regardless of size or stage of growth. All plans include email support, guidance for effective implementation, API-based code snippets and security patches.
 
-[Contact sales](/docs/guide/contact)
+| Standard | Priority | Enterprise |
+| :---- | :---- | :---- |
+| Email | Email, Zoom, Meet | Email, Zoom, Meet, dedicated Slack channel, and your channels |
+|  | Code review: 2 hrs/yr | Code review: 5 hrs/yr |
+|  |  | Dedicated account manager, support for older versions, SLAs |
+
+[See all support plan details](https://hyperformula.handsontable.com/#pricing)
 
 ## Consulting services
 
-If you need an instant turn-key solution, then consulting services
-are the quickest way to get it done. Along with our technical partners,
-we can help you in many ways. For instance:
+If you need an instant turn-key solution, then consulting services are the quickest way to get it done. Along with our technical partners, we can help you in many ways. For instance:
 
 * Build a proof of concept
 * Develop deployment strategies


### PR DESCRIPTION
### Context
Updates the [Support](docs/src/content/docs/guide/support.md) guide page to match the new support content defined in [HF-128](https://app.clickup.com/t/9015210959/HF-128).

Changes:
- **Community support** now points developers to the [community forum](https://forum.handsontable.com/) for questions/feature requests and to the [bug report issue template](https://github.com/handsontable/hyperformula/issues/new?template=bug_report.yaml) for bugs.
- **Premium support** describes the three support tiers (Standard, Priority, Enterprise) in a comparison table, with a link to the full plan details.
- **Consulting services** section retained.

The "Contact sales" link uses the site-root-relative `/docs/guide/contact` form per the docs internal-link convention (docs/CLAUDE.md §7) instead of the absolute `.html` URL from the source content.

### How did you test your changes?
Documentation-only change. Verified the referenced `bug_report.yaml` issue template exists in `.github/ISSUE_TEMPLATE/` and that the internal contact link matches the existing convention used across guide pages.

### Types of changes
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [x] Change to the documentation

### Related issues:
1. HF-128

### Checklist:
- [x] I have reviewed the guidelines about Contributing to HyperFormula and I confirm that my code follows the code style of this project.
- [x] My changes require a documentation update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to marketing/support copy and links; no application code, auth, or data handling.
> 
> **Overview**
> Updates the **Support** guide (`support.md`) to align with HF-128—documentation only, no runtime changes.
> 
> **Community support** is split into clear paths: questions and feature requests go to the [community forum](https://forum.handsontable.com/), and bugs use GitHub with the `bug_report.yaml` issue template instead of the generic “create an issue” flow.
> 
> **Premium support** replaces the short sales blurb with copy about three tiers (Standard, Priority, Enterprise), a comparison table of channels and extras (e.g. code review hours, SLAs), and a link to full plan details on the marketing site pricing anchor.
> 
> **Consulting services** is unchanged in substance; wording is tightened. **Contact sales** still points to `/docs/guide/contact`, consistent with other guide pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 180670a66d33c75fd8c39519b40bc4f9ae0c8b98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->