### PR TITLE
fix(metadata): mark the SHEET/SHEETS argument as optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Fixed the `SHEET` and `SHEETS` functions declaring their single argument as required, while both accept a zero-argument call.
 - Fixed the behavior of `MATCH`, `VLOOKUP`, `HLOOKUP`, and `XLOOKUP` functions when the search range contained empty cells. [#1697](https://github.com/handsontable/hyperformula/pull/1697)
 - Fixed the `VLOOKUP`, `HLOOKUP`, and `XLOOKUP` functions to return `0` instead of an empty value when the matched cell in the result range is empty. [#1697](https://github.com/handsontable/hyperformula/pull/1697)
 - Fixed the page freezing when entering a long string of digits containing a non-digit character near the end (e.g. `012...789a` or `012...789 123`) into a cell. [#1520](https://github.com/handsontable/hyperformula/issues/1520)

--- a/src/interpreter/plugin/InformationPlugin.ts
+++ b/src/interpreter/plugin/InformationPlugin.ts
@@ -137,7 +137,7 @@ export class InformationPlugin extends FunctionPlugin implements FunctionPluginT
     'SHEET': {
       method: 'sheet',
       parameters: [
-        {argumentType: FunctionArgumentType.STRING}
+        {argumentType: FunctionArgumentType.STRING, optionalArg: true}
       ],
       doesNotNeedArgumentsToBeComputed: true,
       vectorizationForbidden: true,
@@ -145,7 +145,7 @@ export class InformationPlugin extends FunctionPlugin implements FunctionPluginT
     'SHEETS': {
       method: 'sheets',
       parameters: [
-        {argumentType: FunctionArgumentType.STRING}
+        {argumentType: FunctionArgumentType.STRING, optionalArg: true}
       ],
       doesNotNeedArgumentsToBeComputed: true,
       vectorizationForbidden: true,


### PR DESCRIPTION
`SHEET` and `SHEETS` declared their single argument as required in `implementedFunctions`, although both accept a zero-argument call: `runFunctionWithReferenceArgument` serves `args.length === 0` itself, before `isNumberOfArgumentValuesValid` is consulted.

The change is metadata-only — `optionalArg` has no other consumer in `src/`, and evaluation is unaffected (covered by the existing function-sheet/function-sheets specs). It is split out of #1692, whose function-metadata API is the first consumer that can observe it.

### Context
<!--- Why are your changes required? What problem do they solve? -->

### How did you test your changes?
<!--- Describe in detail how you tested your changes. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Related issues:
1. Fixes #...
2.
3.

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [ ] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [ ] My change is compatible with Microsoft Excel.
- [ ] My change is compatible with Google Sheets.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
