### PR TITLE
Fix MAXPOOL and MEDIANPOOL throwing on non-tiling dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Fixed the MAXPOOL and MEDIANPOOL functions throwing an uncaught `TypeError` instead of returning the `#VALUE!` error when the range dimensions are not a whole multiple of the window size and the stride.
+- Fixed the MAXPOOL and MEDIANPOOL functions throwing an uncaught `TypeError` instead of returning the `#VALUE!` error when the range dimensions are not a whole multiple of the window size and the stride. [#1718](https://github.com/handsontable/hyperformula/pull/1718)
 - Fixed the `MOD` function returning a remainder with the sign of the dividend instead of the sign of the divisor, which made the results differ from Excel and Google Sheets for arguments with opposite signs (e.g. `=MOD(-3, 12)` now returns `9` instead of `-3`). [#1747](https://github.com/handsontable/hyperformula/issues/1747)
 
 ## [3.4.0] - 2026-08-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Fixed the MAXPOOL and MEDIANPOOL functions throwing an uncaught `TypeError` instead of returning the `#VALUE!` error when the range dimensions are not a whole multiple of the window size and the stride.
 - Fixed the `MOD` function returning a remainder with the sign of the dividend instead of the sign of the divisor, which made the results differ from Excel and Google Sheets for arguments with opposite signs (e.g. `=MOD(-3, 12)` now returns `9` instead of `-3`). [#1747](https://github.com/handsontable/hyperformula/issues/1747)
 
 ## [3.4.0] - 2026-08-10

--- a/src/error-message.ts
+++ b/src/error-message.ts
@@ -12,6 +12,7 @@ export class ErrorMessage {
   public static EmptyArg = 'Empty function argument.'
   public static EmptyArray = 'Empty array not allowed.'
   public static ArrayDimensions = 'Array dimensions are not compatible.'
+  public static PoolDimensions = 'Range dimensions are not compatible with the window size and the stride.'
   public static NoSpaceForArrayResult = 'No space for array result.'
   public static ValueSmall = 'Value too small.'
   public static ValueLarge = 'Value too large.'

--- a/src/interpreter/functionMetadata/categories/matrix-functions.ts
+++ b/src/interpreter/functionMetadata/categories/matrix-functions.ts
@@ -13,14 +13,14 @@ export const MATRIX_FUNCTIONS_DOCS: Record<string, FunctionDoc> = {
   MAXPOOL: {
     category: 'Matrix functions',
     shortDescription: 'Calculates a smaller range which is a maximum of a window_size, in a given range, for every stride element.',
-    parameters: [{name: 'range', description: 'The range of numeric values to pool; must contain only numbers.'}, {name: 'window_size', description: 'The width and height, in cells, of the square window whose maximum is taken at each step.'}, {name: 'stride', description: 'The number of cells the window moves between steps; defaults to window_size when omitted.'}],
+    parameters: [{name: 'range', description: 'The range of numeric values to pool; must contain only numbers, and its dimensions must fit a whole number of windows (see window_size and stride).'}, {name: 'window_size', description: 'The width and height, in cells, of the square window whose maximum is taken at each step; a positive integer that is not greater than either dimension of range.'}, {name: 'stride', description: 'The number of cells the window moves between steps; a positive integer that defaults to window_size when omitted. Both dimensions of range, reduced by window_size, must be whole multiples of it, otherwise the function returns the #VALUE! error.'}],
     documentationUrl: 'https://hyperformula.handsontable.com/docs/guide/built-in-functions.html',
     examples: ['=MAXPOOL(A1:D4, 2)', '=MAXPOOL(A1:D4, 2, 1)'],
   },
   MEDIANPOOL: {
     category: 'Matrix functions',
     shortDescription: 'Calculates a smaller range which is a median of a window_size, in a given range, for every stride element.',
-    parameters: [{name: 'range', description: 'The range of numeric values to pool; must contain only numbers.'}, {name: 'window_size', description: 'The width and height, in cells, of the square window whose median is taken at each step.'}, {name: 'stride', description: 'The number of cells the window moves between steps; defaults to window_size when omitted.'}],
+    parameters: [{name: 'range', description: 'The range of numeric values to pool; must contain only numbers, and its dimensions must fit a whole number of windows (see window_size and stride).'}, {name: 'window_size', description: 'The width and height, in cells, of the square window whose median is taken at each step; a positive integer that is not greater than either dimension of range.'}, {name: 'stride', description: 'The number of cells the window moves between steps; a positive integer that defaults to window_size when omitted. Both dimensions of range, reduced by window_size, must be whole multiples of it, otherwise the function returns the #VALUE! error.'}],
     documentationUrl: 'https://hyperformula.handsontable.com/docs/guide/built-in-functions.html',
     examples: ['=MEDIANPOOL(A1:D4, 2)', '=MEDIANPOOL(A1:D4, 2, 1)'],
   },

--- a/src/interpreter/functionMetadata/categories/matrix-functions.ts
+++ b/src/interpreter/functionMetadata/categories/matrix-functions.ts
@@ -12,14 +12,14 @@ import {FunctionDoc} from '../FunctionDescription'
 export const MATRIX_FUNCTIONS_DOCS: Record<string, FunctionDoc> = {
   MAXPOOL: {
     category: 'Matrix functions',
-    shortDescription: 'Calculates a smaller range which is a maximum of a window_size, in a given range, for every stride element.',
+    shortDescription: 'Calculates a smaller range which is a maximum of a window_size, in a given range, for every stride element.<br>window_size and stride must be positive integers, and the window must tile the range exactly: window_size cannot exceed either dimension of range, and both dimensions, reduced by window_size, must be whole multiples of stride. Otherwise the function returns the #VALUE! error.',
     parameters: [{name: 'range', description: 'The range of numeric values to pool; must contain only numbers, and its dimensions must fit a whole number of windows (see window_size and stride).'}, {name: 'window_size', description: 'The width and height, in cells, of the square window whose maximum is taken at each step; a positive integer that is not greater than either dimension of range.'}, {name: 'stride', description: 'The number of cells the window moves between steps; a positive integer that defaults to window_size when omitted. Both dimensions of range, reduced by window_size, must be whole multiples of it, otherwise the function returns the #VALUE! error.'}],
     documentationUrl: 'https://hyperformula.handsontable.com/docs/guide/built-in-functions.html',
     examples: ['=MAXPOOL(A1:D4, 2)', '=MAXPOOL(A1:D4, 2, 1)'],
   },
   MEDIANPOOL: {
     category: 'Matrix functions',
-    shortDescription: 'Calculates a smaller range which is a median of a window_size, in a given range, for every stride element.',
+    shortDescription: 'Calculates a smaller range which is a median of a window_size, in a given range, for every stride element.<br>window_size and stride must be positive integers, and the window must tile the range exactly: window_size cannot exceed either dimension of range, and both dimensions, reduced by window_size, must be whole multiples of stride. Otherwise the function returns the #VALUE! error.',
     parameters: [{name: 'range', description: 'The range of numeric values to pool; must contain only numbers, and its dimensions must fit a whole number of windows (see window_size and stride).'}, {name: 'window_size', description: 'The width and height, in cells, of the square window whose median is taken at each step; a positive integer that is not greater than either dimension of range.'}, {name: 'stride', description: 'The number of cells the window moves between steps; a positive integer that defaults to window_size when omitted. Both dimensions of range, reduced by window_size, must be whole multiples of it, otherwise the function returns the #VALUE! error.'}],
     documentationUrl: 'https://hyperformula.handsontable.com/docs/guide/built-in-functions.html',
     examples: ['=MEDIANPOOL(A1:D4, 2)', '=MEDIANPOOL(A1:D4, 2, 1)'],

--- a/src/interpreter/plugin/MatrixPlugin.ts
+++ b/src/interpreter/plugin/MatrixPlugin.ts
@@ -9,6 +9,7 @@ import {ErrorMessage} from '../../error-message'
 import {AstNodeType, ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InternalScalarValue, InterpreterValue} from '../InterpreterValue'
+import {Maybe} from '../../Maybe'
 import {SimpleRangeValue} from '../../SimpleRangeValue'
 import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
@@ -37,6 +38,45 @@ function arraySizeForPoolFunction(inputArray: ArraySize, windowSize: number, str
   )
 }
 
+/**
+ * Checks whether a square pooling window tiles the input array exactly, so that no window reaches outside of it.
+ *
+ * The window size and the stride have to be positive integers, the window has to fit inside the input array,
+ * and both of its dimensions, reduced by the window size, have to be whole multiples of the stride.
+ *
+ * @param inputArray - dimensions of the pooled input array
+ * @param windowSize - side length of the square pooling window
+ * @param stride - distance between the top-left corners of two consecutive windows
+ */
+function isPoolWindowFittingInputArray(inputArray: ArraySize, windowSize: number, stride: number): boolean {
+  return Number.isInteger(windowSize) && windowSize >= 1
+    && Number.isInteger(stride) && stride >= 1
+    && windowSize <= inputArray.width
+    && windowSize <= inputArray.height
+    && (inputArray.width - windowSize) % stride === 0
+    && (inputArray.height - windowSize) % stride === 0
+}
+
+/**
+ * Validates the arguments shared by the pooling functions (MAXPOOL, MEDIANPOOL).
+ *
+ * @param matrix - the pooled input range
+ * @param windowSize - side length of the square pooling window
+ * @param stride - distance between the top-left corners of two consecutive windows
+ * @returns a {@link CellError} describing the violated constraint, or `undefined` when the arguments are valid
+ */
+function poolFunctionArgumentsError(matrix: SimpleRangeValue, windowSize: number, stride: number): Maybe<CellError> {
+  if (!matrix.hasOnlyNumbers()) {
+    return new CellError(ErrorType.VALUE, ErrorMessage.NumberRange)
+  }
+
+  if (!isPoolWindowFittingInputArray(matrix.size, windowSize, stride)) {
+    return new CellError(ErrorType.VALUE, ErrorMessage.PoolDimensions)
+  }
+
+  return undefined
+}
+
 export class MatrixPlugin extends FunctionPlugin implements FunctionPluginTypecheck<MatrixPlugin> {
   public static implementedFunctions: ImplementedFunctions = {
     'MMULT': {
@@ -61,8 +101,8 @@ export class MatrixPlugin extends FunctionPlugin implements FunctionPluginTypech
       sizeOfResultArrayMethod: 'maxpoolArraySize',
       parameters: [
         {argumentType: FunctionArgumentType.RANGE},
-        {argumentType: FunctionArgumentType.NUMBER},
-        {argumentType: FunctionArgumentType.NUMBER, optionalArg: true},
+        {argumentType: FunctionArgumentType.INTEGER, minValue: 1},
+        {argumentType: FunctionArgumentType.INTEGER, minValue: 1, optionalArg: true},
       ],
       vectorizationForbidden: true,
     },
@@ -71,8 +111,8 @@ export class MatrixPlugin extends FunctionPlugin implements FunctionPluginTypech
       sizeOfResultArrayMethod: 'medianpoolArraySize',
       parameters: [
         {argumentType: FunctionArgumentType.RANGE},
-        {argumentType: FunctionArgumentType.NUMBER},
-        {argumentType: FunctionArgumentType.NUMBER, optionalArg: true},
+        {argumentType: FunctionArgumentType.INTEGER, minValue: 1},
+        {argumentType: FunctionArgumentType.INTEGER, minValue: 1, optionalArg: true},
       ],
       vectorizationForbidden: true,
     },
@@ -110,10 +150,19 @@ export class MatrixPlugin extends FunctionPlugin implements FunctionPluginTypech
     return arraySizeForMultiplication(left, right)
   }
 
+  /**
+   * Corresponds to MAXPOOL(Range, Window_size, Stride).
+   *
+   * Reduces the input range to the maximum value of every window of `Window_size` x `Window_size` cells,
+   * moving the window by `Stride` cells. The window has to fit inside the range and the range dimensions,
+   * reduced by the window size, have to be whole multiples of the stride. Otherwise, the function
+   * returns the #VALUE! error.
+   */
   public maxpool(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
     return this.runFunction(ast.args, state, this.metadata('MAXPOOL'), (matrix: SimpleRangeValue, windowSize: number, stride: number = windowSize) => {
-      if (!matrix.hasOnlyNumbers()) {
-        return new CellError(ErrorType.VALUE, ErrorMessage.NumberRange)
+      const argumentsError = poolFunctionArgumentsError(matrix, windowSize, stride)
+      if (argumentsError !== undefined) {
+        return argumentsError
       }
       const outputSize = arraySizeForPoolFunction(matrix.size, windowSize, stride)
 
@@ -133,10 +182,19 @@ export class MatrixPlugin extends FunctionPlugin implements FunctionPluginTypech
     })
   }
 
+  /**
+   * Corresponds to MEDIANPOOL(Range, Window_size, Stride).
+   *
+   * Reduces the input range to the median value of every window of `Window_size` x `Window_size` cells,
+   * moving the window by `Stride` cells. The window has to fit inside the range and the range dimensions,
+   * reduced by the window size, have to be whole multiples of the stride. Otherwise, the function
+   * returns the #VALUE! error.
+   */
   public medianpool(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
     return this.runFunction(ast.args, state, this.metadata('MEDIANPOOL'), (matrix: SimpleRangeValue, windowSize: number, stride: number = windowSize) => {
-      if (!matrix.hasOnlyNumbers()) {
-        return new CellError(ErrorType.VALUE, ErrorMessage.NumberRange)
+      const argumentsError = poolFunctionArgumentsError(matrix, windowSize, stride)
+      if (argumentsError !== undefined) {
+        return argumentsError
       }
       const outputSize = arraySizeForPoolFunction(matrix.size, windowSize, stride)
 
@@ -227,9 +285,7 @@ export class MatrixPlugin extends FunctionPlugin implements FunctionPluginTypech
       }
     }
 
-    if (window > array.width || window > array.height
-      || stride > window
-      || (array.width - window) % stride !== 0 || (array.height - window) % stride !== 0) {
+    if (stride > window || !isPoolWindowFittingInputArray(array, window, stride)) {
       return ArraySize.error()
     }
 

--- a/src/interpreter/plugin/MatrixPlugin.ts
+++ b/src/interpreter/plugin/MatrixPlugin.ts
@@ -285,7 +285,7 @@ export class MatrixPlugin extends FunctionPlugin implements FunctionPluginTypech
       }
     }
 
-    if (stride > window || !isPoolWindowFittingInputArray(array, window, stride)) {
+    if (!isPoolWindowFittingInputArray(array, window, stride)) {
       return ArraySize.error()
     }
 


### PR DESCRIPTION
### Context

`MAXPOOL` and `MEDIANPOOL` computed the output array size without checking that the pooling window actually tiles the input range. When the range dimensions, reduced by the window size, were not whole multiples of the stride, the kernel read past the last row of the input, and an uncaught `TypeError` escaped the interpreter and the public API:

```ts
const hf = HyperFormula.buildEmpty({licenseKey: 'gpl-v3'})
const id = hf.getSheetId(hf.addSheet('S'))
hf.setSheetContent(id, [[3, 1, 2], [9, 7, 8], [5, 4, 6]])   // 3x3

hf.calculateFormula('=MAXPOOL(A1:C3, 2)', id)
// TypeError: Cannot read properties of undefined (reading '0')
hf.calculateFormula('=MEDIANPOOL(A1:C3, 2)', id)            // same
```

The same exception escaped `setCellContents()`. `maxpoolArraySize()` already rejected such arguments, but `ArraySize.error()` is `(1, 1, isRef: true)`, which `isScalar()` reports as scalar, so the formula was evaluated as an ordinary scalar formula and the invalid arguments reached the kernel anyway.

Related failure modes found while reproducing: a window larger than the range, a stride that makes the last window overshoot, and a zero, negative or fractional window size or stride all threw as well (`TypeError` or `RangeError: Invalid array length`).

### Changes

- `MatrixPlugin.maxpool()` / `MatrixPlugin.medianpool()` now validate the window size and the stride against the range dimensions and return `#VALUE!` with a new `ErrorMessage.PoolDimensions` (`'Range dimensions are not compatible with the window size and the stride.'`) instead of running the kernel out of bounds. `#VALUE!` matches how `MMULT` reports incompatible dimensions.
- The window size and the stride are declared as `FunctionArgumentType.INTEGER` with `minValue: 1`, so a zero, negative or fractional value returns `#NUM!` (`Value too small.` / `Value needs to be an integer.`) instead of throwing.
- The new `isPoolWindowFittingInputArray()` predicate is shared with `maxpoolArraySize()`, keeping the predicted array size and the runtime validation in sync. It also carries the positive-integer requirement, which fixes a second defect: `maxpoolArraySize()` predicted a **negative** array size for a negative stride, because `(4 - 2) % -1 === 0` passes a naive divisibility check. The cell then reported `#SPILL!` instead of the `#NUM!` the function actually returns.
- The dimension constraint is documented in the `range` / `window_size` / `stride` entries of `src/interpreter/functionMetadata/categories/matrix-functions.ts` — the single source of truth from which `docs/guide/built-in-functions.md` is generated — and in the JSDoc of both methods.

### Tests

In the private suite: **handsontable/hyperformula-tests#48**, on the matching `claude/vigilant-gates-3dkoua` branch so `fetch-tests.sh` pairs the two and this PR's CI runs against it.

New cases in `unit/interpreter/matrix-plugin.spec.ts` cover dimensions that are not a whole multiple of the window size (in a cell and via `calculateFormula()`), only one dimension divisible, a window larger than the range, an overshooting stride, a zero/negative/fractional window size and stride, and a window covering the whole range. The existing `matrix maxpool`, `matrix maxpool, custom stride` and `matrix medianpool on even/odd square` tests already guard the working cases.

Verified locally against the full private suite: **502 suites, 6230 tests passed, 3 skipped**. `npm run compile` passes.

### Types of changes

- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [x] Change to the documentation

### Related issues:

1. Fixes #...

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard. — `MAXPOOL` and `MEDIANPOOL` are HyperFormula-specific functions, not covered by the standard.
- [ ] My change is compatible with Microsoft Excel. — not applicable, these functions do not exist in Excel.
- [ ] My change is compatible with Google Sheets. — not applicable, these functions do not exist in Google Sheets.
- [x] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [x] My changes require a documentation update.
- [ ] My changes require a migration guide.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized bug fix to HyperFormula-specific pooling functions with stricter validation and clearer errors; no auth, data, or broad API contract changes beyond replacing throws with spreadsheet errors.
> 
> **Overview**
> **MAXPOOL** and **MEDIANPOOL** no longer throw uncaught `TypeError` (or related runtime errors) when the range does not tile cleanly with the window and stride. They now validate arguments up front and return **#VALUE!** with `ErrorMessage.PoolDimensions`, consistent with how incompatible dimensions are handled elsewhere (e.g. **MMULT**).
> 
> Shared helpers `isPoolWindowFittingInputArray()` and `poolFunctionArgumentsError()` enforce positive integer window size and stride, window fit inside the range, and divisibility of `(dimension - window_size)` by stride. The same predicate is used in `maxpoolArraySize()` so array-size prediction matches runtime behavior (including cases that previously mis-predicted size for invalid strides).
> 
> `window_size` and optional `stride` are typed as **INTEGER** with `minValue: 1` instead of generic numbers, so zero, negative, or fractional values surface as **#NUM!** via argument coercion rather than reaching the kernel. Function metadata and the changelog document the tiling rules and the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60606ca6ed773aa43e5090af067c56d2b91a4f89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->