### PR TITLE
Release script

### DIFF
--- a/script/release/release-README.md
+++ b/script/release/release-README.md
@@ -9,6 +9,14 @@ Usage:
 npm run release -- <command> [options]     # or: bash script/release/release.sh
 ```
 
+This file describes what each step *does*. It deliberately does not transcribe
+the commands the script runs — as it goes, the script prints each command that
+changes something (as a `$` line, and in a dry run prints it without running it)
+and previews the content it would write, so the script is the authority and this
+file cannot drift out of step with it. Not everything is echoed verbatim, though:
+read-only state checks run silently, and the in-place `node`/`perl` file edits
+are shown as preview blocks or `(set …)` lines rather than as literal commands.
+
 ## Before you start
 
 Both commands work across three repositories: this one, `hyperformula-tests`,
@@ -16,19 +24,26 @@ and `hyperformula-demos`. Before making any change — including during a dry
 run — each command checks that all three are usable, and refuses to start if
 they are not.
 
-- `hyperformula-tests` (default `test/hyperformula-tests`, override with
-  `--tests-dir PATH`) and `hyperformula-demos` (default `../hyperformula-demos`,
-  override with `--demos-dir PATH`) must each be a clone that has:
-  - a clean working tree,
-  - the branches this release will move (`develop` in both repos, plus
-    `master` in `hyperformula-tests` while running `publish`),
-  - a reachable `origin`.
-- If you have never had a private test clone, run `npm run test:setup-private`
-  first — it creates `test/hyperformula-tests` for you. `code-freeze` and
-  `publish` deliberately do not clone it for you mid-run.
-- A missing or dirty clone is an **error**, not a warning. This applies to dry
-  runs too: a preview that cannot see the repositories it would touch is not a
-  faithful preview.
+- **This repository** must be a git work tree with `package.json` present, the
+  branches the command will move, and a clean working tree. `code-freeze` relaxes
+  the last one for a dry run and for a resume: see [its preflight](#preflight).
+- **`hyperformula-tests`** always lives at `test/hyperformula-tests`. This is not
+  configurable, because `test/fetch-tests.sh` and the CI workflows all hardcode
+  it — if the script let you point it elsewhere, a freeze would validate one
+  clone and mutate another. If you have never had a private test clone, run
+  `npm run test:setup-private` first; it creates the clone for you. `code-freeze`
+  and `publish` deliberately do not clone it for you mid-run.
+- **`hyperformula-demos`** defaults to `../hyperformula-demos`, override with
+  `--demos-dir PATH`.
+- Each sibling clone must have a clean working tree, a reachable `origin`, the
+  branches the command will move (`develop` in both, plus `master` in
+  `hyperformula-tests` while running `publish`), and the script that command runs
+  inside it. The last one matters most for `publish`, whose demos script runs
+  *after* the npm publish that cannot be undone — so a wrong `--demos-dir` has to
+  be caught in the preflight or not at all.
+- A missing, dirty, or wrong clone is an **error**, not a warning. This applies
+  to dry runs too: a preview that cannot see the repositories it would touch is
+  not a faithful preview.
 
 ## Command: `code-freeze`
 
@@ -53,47 +68,99 @@ Arguments are `<version>` (e.g. `2.1.0`) and `<release-date>` in `YYYY-MM-DD`.
 | Flag | Effect |
 |------|--------|
 | `--real-run` | Actually run the commands. Without it, the script only previews (dry run). |
+| `--dry-run` | Preview only. This is the default; the flag exists to override a shell alias. |
 | `--demos-dir PATH` | Path to your `hyperformula-demos` clone. |
-| `--tests-dir PATH` | Path to your `hyperformula-tests` clone. |
 | `-h`, `--help` | Show help for this command. |
 
-`--tests-dir` should normally stay at its default. `test/fetch-tests.sh`
-(invoked by the freeze through `npm run test:setup-private`) and the CI
-workflows all hardcode `test/hyperformula-tests`, so pointing `--tests-dir`
-elsewhere splits the freeze across two clones — and you must pass the same
-`--tests-dir` to `publish` later, or it will look in `test/hyperformula-tests`
-and fail to find the release branch.
+### Preflight
+
+Before changing anything, and in a dry run too, `code-freeze` fetches `origin`
+(see below — the checks depend on it) and then checks that:
+
+1. This is a git work tree with `package.json` and a `develop` branch, and that
+   `npm`, `node` and `perl` are all on `PATH` — `node` makes the version, date
+   and release-notes edits, `perl` rewrites the demo URLs.
+2. `<version>` is not already tagged. A tag means the version is released, so
+   freezing it again is a typo rather than an intention. This is why the fetch
+   comes first: a tag a colleague pushed is invisible until it is fetched, which
+   is exactly the case worth catching.
+3. `<release-date>` is a date that exists. The `YYYY-MM-DD` shape is not enough:
+   `2026-02-30` would otherwise reach `ht.config.js` verbatim while the release
+   notes silently said March 2 and the changelog said February 30.
+4. Both sibling clones are usable (see [Before you start](#before-you-start)).
+5. The working tree is clean. Two cases stop short of refusing: a dry run
+   changes nothing, so it previews from a dirty tree and just says a real run
+   would refuse; and a resume — meaning `release/<version>` already exists **in
+   this clone** — is exempt, because there the dirty tree is the freeze's own
+   unfinished work and refusing would break the resume. Both are noted under
+   "worth checking" rather than treated as failures. A branch that exists only on
+   origin is *not* a resume: another clone ran that freeze, so anything dirty here
+   is your own and the run refuses.
+
+That fetch runs for real even in a dry run, so that every "does origin already
+have this?" answer is fresh, check 2 can see a tag someone else pushed, and the
+release type is classified against origin's `develop` rather than a possibly
+stale local copy. Only this repository is fetched with `--tags` — the tag checks
+above are what need them. The sibling clones are fetched the same way as each
+command reaches them, but plainly: neither `hyperformula-tests` nor
+`hyperformula-demos` is tag-gated, so a bare `git fetch origin` is enough there.
+
+So a dry run is not quite a no-op on disk: it updates remote-tracking refs and
+creates local tags. It never touches a working tree, a local branch, or a remote,
+which is what "changes nothing" means here — and without it the preview would
+describe decisions made from stale refs. The script marks these fetches
+`(always runs)` to distinguish them from the `$` lines that only execute with
+`--real-run`.
 
 ### What it does
 
-1. Gets onto `release/<version>`: creates it off `develop` the first time; on
-   a re-run, resumes an existing one — checking out the local branch, or
-   fetching it from origin first when only the remote has it (a cold local
-   tracking ref).
-2. Syncs the private test suite: `npm run test:setup-private` points
-   `test/hyperformula-tests` at a branch matching the current branch name,
-   creating that branch from `develop` the first time.
-3. Sets `version` in `package.json` and `HT_RELEASE_DATE` in `ht.config.js` —
-   each skipped when it already matches the target, so a re-run does not
-   rewrite files it already wrote.
-4. Reinstalls dependencies (wipes `node_modules`, deletes `package-lock.json`,
-   runs `npm i`) — skipped when `package-lock.json` already names the new
-   version and `node_modules` exists.
-5. `npm run bundle-all`, then `npm run lint` and `npm run test:jest`. These
-   always run, even when resuming a freeze that got this far before.
-6. Inserts `## [<version>] - <date>` under `## [Unreleased]` in
-   `CHANGELOG.md`, unless that entry already exists.
-7. **Generates the release notes**: turns that changelog entry into a
-   `docs/guide/release-notes.md` entry (`## <version>` +
-   `**Release date: Month D, YYYY**` + the same bullets), unless it's already there.
-8. **Major/minor only:** in `hyperformula-demos` runs `set-hyperformula-version.sh`,
-   commits, pushes, and creates the `M.m.x` branch; then find-replaces the
-   CodeSandbox demo URLs in `docs/`. Skipped entirely for a patch release.
-9. `git add . && git commit -m <version> && git push -u origin release/<version>`
-   — commits only if there is something to commit.
-10. Creates `release/<version>` in `hyperformula-tests` too (the same resume
-    logic as step 1), then `git push -u origin release/<version>` — so the
-    branch is ready for CI and for other developers for the rest of the freeze.
+1. **Gets onto `release/<version>`.** Creates it off `develop` the first time;
+   on a re-run, resumes the existing branch — fast-forwarding a local one, or
+   creating it from origin's when only the remote has it.
+2. **Gives the freeze a branch in `hyperformula-tests` and syncs the suite.**
+   Creates and pushes `release/<version>` there, then points the private test
+   suite at it via `npm run test:setup-private`. The push comes first on purpose:
+   `test/fetch-tests.sh` pulls the matching branch *from origin*, so a branch
+   that existed only locally used to make every resume fail here. Pushing it now
+   also publishes it for CI and for the other developers who add tests during
+   the freeze.
+3. **Sets the version and the release date** — `version` in `package.json` and
+   `HT_RELEASE_DATE` in `ht.config.js`. Each is skipped when it already matches,
+   so a re-run does not rewrite files it already wrote.
+4. **Reinstalls dependencies** and regenerates the lock file — skipped when
+   `package-lock.json` already names the new version *and* `node_modules` exists.
+   Both are required: an interrupted install can leave the lock file written and
+   `node_modules` missing, and skipping then would carry a broken install
+   straight into the build.
+5. **Builds, lints and runs the unit tests.** These always run, even when
+   resuming a freeze that got this far before. The browser suite is left to CI.
+6. **Adds the version section to `CHANGELOG.md`**, directly under
+   `## [Unreleased]` so that the bullets accumulated during development become
+   the new section — unless that section already exists.
+7. **Generates the release notes** from that changelog section: a `## <version>`
+   entry in `docs/guide/release-notes.md` with the release date and the same
+   bullets, unless it is already there. Only the two seams the insert creates are
+   reformatted, so the rest of the file is left exactly as it was.
+8. **Major/minor only — updates the demos and the docs URLs.** In
+   `hyperformula-demos`: sets the HyperFormula version across the demos on
+   `develop`, commits and pushes, then gets onto the `M.m.x` branch (creating it
+   if needed, fast-forwarding it first if it already exists) and makes sure the
+   version bump is on it. Then, in this repository, repoints every CodeSandbox
+   and StackBlitz demo URL in `docs/guide/` and `docs/index.md` — the tracked
+   files that carry them, so the rewrite never descends into generated output
+   like `docs/api/` — at `tree/<M.m.x>`, whatever branch it names today; old
+   releases left several behind. URLs for demos that no longer exist on the
+   current branch stay pinned to the last branch that has them (`vue-demo`, the
+   Vue 2 example replaced by `vue-3-demo` after 2.5.x); if you retire a demo, add
+   it to that list in the script. Skipped entirely for a patch release, where
+   `M.m.x` already names the right branch.
+9. **Commits and pushes the release branch.** Commits only if there is something
+   to commit. Stages **named paths, not `git add .`** — `package.json`,
+   `CHANGELOG.md`, and whichever of `package-lock.json`, `ht.config.js` and
+   `docs/` exist — so unrelated work elsewhere in your tree cannot ride along.
+   These are whole paths, though, not a list of files the run wrote, which is why
+   the preflight refuses to start a fresh freeze on a dirty tree. If you add a
+   step that writes somewhere new, add its path to that list too.
 
 ### What stays manual
 
@@ -111,6 +178,10 @@ are hard to miss in the output:
   [ ] Check that CI is green on release/<version> before publishing (the freeze runs
       the unit tests locally; the browser suite runs in CI on the pushed branch)
 ```
+
+A major release adds an item about testing the demos against the rc build.
+Anything the run could not do is listed in the same box, above these — see
+[Recorded failures](#recorded-failures).
 
 ## Command: `publish`
 
@@ -140,9 +211,9 @@ AND in `hyperformula-tests`; run `code-freeze` first if it doesn't.
 | Flag | Effect |
 |------|--------|
 | `--real-run` | Actually run the commands. Without it, the script only previews (dry run). |
-| `--skip-build` | Skip `npm ci` + `npm run bundle-all` (assumes the on-disk build already matches the release commit). `npm run verify:publish-package` still runs. Meant for a fast resume after a late failure. |
+| `--dry-run` | Preview only. This is the default; the flag exists to override a shell alias. |
+| `--skip-build` | Skip the reinstall and rebuild (assumes the on-disk build already matches the release commit). The package check still runs. Meant for a fast resume after a late failure. |
 | `--demos-dir PATH` | Path to your `hyperformula-demos` clone. |
-| `--tests-dir PATH` | Path to your `hyperformula-tests` clone. |
 | `-h`, `--help` | Show help for this command. |
 
 ### Preflight
@@ -151,45 +222,66 @@ Before changing anything, `publish` checks every hard requirement and exits
 with an error — in a dry run too — if one is not met:
 
 1. This repo is a usable git work tree: `package.json` present, both `master`
-   and `develop` branches exist, and the working tree is clean.
-2. Both sibling clones are usable (see [Before you start](#before-you-start)).
+   and `develop` branches exist, and the working tree is clean — unconditionally
+   here, unlike `code-freeze`, because `publish` never leaves work uncommitted.
+   `npm` and `node` must both be on `PATH`; `node` reads `package.json` off the
+   release ref in check 5.
+2. Both sibling clones are usable, including the demos script this run will
+   execute (see [Before you start](#before-you-start)).
 3. `release/<version>` exists — locally or on origin — in this repo AND in
    `hyperformula-tests`. `publish` finishes a freeze; it never improvises one,
    so a missing branch is an error rather than a step it works around.
-4. If both a local `release/<version>` and `origin/release/<version>` exist in
-   this repo, they must point at the same commit — reconcile them first with
-   `git checkout release/<version> && git pull --ff-only`.
+4. Where both a local `release/<version>` and `origin/release/<version>` exist,
+   they must point at the same commit — otherwise a late fix pushed to the freeze
+   branch would be silently dropped. The error names the commits and how to
+   reconcile them. Checked in both repositories, by the same code, so the two
+   guards cannot drift apart.
 5. `package.json` on `release/<version>` has `version` equal to the version
    you passed.
 6. `npm whoami` succeeds. In a dry run, a failure here doesn't stop the
    preview — it just shows `<not logged in>` in the plan.
+7. `hyperformula-demos` has the `M.m.x` branch. A missing one is noted rather
+   than fatal: step 8 can create it, and by then the release is already out, so
+   refusing there would leave a published package and a dead script. Reporting it
+   in the preflight is what gives you the chance to act. For a major or minor
+   release a missing `M.m.x` means the freeze's demos step never finished, so the
+   CodeSandbox URLs in `docs/` are probably wrong too; for the first patch on a
+   new minor line there may simply be nothing there yet.
+
+The commit `publish` merges is pinned during the preflight, so the later steps
+merge exactly the commit these checks verified, even though pulling along the way
+refreshes the refs.
 
 ### What it does
 
-1. Merges `release/<version>` into `master` (`--no-ff`), unless it is already
-   merged.
-2. Tags `<version>` on `master` — an annotated tag, message = the version —
-   unless that tag already exists and is already in `master`'s history (if it
-   exists anywhere else, the run stops so you can check it).
-3. Merges `release/<version>` into `develop` (`--no-ff`), unless it is already
-   merged.
-4. Checks out `master` and builds: `npm ci` + `npm run bundle-all` (both
-   skipped by `--skip-build`), then always `npm run verify:publish-package`.
-5. Pushes `master`, `develop` and every tag in one atomic push:
-   `git push --atomic origin master develop --tags`.
-6. In `hyperformula-tests`: merges `release/<version>` into `master` and into
-   `develop` there too (no tag — that repo isn't versioned), then
-   `git push --atomic origin master develop`.
-7. **The pause — the only irreversible step.** Unless `hyperformula@<version>`
-   is already on npm, prints the registry and the `npm whoami` user and asks
-   you to type the version back (anything else aborts), then runs
-   `npm publish` and waits up to 60s for the new version to become visible on
-   the registry.
-8. Updates `hyperformula-demos`: fetches, syncs `develop`, runs
-   `update-hyperformula-in-lock-files.sh`, commits if anything changed, and
-   pushes; then gets onto the `M.m.x` branch (creating it if needed) and
-   merges `develop` into it (unless already merged), pushing that too.
-9. Leaves you on `develop` in this repo.
+1. **Merges `release/<version>` into `master`** as a merge commit, unless it is
+   already merged.
+2. **Tags `<version>` on `master`** — an annotated tag, message = the version —
+   unless that tag already exists and is already in `master`'s (or
+   `origin/master`'s) history — the latter so a dry run against a stale local
+   `master` still recognises a tag that is fine on origin. If it exists anywhere
+   else, the run stops so you can check it.
+3. **Merges `release/<version>` into `develop`**, unless already merged.
+4. **Builds and verifies the package** from `master`: reinstall and rebuild
+   (both skipped by `--skip-build`), then always the publish-package check.
+5. **Pushes `master`, `develop` and the tags** in one atomic push, so a rejected
+   `master` cannot leave the tag and `develop` published on their own. This
+   happens before the npm publish, so the commit npm ships is already on origin.
+6. **Merges the release branch back in `hyperformula-tests`**, into both `master`
+   and `develop` there, and pushes both atomically. No tag — that repo is not
+   versioned.
+7. **The pause — the only step that cannot be undone.** Unless
+   `hyperformula@<version>` is already on npm, prints the registry and the
+   `npm whoami` user and asks you to type the version back (anything else
+   aborts), then publishes and waits up to 60s for the new version to become
+   visible on the registry. A plain `x.y.z` publishes under npm's `latest` tag;
+   a version carrying a prerelease suffix (an rc, e.g. `3.5.0-rc.1`) publishes
+   under `next` instead, so `npm install hyperformula` never resolves to it.
+8. **Updates `hyperformula-demos`.** Syncs `develop`, refreshes the lock files,
+   commits if anything changed, and pushes; then gets onto the `M.m.x` branch
+   (fast-forwarding it first) and merges `develop` into it unless already merged,
+   pushing that too. Ends on `develop` there.
+9. **Leaves you on `develop`** in this repo, where the next cycle starts.
 
 ### What stays manual
 
@@ -206,6 +298,36 @@ they are hard to miss in the output:
   [ ] Review the deployed docs and test the demos
 ```
 
+For a prerelease version (an rc — anything not a plain `x.y.z`) the GitHub link
+carries `&prerelease=1` and the checklist reminds you to leave *Set as the latest
+release* unchecked, so the prerelease is not marked latest on GitHub either —
+matching the `next` npm tag from step 7.
+
+## Recorded failures
+
+Both commands record anything you need to act on and re-print it as a `[ ]` item
+at the top of the closing checklist. A single marker line mid-run cannot carry
+that weight — it scrolls past in an output that also holds a full install, build
+and test log. There are two kinds, and only one of them means the run fell short:
+
+- **`!` — the script could not do it.** A step's target file has been
+  restructured, or the `[Unreleased]` section is empty, so the step cannot do its
+  job but the run is still worth finishing. These change the closing banner.
+- **`i` — worth checking.** The run did its job, but something deserves a look:
+  a resume that started from a dirty tree, or a demos version branch `publish`
+  had to create itself. These are listed without changing the banner, so an
+  ordinary resume does not announce itself as a failure.
+
+So `Done - release/<version> is ready for the freeze` (or `Done - <version> is
+released`) means the run did everything it set out to do, whatever is in the
+"worth checking" list. `Finished, but N thing(s) could not be done` means the box
+lists work that is still yours, and for a freeze the release branch needs those
+fixes committed before the freeze is really under way.
+
+The exit status stays 0 either way: these are interactive commands whose output
+*is* the report, and a non-zero exit would make `npm run release` bury the
+highlighted box under its own error block.
+
 ## Notes
 
 - Both commands are re-runnable. Every step checks whether it is already done
@@ -220,25 +342,33 @@ they are hard to miss in the output:
   CodeSandbox URL line it would rewrite (`-` current, `+` replacement).
 - If any step fails, the script stops right there, prints which step failed, and
   runs nothing further.
+- Getting onto a branch is one shared operation, wherever it happens: fetch
+  first, prefer the local branch and fast-forward it, else create it from
+  origin's, else create it from a named base. It never merges to get there, so a
+  branch that has genuinely diverged is an error you get to look at rather than a
+  merge commit invented on `develop` or on a shared version branch.
 - Verification steps (build, lint, tests, and `publish`'s package check)
   always re-run, even on a resumed freeze or a resumed publish — nothing on
   disk proves the build artifacts still match the release commit, and these
   are usually the steps a re-run is retrying anyway. `publish`'s
-  `--skip-build` is the explicit, deliberate override for the slow part
-  (`npm ci` + `npm run bundle-all`); the package check still runs even then.
+  `--skip-build` is the explicit, deliberate override for the slow part; the
+  package check still runs even then.
 - Release notes come straight from the changelog, so keep the `[Unreleased]`
   section tidy during development — that's exactly what becomes the notes.
-- The git-flow steps are translated to plain git: `release start` →
-  `git checkout -b release/<v> develop`; `release publish` →
-  `git push -u origin release/<v>`. `publish` (this script's command) covers
-  the rest of `release finish` — the merges into `master` and `develop`, and
-  the tag — except that it never deletes `release/<v>`; the branch is kept in
-  both repositories.
+- The git-flow steps are translated to plain git: `release start` becomes a
+  branch off `develop`, `release publish` becomes a push. `publish` (this
+  script's command) covers the rest of `release finish` — the merges into
+  `master` and `develop`, and the tag — except that it never deletes
+  `release/<v>`; the branch is kept in both repositories.
 - The way both commands handle `hyperformula-tests` deliberately differs from
   the [ClickUp process doc](https://app.clickup.com/9015210959/v/dc/8cnjcyf-9495/8cnjcyf-12135)
-  linked at the top of this file. See
-  `test/hyperformula-tests/dev_docs/2026-08-03-release-script-publish-command.md`
-  for why the two disagree. The ClickUp doc still needs updating to match.
+  linked at the top of this file: the freeze gives that repo its own
+  `release/<version>` branch and `publish` merges it back, where the doc still
+  describes pointing its `master` at `develop` by hand. The ClickUp doc still
+  needs updating to match.
+- Not automated, and not on either checklist: the ClickUp doc's step of deploying
+  the documentation to staging during the freeze. The checklist item about
+  testing the code examples on staging assumes you have done it.
 
 ## Adding a command later
 
@@ -246,4 +376,5 @@ Each command is a `cmd_<name>` function plus a line in the `case` at the bottom 
 the script, and a `usage_<name>` help function. To add, say, `post-release`: write
 `cmd_post_release()`, add `post-release) cmd_post_release "$@" ;;` to the dispatch,
 and list it in `usage_top`. (`cmd_code_freeze` and `cmd_publish` already follow
-this shape — use either as a reference.)
+this shape — use either as a reference.) Call `start_warning_register` first if
+the command has any step that can fail softly.

--- a/script/release/release-README.md
+++ b/script/release/release-README.md
@@ -107,6 +107,9 @@ are hard to miss in the output:
   [ ] Review the docs changes (GitHub compare)
   [ ] Test the code examples on staging
   [ ] Work with marketing on the blog post and social media content
+
+  [ ] Check that CI is green on release/<version> before publishing (the freeze runs
+      the unit tests locally; the browser suite runs in CI on the pushed branch)
 ```
 
 ## Command: `publish`

--- a/script/release/release-README.md
+++ b/script/release/release-README.md
@@ -104,9 +104,9 @@ are hard to miss in the output:
   [ ] Post a heads-up about the code freeze in #hyperformula and #release
 
   During the freeze:
-  [ ] Review the documentation changes (GitHub compare)
+  [ ] Review the docs changes (GitHub compare)
   [ ] Test the code examples on staging
-  [ ] Work with marketing team on the release blog post and social media announcements
+  [ ] Work with marketing on the blog post and social media content
 ```
 
 ## Command: `publish`

--- a/script/release/release-README.md
+++ b/script/release/release-README.md
@@ -9,6 +9,27 @@ Usage:
 npm run release -- <command> [options]     # or: bash script/release/release.sh
 ```
 
+## Before you start
+
+Both commands work across three repositories: this one, `hyperformula-tests`,
+and `hyperformula-demos`. Before making any change — including during a dry
+run — each command checks that all three are usable, and refuses to start if
+they are not.
+
+- `hyperformula-tests` (default `test/hyperformula-tests`, override with
+  `--tests-dir PATH`) and `hyperformula-demos` (default `../hyperformula-demos`,
+  override with `--demos-dir PATH`) must each be a clone that has:
+  - a clean working tree,
+  - the branches this release will move (`develop` in both repos, plus
+    `master` in `hyperformula-tests` while running `publish`),
+  - a reachable `origin`.
+- If you have never had a private test clone, run `npm run test:setup-private`
+  first — it creates `test/hyperformula-tests` for you. `code-freeze` and
+  `publish` deliberately do not clone it for you mid-run.
+- A missing or dirty clone is an **error**, not a warning. This applies to dry
+  runs too: a preview that cannot see the repositories it would touch is not a
+  faithful preview.
+
 ## Command: `code-freeze`
 
 Starts a HyperFormula code freeze. **Previews by default** — prints every command
@@ -36,26 +57,43 @@ Arguments are `<version>` (e.g. `2.1.0`) and `<release-date>` in `YYYY-MM-DD`.
 | `--tests-dir PATH` | Path to your `hyperformula-tests` clone. |
 | `-h`, `--help` | Show help for this command. |
 
+`--tests-dir` should normally stay at its default. `test/fetch-tests.sh`
+(invoked by the freeze through `npm run test:setup-private`) and the CI
+workflows all hardcode `test/hyperformula-tests`, so pointing `--tests-dir`
+elsewhere splits the freeze across two clones — and you must pass the same
+`--tests-dir` to `publish` later, or it will look in `test/hyperformula-tests`
+and fail to find the release branch.
+
 ### What it does
 
-1. `git checkout develop && git pull`, then `npm run test:setup-private` to put
-   `test/hyperformula-tests` on an up-to-date `develop`
-2. Creates `release/<version>` off develop
-3. Sets `version` in `package.json` and `HT_RELEASE_DATE` in `ht.config.js`
-4. Wipes `node_modules`, deletes `package-lock.json`, runs `npm i`
-5. `npm run bundle-all`, then `npm run test:setup-private` (points
-   `test/hyperformula-tests` at a branch matching `release/<version>`), then
-   `npm run lint` and `npm run test`
-6. Inserts `## [<version>] - <date>` under `## [Unreleased]` in `CHANGELOG.md`
+1. Gets onto `release/<version>`: creates it off `develop` the first time; on
+   a re-run, resumes an existing one — checking out the local branch, or
+   fetching it from origin first when only the remote has it (a cold local
+   tracking ref).
+2. Syncs the private test suite: `npm run test:setup-private` points
+   `test/hyperformula-tests` at a branch matching the current branch name,
+   creating that branch from `develop` the first time.
+3. Sets `version` in `package.json` and `HT_RELEASE_DATE` in `ht.config.js` —
+   each skipped when it already matches the target, so a re-run does not
+   rewrite files it already wrote.
+4. Reinstalls dependencies (wipes `node_modules`, deletes `package-lock.json`,
+   runs `npm i`) — skipped when `package-lock.json` already names the new
+   version and `node_modules` exists.
+5. `npm run bundle-all`, then `npm run lint` and `npm run test:jest`. These
+   always run, even when resuming a freeze that got this far before.
+6. Inserts `## [<version>] - <date>` under `## [Unreleased]` in
+   `CHANGELOG.md`, unless that entry already exists.
 7. **Generates the release notes**: turns that changelog entry into a
    `docs/guide/release-notes.md` entry (`## <version>` +
-   `**Release date: Month D, YYYY**` + the same bullets)
+   `**Release date: Month D, YYYY**` + the same bullets), unless it's already there.
 8. **Major/minor only:** in `hyperformula-demos` runs `set-hyperformula-version.sh`,
    commits, pushes, and creates the `M.m.x` branch; then find-replaces the
-   CodeSandbox demo URLs in `docs/`
+   CodeSandbox demo URLs in `docs/`. Skipped entirely for a patch release.
 9. `git add . && git commit -m <version> && git push -u origin release/<version>`
-   (the plain-git equivalent of `git flow release publish`)
-10. In `hyperformula-tests`: `git checkout master && git pull origin develop`
+   — commits only if there is something to commit.
+10. Creates `release/<version>` in `hyperformula-tests` too (the same resume
+    logic as step 1), then `git push -u origin release/<version>` — so the
+    branch is ready for CI and for other developers for the rest of the freeze.
 
 ### What stays manual
 
@@ -73,15 +111,105 @@ are hard to miss in the output:
 
 ## Command: `publish`
 
-Placeholder for the later "Release steps" (npm publish, tags, GitHub release,
-post-release). Not implemented yet — running it prints a notice and exits.
+Publishes a finished release: merges `release/<version>` into `master` and
+`develop`, tags it, builds and verifies the package, publishes it to npm, and
+updates `hyperformula-tests` and `hyperformula-demos`. **Previews by
+default** — prints every command and changes nothing. Add `--real-run` to
+actually do it.
 
 ```bash
-npm run release -- publish 2.1.0        # prints "not implemented yet"
+# Preview (dry run) — the default:
+npm run release -- publish 2.1.0
+
+# Do it for real:
+npm run release -- publish 2.1.0 --real-run
+```
+
+(The `--` tells npm to pass the rest through to the script. Or run it
+directly: `bash script/release/release.sh publish 2.1.0 --real-run`.)
+
+The argument is `<version>` (e.g. `2.1.0`) — the same version `code-freeze`
+started. `publish` requires `release/<version>` to already exist in this repo
+AND in `hyperformula-tests`; run `code-freeze` first if it doesn't.
+
+### Options
+
+| Flag | Effect |
+|------|--------|
+| `--real-run` | Actually run the commands. Without it, the script only previews (dry run). |
+| `--skip-build` | Skip `npm ci` + `npm run bundle-all` (assumes the on-disk build already matches the release commit). `npm run verify:publish-package` still runs. Meant for a fast resume after a late failure. |
+| `--demos-dir PATH` | Path to your `hyperformula-demos` clone. |
+| `--tests-dir PATH` | Path to your `hyperformula-tests` clone. |
+| `-h`, `--help` | Show help for this command. |
+
+### Preflight
+
+Before changing anything, `publish` checks every hard requirement and exits
+with an error — in a dry run too — if one is not met:
+
+1. This repo is a usable git work tree: `package.json` present, both `master`
+   and `develop` branches exist, and the working tree is clean.
+2. Both sibling clones are usable (see [Before you start](#before-you-start)).
+3. `release/<version>` exists — locally or on origin — in this repo AND in
+   `hyperformula-tests`. `publish` finishes a freeze; it never improvises one,
+   so a missing branch is an error rather than a step it works around.
+4. If both a local `release/<version>` and `origin/release/<version>` exist in
+   this repo, they must point at the same commit — reconcile them first with
+   `git checkout release/<version> && git pull --ff-only`.
+5. `package.json` on `release/<version>` has `version` equal to the version
+   you passed.
+6. `npm whoami` succeeds. In a dry run, a failure here doesn't stop the
+   preview — it just shows `<not logged in>` in the plan.
+
+### What it does
+
+1. Merges `release/<version>` into `master` (`--no-ff`), unless it is already
+   merged.
+2. Tags `<version>` on `master` — an annotated tag, message = the version —
+   unless that tag already exists and is already in `master`'s history (if it
+   exists anywhere else, the run stops so you can check it).
+3. Merges `release/<version>` into `develop` (`--no-ff`), unless it is already
+   merged.
+4. Checks out `master` and builds: `npm ci` + `npm run bundle-all` (both
+   skipped by `--skip-build`), then always `npm run verify:publish-package`.
+5. Pushes `master`, `develop` and every tag in one atomic push:
+   `git push --atomic origin master develop --tags`.
+6. In `hyperformula-tests`: merges `release/<version>` into `master` and into
+   `develop` there too (no tag — that repo isn't versioned), then
+   `git push --atomic origin master develop`.
+7. **The pause — the only irreversible step.** Unless `hyperformula@<version>`
+   is already on npm, prints the registry and the `npm whoami` user and asks
+   you to type the version back (anything else aborts), then runs
+   `npm publish` and waits up to 60s for the new version to become visible on
+   the registry.
+8. Updates `hyperformula-demos`: fetches, syncs `develop`, runs
+   `update-hyperformula-in-lock-files.sh`, commits if anything changed, and
+   pushes; then gets onto the `M.m.x` branch (creating it if needed) and
+   merges `develop` into it (unless already merged), pushing that too.
+9. Leaves you on `develop` in this repo.
+
+### What stays manual
+
+The script finishes by printing these as a highlighted `[ ]` checklist, so
+they are hard to miss in the output:
+
+```
+  [ ] Create the GitHub release for <version> (body = the <version> section of CHANGELOG.md):
+        https://github.com/handsontable/hyperformula/releases/new?tag=<version>&title=<version>
+  [ ] Check that the docs workflow deployed the documentation to gh-pages
+  [ ] Announce the release in #hyperformula and #release
+  [ ] Close the GitHub and ClickUp tasks in this release, announcing <version>,
+      notify everyone involved in the discussions, and check linked issues
+  [ ] Review the deployed docs and test the demos
 ```
 
 ## Notes
 
+- Both commands are re-runnable. Every step checks whether it is already done
+  before acting; a `=` marker (instead of `run`'s `$`) means the step found
+  nothing to do and skipped. If a run fails partway, fix the problem and run
+  the same command again — it resumes from wherever it stopped, rather than
+  redoing already-finished work.
 - Dry run is the default; nothing changes until you pass `--real-run`. Wherever
   the script generates or edits content it previews the exact text, fenced by
   `-----` lines, so you can proofread it before the real run: the new
@@ -89,18 +217,30 @@ npm run release -- publish 2.1.0        # prints "not implemented yet"
   CodeSandbox URL line it would rewrite (`-` current, `+` replacement).
 - If any step fails, the script stops right there, prints which step failed, and
   runs nothing further.
-- If `release/<version>` already exists (locally or on origin), the script prints
-  a message and does nothing. Delete the branch first if you want to redo the freeze.
+- Verification steps (build, lint, tests, and `publish`'s package check)
+  always re-run, even on a resumed freeze or a resumed publish — nothing on
+  disk proves the build artifacts still match the release commit, and these
+  are usually the steps a re-run is retrying anyway. `publish`'s
+  `--skip-build` is the explicit, deliberate override for the slow part
+  (`npm ci` + `npm run bundle-all`); the package check still runs even then.
 - Release notes come straight from the changelog, so keep the `[Unreleased]`
   section tidy during development — that's exactly what becomes the notes.
 - The git-flow steps are translated to plain git: `release start` →
   `git checkout -b release/<v> develop`; `release publish` →
-  `git push -u origin release/<v>`. (`code-freeze` only covers the *freeze*, so it
-  never merges/tags — that's a future command.)
+  `git push -u origin release/<v>`. `publish` (this script's command) covers
+  the rest of `release finish` — the merges into `master` and `develop`, and
+  the tag — except that it never deletes `release/<v>`; the branch is kept in
+  both repositories.
+- The way both commands handle `hyperformula-tests` deliberately differs from
+  the [ClickUp process doc](https://app.clickup.com/9015210959/v/dc/8cnjcyf-9495/8cnjcyf-12135)
+  linked at the top of this file. See
+  `test/hyperformula-tests/dev_docs/2026-08-03-release-script-publish-command.md`
+  for why the two disagree. The ClickUp doc still needs updating to match.
 
 ## Adding a command later
 
 Each command is a `cmd_<name>` function plus a line in the `case` at the bottom of
 the script, and a `usage_<name>` help function. To add, say, `post-release`: write
 `cmd_post_release()`, add `post-release) cmd_post_release "$@" ;;` to the dispatch,
-and list it in `usage_top`. (`publish` is already stubbed this way — a good template.)
+and list it in `usage_top`. (`cmd_code_freeze` and `cmd_publish` already follow
+this shape — use either as a reference.)

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -121,6 +121,29 @@ merge_release_into() { # merge_release_into <target branch> <release ref, for me
   fi
 }
 
+# The point of no return. Prints what is about to happen and requires the
+# operator to type the version back, so a stray Enter cannot publish.
+confirm_publish() { # confirm_publish <version> <npm user>
+  local version="$1" npm_user="$2" answer
+  printf '\n%s%s\n  ABOUT TO PUBLISH %s TO npm - THIS CANNOT BE UNDONE\n%s\n' \
+    "$HIGHLIGHT" "$CHECKLIST_RULE" "$version" "$CHECKLIST_RULE"
+  printf '  registry: %s\n  npm user: %s\n%s\n' \
+    "$(npm config get registry)" "$npm_user" "$RESET"
+  read -r -p "  Type the version to publish (anything else aborts): " answer
+  [[ "$answer" == "$version" ]] || die "aborted at the publish confirmation (got '$answer')."
+}
+
+# Waits until the registry serves the new version, so the steps after publish
+# (which install it) do not race npm's propagation.
+wait_for_npm() { # wait_for_npm <version>
+  local version="$1" waited=0
+  until on_npm "$version"; do
+    [[ $waited -ge 60 ]] && die "hyperformula@$version is not visible on npm after ${waited}s."
+    sleep 5; waited=$((waited + 5))
+    printf '    waiting for hyperformula@%s on npm (%ss)\n' "$version" "$waited"
+  done
+}
+
 usage_top() {
 cat <<'USAGE'
 release - HyperFormula release automation.
@@ -721,6 +744,20 @@ step "6. Merge $TESTS_REF back in hyperformula-tests"
   merge_release_into master  "$TESTS_REF" "$TESTS_TIP"
   merge_release_into develop "$TESTS_REF" "$TESTS_TIP"
   run git push --atomic origin master develop )
+
+# 7. The only irreversible step, behind a typed confirmation. Both the pause
+#    and the publish are skipped when the version is already on the registry,
+#    which is what makes a re-run after a mid-publish failure safe.
+step "7. Publish hyperformula@$VERSION to npm"
+if on_npm "$VERSION"; then
+  skip "hyperformula@$VERSION is already on npm - not publishing again"
+elif $DRY_RUN; then
+  echo "    (would ask for confirmation, then run: npm publish)"
+else
+  confirm_publish "$VERSION" "$NPM_USER"
+  run npm publish
+  wait_for_npm "$VERSION"
+fi
 }
 
 # ============================================================================

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -461,8 +461,10 @@ else
       skip "demos already at $VERSION - no commit needed"
     fi
     run git push
-    if git show-ref --verify --quiet "refs/heads/$VERSION_BRANCH"; then
+    if branch_exists "$VERSION_BRANCH"; then
       run git checkout "$VERSION_BRANCH"
+    elif remote_branch_exists "$VERSION_BRANCH"; then
+      run git checkout -b "$VERSION_BRANCH" "origin/$VERSION_BRANCH"
     else
       run git checkout -b "$VERSION_BRANCH"
     fi
@@ -685,6 +687,14 @@ elif remote_branch_exists "release/$VERSION" "$TESTS_DIR"; then
   TESTS_REF="origin/release/$VERSION"
 else
   die "No release/$VERSION branch in the tests repo ($TESTS_DIR) - the freeze did not create it."
+fi
+# Same divergence guard as the public repo above: a stale local branch here
+# would silently drop a test pushed to the freeze branch by someone else.
+if [[ "$TESTS_REF" == "release/$VERSION" ]] && remote_branch_exists "release/$VERSION" "$TESTS_DIR"; then
+  LOCAL_TESTS_TIP="$(git -C "$TESTS_DIR" rev-parse "release/$VERSION")"
+  ORIGIN_TESTS_TIP="$(git -C "$TESTS_DIR" rev-parse "origin/release/$VERSION" 2>/dev/null || true)"
+  [[ -n "$ORIGIN_TESTS_TIP" && "$LOCAL_TESTS_TIP" == "$ORIGIN_TESTS_TIP" ]] \
+    || die "Local release/$VERSION in the tests repo ($LOCAL_TESTS_TIP) differs from origin ($ORIGIN_TESTS_TIP) - reconcile them first: git -C $TESTS_DIR checkout release/$VERSION && git -C $TESTS_DIR pull --ff-only"
 fi
 # Pinned here, like RELEASE_TIP: the merge below must use the commit this
 # preflight verified, not whatever the ref names once sync_branch has pulled.

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -420,11 +420,15 @@ cmd_publish() {
 # ============================================================================
 # Dispatch
 # ============================================================================
-if [[ $# -eq 0 ]]; then usage_top; exit 0; fi
-COMMAND="$1"; shift
-case "$COMMAND" in
-  code-freeze)    cmd_code_freeze "$@" ;;
-  publish)        cmd_publish "$@" ;;
-  -h|--help|help) usage_top ;;
-  *) printf 'Unknown command: %s\n\n' "$COMMAND" >&2; usage_top >&2; exit 1 ;;
-esac
+# Only dispatch when executed. Sourcing the script (the test harness does this)
+# just defines the helpers, so they can be exercised on their own.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  if [[ $# -eq 0 ]]; then usage_top; exit 0; fi
+  COMMAND="$1"; shift
+  case "$COMMAND" in
+    code-freeze)    cmd_code_freeze "$@" ;;
+    publish)        cmd_publish "$@" ;;
+    -h|--help|help) usage_top ;;
+    *) printf 'Unknown command: %s\n\n' "$COMMAND" >&2; usage_top >&2; exit 1 ;;
+  esac
+fi

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -553,8 +553,20 @@ fi
 
 # 9. Commit the release branch and publish it (git flow release publish = push)
 step "9. Commit + push release/$VERSION"
-run git add .
-if $DRY_RUN || [[ -n "$(git status --porcelain)" ]]; then
+# Named pathspecs, not '.': an unrelated uncommitted change elsewhere in the
+# working tree (something the operator was working on, unrelated to the
+# freeze) must not ride along into the release commit. package-lock.json,
+# ht.config.js and docs/ are each conditional on existing - step 4 deletes and
+# regenerates the lock file, so between an 'npm i' and its write it is briefly
+# gone, and both files can be legitimately absent altogether (see step 3, and
+# t05b for the missing ht.config.js case) - a bare pathspec for any of them
+# would die under 'set -e' when it is not there.
+ADD_PATHS=(package.json CHANGELOG.md)
+[[ -f package-lock.json ]] && ADD_PATHS+=(package-lock.json)
+[[ -f ht.config.js ]] && ADD_PATHS+=(ht.config.js)
+[[ -d docs ]] && ADD_PATHS+=(docs)
+run git add "${ADD_PATHS[@]}"
+if $DRY_RUN || [[ -n "$(git status --porcelain -- "${ADD_PATHS[@]}")" ]]; then
   run git commit -m "$VERSION"
 else
   skip "nothing to commit"
@@ -593,6 +605,9 @@ manual_checklist <<NEXT
   [ ] Review the docs changes (GitHub compare)
   [ ] Test the code examples on staging
   [ ] Work with marketing on the blog post and social media content
+
+  [ ] Check that CI is green on release/$VERSION before publishing (the freeze runs
+      the unit tests locally; the browser suite runs in CI on the pushed branch)
 NEXT
 exit 0
 }
@@ -822,7 +837,11 @@ step "8. Update hyperformula-demos"
   else
     run git merge --no-ff -m "Merge branch 'develop' into $VERSION_BRANCH" develop
   fi
-  run git push -u origin "$VERSION_BRANCH" )
+  run git push -u origin "$VERSION_BRANCH"
+  # All three clones end on develop - see step 9 below for this repo. Unlike
+  # code-freeze, there is no reason to leave the operator on the version branch
+  # here: the freeze just created it, but publish only ever revisits it.
+  run git checkout develop )
 
 # 9. Leave the operator where the next cycle starts.
 step "9. Back to develop"

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -129,7 +129,10 @@ confirm_publish() { # confirm_publish <version> <npm user>
     "$HIGHLIGHT" "$CHECKLIST_RULE" "$version" "$CHECKLIST_RULE"
   printf '  registry: %s\n  npm user: %s\n%s\n' \
     "$(npm config get registry)" "$npm_user" "$RESET"
-  read -r -p "  Type the version to publish (anything else aborts): " answer
+  # A failed read means EOF or no terminal at all - a cron or CI invocation, say.
+  # Name that case rather than letting the ERR trap report a generic step failure.
+  read -r -p "  Type the version to publish (anything else aborts): " answer \
+    || die "no answer at the publish confirmation (no terminal?) - nothing was published."
   [[ "$answer" == "$version" ]] || die "aborted at the publish confirmation (got '$answer')."
 }
 

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -124,11 +124,17 @@ merge_release_into() { # merge_release_into <target branch> <release ref, for me
 # The point of no return. Prints what is about to happen and requires the
 # operator to type the version back, so a stray Enter cannot publish.
 confirm_publish() { # confirm_publish <version> <npm user>
-  local version="$1" npm_user="$2" answer
+  local version="$1" npm_user="$2" answer registry
+  # Read the registry into a variable first, tolerating failure: substituting the
+  # command inline would blank the line and print npm's stderr into the middle of
+  # the box, breaking the one banner in this script that must not be missed.
+  # Note this shows npm's configured registry; a publishConfig.registry in
+  # package.json would override it for the actual publish - there is none today.
+  registry="$(npm config get registry 2>/dev/null || true)"
   printf '\n%s%s\n  ABOUT TO PUBLISH %s TO npm - THIS CANNOT BE UNDONE\n%s\n' \
     "$HIGHLIGHT" "$CHECKLIST_RULE" "$version" "$CHECKLIST_RULE"
   printf '  registry: %s\n  npm user: %s\n%s\n' \
-    "$(npm config get registry)" "$npm_user" "$RESET"
+    "${registry:-<unknown - could not read npm config>}" "$npm_user" "$RESET"
   # A failed read means EOF or no terminal at all - a cron or CI invocation, say.
   # Name that case rather than letting the ERR trap report a generic step failure.
   read -r -p "  Type the version to publish (anything else aborts): " answer \
@@ -141,7 +147,9 @@ confirm_publish() { # confirm_publish <version> <npm user>
 wait_for_npm() { # wait_for_npm <version>
   local version="$1" waited=0
   until on_npm "$version"; do
-    [[ $waited -ge 60 ]] && die "hyperformula@$version is not visible on npm after ${waited}s."
+    # Say that the publish itself succeeded: by this point it has, and a bare
+    # "not visible" reads like the publish failed, which would invite a retry.
+    [[ $waited -ge 60 ]] && die "npm publish reported success, but hyperformula@$version is still not visible on npm after ${waited}s - check the registry before retrying."
     sleep 5; waited=$((waited + 5))
     printf '    waiting for hyperformula@%s on npm (%ss)\n' "$version" "$waited"
   done

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -536,7 +536,7 @@ exit 0
 }
 
 # ============================================================================
-# Command: publish  (placeholder - implement later)
+# Command: publish
 # ============================================================================
 cmd_publish() {
 local DRY_RUN=true SKIP_BUILD=false DEMOS_DIR="" TESTS_DIR="" VERSION=""

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -7,7 +7,7 @@
 #
 # Commands:
 #   code-freeze <version> <release-date> [--real-run]   Start a code freeze.
-#   publish <version>                                   Publish a release. (not implemented yet)
+#   publish <version> [--real-run]                      Publish a finished release.
 #
 # More commands will be added over time.
 # Run 'release.sh <command> --help' for command-specific options.
@@ -113,7 +113,7 @@ Usage: release.sh <command> [options]
 
 Commands:
   code-freeze <version> <release-date> [--real-run]   Start a code freeze.
-  publish <version>                                   Publish a release. (not implemented yet)
+  publish <version> [--real-run]                      Publish a finished release.
 
 Run 'release.sh <command> --help' for command-specific options.
 USAGE
@@ -141,8 +141,27 @@ usage_publish() {
 cat <<'USAGE'
 Usage: release.sh publish <version> [options]
 
-Publish a finished release - the "Release steps" section of the doc
-(npm publish, tags, GitHub release, post-release). NOT IMPLEMENTED YET.
+Publishes a finished release: merges release/<version> into master and develop,
+tags it, pushes, publishes to npm (after an interactive confirmation), and
+updates hyperformula-tests and hyperformula-demos. Previews by default (prints
+commands, changes nothing); add --real-run to make changes.
+
+Requires release/<version> to exist in this repo AND in hyperformula-tests -
+run 'release.sh code-freeze' first. Every step checks whether it is already
+done, so a failed run is recovered by running the same command again.
+
+Options:
+  --real-run         Actually run the commands (default is a dry-run preview).
+  --skip-build       Skip 'npm ci' + 'npm run bundle-all' (the on-disk build is
+                     assumed to match the release commit). The package check
+                     still runs. Meant for a fast resume after a late failure.
+  --demos-dir PATH   hyperformula-demos clone (default: ../hyperformula-demos).
+  --tests-dir PATH   hyperformula-tests clone (default: test/hyperformula-tests).
+
+Examples:
+  release.sh publish 2.1.0                          # preview (dry run)
+  release.sh publish 2.1.0 --real-run               # do it for real
+  release.sh publish 2.1.0 --real-run --skip-build  # resume without rebuilding
 USAGE
 }
 
@@ -520,10 +539,107 @@ exit 0
 # Command: publish  (placeholder - implement later)
 # ============================================================================
 cmd_publish() {
-  case "${1:-}" in -h|--help) usage_publish; exit 0 ;; esac
-  echo "release.sh publish is not implemented yet - placeholder for a future step."
-  echo "See the 'Release steps' section of the doc; for now, publish manually."
-  exit 1
+local DRY_RUN=true SKIP_BUILD=false DEMOS_DIR="" TESTS_DIR="" VERSION=""
+
+# ---- args ----
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --real-run)     DRY_RUN=false ;;
+    --dry-run)      DRY_RUN=true ;;
+    --skip-build)   SKIP_BUILD=true ;;
+    --demos-dir)    DEMOS_DIR="${2:-}"; shift ;;
+    --tests-dir)    TESTS_DIR="${2:-}"; shift ;;
+    -h|--help)      usage_publish; exit 0 ;;
+    -*)             die "Unknown option: $1" ;;
+    *) if [[ -z "$VERSION" ]]; then VERSION="$1"
+       else die "Unexpected arg: $1"; fi ;;
+  esac
+  shift
+done
+
+[[ -n "$VERSION" ]] || read -r -p "Version to publish (e.g. 2.1.0): " VERSION
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || die "Bad version: $VERSION"
+
+# ---- sanity checks ----
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "Not inside a git repo."
+[[ -f package.json ]] || die "No package.json here - run from the hyperformula repo root."
+command -v npm >/dev/null || die "npm not found."
+branch_exists master  || die "No 'master' branch."
+branch_exists develop || die "No 'develop' branch."
+[[ -z "$(git status --porcelain)" ]] || die "Working tree is dirty - commit or stash first."
+
+# default repo locations, as in code-freeze
+PARENT="$(dirname "$PWD")"
+[[ -z "$DEMOS_DIR" && -d "$PARENT/hyperformula-demos"   ]] && DEMOS_DIR="$PARENT/hyperformula-demos"
+[[ -z "$TESTS_DIR" && -d "$PWD/test/hyperformula-tests" ]] && TESTS_DIR="$PWD/test/hyperformula-tests"
+
+# Both sibling repositories are written to during a publish, so both are
+# required - same rule as code-freeze. The tests repo also needs master, which
+# step 6 merges into.
+require_repo hyperformula-tests "$TESTS_DIR" --tests-dir master develop
+require_repo hyperformula-demos "$DEMOS_DIR" --demos-dir develop
+
+step "Preflight"
+# Fetching only updates remote-tracking refs, so it is safe in a dry run too -
+# and every "is this already done?" check below needs the fresh state.
+printf '    $ git fetch origin --tags\n'
+git fetch origin --tags >/dev/null 2>&1 || die "git fetch origin failed."
+
+# Both release branches are prerequisites: 'publish' finishes a freeze, it never
+# improvises one. A missing branch means the freeze did not run for this version,
+# so it is an error rather than a step to skip. Prefer the local branch and fall
+# back to origin's, so publishing works from a fresh clone too.
+if branch_exists "release/$VERSION"; then
+  RELEASE_REF="release/$VERSION"
+elif remote_branch_exists "release/$VERSION"; then
+  RELEASE_REF="origin/release/$VERSION"
+else
+  die "No release/$VERSION branch (local or on origin) - run 'release.sh code-freeze $VERSION <date>' first."
+fi
+RELEASE_TIP="$(git rev-parse "$RELEASE_REF")"
+# Tolerant read, then explicit checks: under 'pipefail' an unreadable file or a
+# throwing JSON.parse would fail this assignment and trip the ERR trap, which
+# reports far less than the two messages below.
+REF_VERSION="$(git show "$RELEASE_REF:package.json" 2>/dev/null \
+  | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(JSON.parse(s).version||"")}catch(e){}})' 2>/dev/null || true)"
+[[ -n "$REF_VERSION" ]] \
+  || die "Could not read a version from package.json on $RELEASE_REF."
+[[ "$REF_VERSION" == "$VERSION" ]] \
+  || die "package.json on $RELEASE_REF says $REF_VERSION, not $VERSION."
+
+# Same requirement in the tests repo, checked here so the run fails before it
+# touches master, rather than half-way through step 6.
+printf '    $ git -C %s fetch origin\n' "$TESTS_DIR"
+git -C "$TESTS_DIR" fetch origin >/dev/null 2>&1 || die "git fetch failed in $TESTS_DIR."
+if git -C "$TESTS_DIR" show-ref --verify --quiet "refs/heads/release/$VERSION"; then
+  TESTS_REF="release/$VERSION"
+elif git -C "$TESTS_DIR" ls-remote --heads origin "release/$VERSION" 2>/dev/null | grep -q .; then
+  TESTS_REF="origin/release/$VERSION"
+else
+  die "No release/$VERSION branch in the tests repo ($TESTS_DIR) - the freeze did not create it."
+fi
+
+NPM_USER="$(npm whoami 2>/dev/null || true)"
+if [[ -z "$NPM_USER" ]]; then
+  $DRY_RUN || die "npm whoami failed - run 'npm login' first."
+  NPM_USER="<not logged in>"
+fi
+
+IFS='.' read -r nM nm _ <<<"$VERSION"
+VERSION_BRANCH="${nM}.${nm}.x"
+
+step "Plan"
+cat <<INFO
+  version:      $VERSION
+  release ref:  $RELEASE_REF
+  npm user:     $NPM_USER
+  demos repo:   $DEMOS_DIR  (branch $VERSION_BRANCH)
+  tests repo:   $TESTS_DIR  ($TESTS_REF)
+  build:        $($SKIP_BUILD && echo 'SKIPPED (--skip-build; package check still runs)' || echo 'npm ci + bundle-all + package check')
+  mode:         $($DRY_RUN && echo 'DRY RUN (preview; pass --real-run to make changes)' || echo 'REAL RUN (making changes)')
+INFO
+
+exit 0
 }
 
 # ============================================================================

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -176,8 +176,8 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --real-run)     DRY_RUN=false ;;
     --dry-run)      DRY_RUN=true ;;
-    --demos-dir)    DEMOS_DIR="${2:-}"; shift ;;
-    --tests-dir)    TESTS_DIR="${2:-}"; shift ;;
+    --demos-dir)    [[ $# -ge 2 ]] || die "Missing value for $1"; DEMOS_DIR="$2"; shift ;;
+    --tests-dir)    [[ $# -ge 2 ]] || die "Missing value for $1"; TESTS_DIR="$2"; shift ;;
     -h|--help)      usage_code_freeze; exit 0 ;;
     -*)             die "Unknown option: $1" ;;
     *) if   [[ -z "$VERSION"  ]]; then VERSION="$1"
@@ -547,8 +547,8 @@ while [[ $# -gt 0 ]]; do
     --real-run)     DRY_RUN=false ;;
     --dry-run)      DRY_RUN=true ;;
     --skip-build)   SKIP_BUILD=true ;;
-    --demos-dir)    DEMOS_DIR="${2:-}"; shift ;;
-    --tests-dir)    TESTS_DIR="${2:-}"; shift ;;
+    --demos-dir)    [[ $# -ge 2 ]] || die "Missing value for $1"; DEMOS_DIR="$2"; shift ;;
+    --tests-dir)    [[ $# -ge 2 ]] || die "Missing value for $1"; TESTS_DIR="$2"; shift ;;
     -h|--help)      usage_publish; exit 0 ;;
     -*)             die "Unknown option: $1" ;;
     *) if [[ -z "$VERSION" ]]; then VERSION="$1"
@@ -580,9 +580,11 @@ require_repo hyperformula-tests "$TESTS_DIR" --tests-dir master develop
 require_repo hyperformula-demos "$DEMOS_DIR" --demos-dir develop
 
 step "Preflight"
-# Fetching only updates remote-tracking refs, so it is safe in a dry run too -
-# and every "is this already done?" check below needs the fresh state.
-printf '    $ git fetch origin --tags\n'
+# Fetching writes only refs the release reads (remote-tracking branches, and
+# local tags via --tags), never the working tree - so it is safe in a dry run,
+# and every "is this already done?" check below needs the fresh state. Marked
+# "(always runs)" because elsewhere a '$' line means "only with --real-run".
+printf '    $ git fetch origin --tags   (always runs)\n'
 git fetch origin --tags >/dev/null 2>&1 || die "git fetch origin failed."
 
 # Both release branches are prerequisites: 'publish' finishes a freeze, it never
@@ -608,12 +610,15 @@ REF_VERSION="$(git show "$RELEASE_REF:package.json" 2>/dev/null \
   || die "package.json on $RELEASE_REF says $REF_VERSION, not $VERSION."
 
 # Same requirement in the tests repo, checked here so the run fails before it
-# touches master, rather than half-way through step 6.
-printf '    $ git -C %s fetch origin\n' "$TESTS_DIR"
+# touches master, rather than half-way through the merge-back. Use the shared
+# predicates with their repo-path argument: a raw 'ls-remote --heads origin
+# release/X' matches by path component, so an unrelated 'old/release/X' would
+# satisfy it - the collision remote_branch_exists exists to prevent.
+printf '    $ git -C %s fetch origin   (always runs)\n' "$TESTS_DIR"
 git -C "$TESTS_DIR" fetch origin >/dev/null 2>&1 || die "git fetch failed in $TESTS_DIR."
-if git -C "$TESTS_DIR" show-ref --verify --quiet "refs/heads/release/$VERSION"; then
+if branch_exists "release/$VERSION" "$TESTS_DIR"; then
   TESTS_REF="release/$VERSION"
-elif git -C "$TESTS_DIR" ls-remote --heads origin "release/$VERSION" 2>/dev/null | grep -q .; then
+elif remote_branch_exists "release/$VERSION" "$TESTS_DIR"; then
   TESTS_REF="origin/release/$VERSION"
 else
   die "No release/$VERSION branch in the tests repo ($TESTS_DIR) - the freeze did not create it."

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -209,6 +209,13 @@ PARENT="$(dirname "$PWD")"
 [[ -z "$DEMOS_DIR" && -d "$PARENT/hyperformula-demos"   ]] && DEMOS_DIR="$PARENT/hyperformula-demos"
 [[ -z "$TESTS_DIR" && -d "$PWD/test/hyperformula-tests" ]] && TESTS_DIR="$PWD/test/hyperformula-tests"
 
+# Both sibling repositories are part of a freeze, so verify them before doing
+# anything: a freeze that half-runs across three repositories is worse than one
+# that refuses to start. The demos clone is required even for a patch release
+# (where step 8 is skipped) - the check is about the environment being complete.
+require_repo hyperformula-tests "$TESTS_DIR" --tests-dir develop
+require_repo hyperformula-demos "$DEMOS_DIR" --demos-dir develop
+
 step "Plan"
 cat <<INFO
   version:      $VERSION   (was ${PRE_FREEZE_VERSION:-unknown}, $RELEASE_TYPE release)
@@ -369,35 +376,26 @@ step "8. Demos + docs URLs (major/minor only)"
 if [[ "$RELEASE_TYPE" == patch ]]; then
   echo "    skipped (patch release)"
 else
-  if [[ -n "$DEMOS_DIR" && -d "$DEMOS_DIR" ]]; then
-    echo "    updating $DEMOS_DIR -> $VERSION, branch $VERSION_BRANCH"
-    ( trap - ERR; cd "$DEMOS_DIR"
-      run git checkout develop
-      run git pull
-      run sh set-hyperformula-version.sh "$VERSION"
-      run git add .
-      if $DRY_RUN || [[ -n "$(git status --porcelain)" ]]; then
-        run git commit -m "Set hyperformula version for all demos"
-      else
-        skip "demos already at $VERSION - no commit needed"
-      fi
-      run git push
-      if git show-ref --verify --quiet "refs/heads/$VERSION_BRANCH"; then
-        run git checkout "$VERSION_BRANCH"
-      else
-        run git checkout -b "$VERSION_BRANCH"
-      fi
-      run git push -u origin "$VERSION_BRANCH" )
-    [[ "$RELEASE_TYPE" == major ]] && echo "    ! major: manually test demos against the rc build."
-  else
-    cat <<MANUAL
-    ! demos repo not found - run in your hyperformula-demos clone:
-        git checkout develop && git pull
-        sh set-hyperformula-version.sh $VERSION
-        git add . && git commit -m "Set hyperformula version for all demos" && git push
-        git checkout -b $VERSION_BRANCH && git push -u origin $VERSION_BRANCH
-MANUAL
-  fi
+  # The sanity checks have already proved the demos clone is usable.
+  echo "    updating $DEMOS_DIR -> $VERSION, branch $VERSION_BRANCH"
+  ( trap - ERR; cd "$DEMOS_DIR"
+    run git checkout develop
+    run git pull
+    run sh set-hyperformula-version.sh "$VERSION"
+    run git add .
+    if $DRY_RUN || [[ -n "$(git status --porcelain)" ]]; then
+      run git commit -m "Set hyperformula version for all demos"
+    else
+      skip "demos already at $VERSION - no commit needed"
+    fi
+    run git push
+    if git show-ref --verify --quiet "refs/heads/$VERSION_BRANCH"; then
+      run git checkout "$VERSION_BRANCH"
+    else
+      run git checkout -b "$VERSION_BRANCH"
+    fi
+    run git push -u origin "$VERSION_BRANCH" )
+  [[ "$RELEASE_TYPE" == major ]] && echo "    ! major: manually test demos against the rc build."
   # CodeSandbox demo URLs in this repo's docs/: point every one at the new
   # branch, whatever branch it names now (old releases left several behind)
   if [[ -d docs ]]; then
@@ -482,17 +480,27 @@ else
 fi
 run git push -u origin "release/$VERSION"
 
-# 10. hyperformula-tests repo
-step "10. Update hyperformula-tests"
-if [[ -n "$TESTS_DIR" && -d "$TESTS_DIR" ]]; then
-  ( trap - ERR; cd "$TESTS_DIR"; run git checkout master; run git pull origin develop )
-else
-  cat <<MANUAL
-    ! tests repo not found - run in your hyperformula-tests clone:
-        git checkout master
-        git pull origin develop
-MANUAL
-fi
+# 10. hyperformula-tests: give the freeze its own branch there and publish it,
+#     so CI and other developers can add tests during the freeze. 'publish'
+#     merges it back. (The process doc still describes the older
+#     'checkout master && pull origin develop' - see release-README.md.)
+#     The sanity checks have already proved the clone is usable, so there is no
+#     "repo not found" path here.
+step "10. Create + push release/$VERSION in hyperformula-tests"
+( trap - ERR; cd "$TESTS_DIR"
+  run git fetch origin
+  if branch_exists "release/$VERSION"; then
+    skip "release/$VERSION already exists in the tests repo"
+    run git checkout "release/$VERSION"
+  elif remote_branch_exists "release/$VERSION"; then
+    skip "release/$VERSION exists on the tests repo's origin"
+    run git checkout -b "release/$VERSION" "origin/release/$VERSION"
+  else
+    run git checkout develop
+    run git pull --ff-only
+    run git checkout -b "release/$VERSION"
+  fi
+  run git push -u origin "release/$VERSION" )
 
 step "Done - release/$VERSION is ready for the freeze"
 if $DRY_RUN; then echo "  (dry run - nothing changed; re-run with --real-run to do it for real)"; fi

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -107,14 +107,17 @@ sync_branch() {
 
 # Merges a release ref into a target branch, unless it is already in there.
 # Uses --no-ff so the release stays visible as a merge commit, matching what
-# 'git flow release finish' produces.
-merge_release_into() { # merge_release_into <target branch> <release ref> <release tip sha>
+# 'git flow release finish' produces. Merges the pinned TIP, never the ref:
+# sync_branch's pull refreshes every remote-tracking ref, so a ref could name a
+# newer commit than the one the preflight checked and reported. The ref is used
+# only in messages.
+merge_release_into() { # merge_release_into <target branch> <release ref, for messages> <release tip sha, merged>
   local target="$1" release_ref="$2" release_tip="$3"
   sync_branch "$target"
   if is_ancestor "$release_tip" "$target"; then
     skip "$release_ref already merged into $target"
   else
-    run git merge --no-ff -m "Merge branch '$release_ref' into $target" "$release_ref"
+    run git merge --no-ff -m "Merge branch '$release_ref' into $target" "$release_tip"
   fi
 }
 
@@ -611,6 +614,16 @@ elif remote_branch_exists "release/$VERSION"; then
 else
   die "No release/$VERSION branch (local or on origin) - run 'release.sh code-freeze $VERSION <date>' first."
 fi
+
+# A local release branch can be stale - someone may have pushed a late fix to
+# the freeze branch. Publishing the local tip would silently drop it, so require
+# the two to agree rather than guessing which is wanted.
+if [[ "$RELEASE_REF" == "release/$VERSION" ]] && remote_branch_exists "release/$VERSION"; then
+  LOCAL_TIP="$(git rev-parse "release/$VERSION")"
+  ORIGIN_TIP="$(git rev-parse "origin/release/$VERSION" 2>/dev/null || true)"
+  [[ -n "$ORIGIN_TIP" && "$LOCAL_TIP" == "$ORIGIN_TIP" ]] \
+    || die "Local release/$VERSION ($LOCAL_TIP) differs from origin ($ORIGIN_TIP) - reconcile them first: git checkout release/$VERSION && git pull --ff-only"
+fi
 RELEASE_TIP="$(git rev-parse "$RELEASE_REF")"
 # Tolerant read, then explicit checks: under 'pipefail' an unreadable file or a
 # throwing JSON.parse would fail this assignment and trip the ERR trap, which
@@ -657,11 +670,11 @@ cat <<INFO
   mode:         $($DRY_RUN && echo 'DRY RUN (preview; pass --real-run to make changes)' || echo 'REAL RUN (making changes)')
 INFO
 
-# 1-2. master gets the release
+# 1. master gets the release
 step "1. Merge $RELEASE_REF into master"
 merge_release_into master "$RELEASE_REF" "$RELEASE_TIP"
 
-# 3. Tag the release on master (git flow release finish tags here)
+# 2. Tag the release on master (git flow release finish tags here)
 step "2. Tag $VERSION"
 if tag_exists "$VERSION"; then
   if is_ancestor "refs/tags/$VERSION" master; then
@@ -673,11 +686,11 @@ else
   run git tag -a "$VERSION" -m "$VERSION"
 fi
 
-# 4. develop gets the release too
+# 3. develop gets the release too
 step "3. Merge $RELEASE_REF into develop"
 merge_release_into develop "$RELEASE_REF" "$RELEASE_TIP"
 
-# 5. Build what is about to be published, from master
+# 4. Build what is about to be published, from master
 step "4. Build + verify the package"
 run git checkout master
 if $SKIP_BUILD; then
@@ -688,10 +701,11 @@ else
 fi
 run npm run verify:publish-package
 
-# 6. Publish the branches and the tag before the package, so the commit that
-#    npm publish ships is already on origin.
+# 5. Publish the branches and the tag before the package, so the commit that
+#    npm publish ships is already on origin. --atomic so a rejected master
+#    cannot leave the tag and develop published on their own.
 step "5. Push master, develop and tags"
-run git push origin master develop --tags
+run git push --atomic origin master develop --tags
 }
 
 # ============================================================================

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -649,6 +649,9 @@ elif remote_branch_exists "release/$VERSION" "$TESTS_DIR"; then
 else
   die "No release/$VERSION branch in the tests repo ($TESTS_DIR) - the freeze did not create it."
 fi
+# Pinned here, like RELEASE_TIP: the merge below must use the commit this
+# preflight verified, not whatever the ref names once sync_branch has pulled.
+TESTS_TIP="$(git -C "$TESTS_DIR" rev-parse "$TESTS_REF")"
 
 NPM_USER="$(npm whoami 2>/dev/null || true)"
 if [[ -z "$NPM_USER" ]]; then
@@ -706,6 +709,18 @@ run npm run verify:publish-package
 #    cannot leave the tag and develop published on their own.
 step "5. Push master, develop and tags"
 run git push --atomic origin master develop --tags
+
+# 6. hyperformula-tests: the freeze branch created by 'code-freeze' goes back
+#    into master and develop. No tag - that repo is not versioned. (The process
+#    doc predates this; see release-README.md.)
+step "6. Merge $TESTS_REF back in hyperformula-tests"
+# Preflight proved the clone, the branch and a clean tree, already fetched, and
+# pinned TESTS_TIP - so this is a straight merge of a fixed commit. No
+# 'trap - ERR' here: a failure inside this subshell must still name the step.
+( cd "$TESTS_DIR"
+  merge_release_into master  "$TESTS_REF" "$TESTS_TIP"
+  merge_release_into develop "$TESTS_REF" "$TESTS_TIP"
+  run git push --atomic origin master develop )
 }
 
 # ============================================================================

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -232,26 +232,42 @@ fi
 step "2. Sync the private test suite"
 run npm run test:setup-private
 
-# 3. Bump version + release date
+# 3. Bump version + release date (each half skipped when already correct, so a
+#    re-run after a later failure does not rewrite files it already wrote)
 step "3. Bump version + HT_RELEASE_DATE"
-if $DRY_RUN; then
-  echo "    (set package.json version=$VERSION, ht.config.js HT_RELEASE_DATE='$DATE_HT')"
+CURRENT_VERSION="$(node -e 'process.stdout.write(require("./package.json").version||"")' 2>/dev/null || true)"
+if [[ "$CURRENT_VERSION" == "$VERSION" ]]; then
+  skip "package.json already at $VERSION"
+elif $DRY_RUN; then
+  echo "    (set package.json version=$VERSION)"
 else
   CF_V="$VERSION" node -e 'const f="package.json",j=require("./"+f);j.version=process.env.CF_V;require("fs").writeFileSync(f,JSON.stringify(j,null,2)+"\n")'
   echo "    package.json version -> $VERSION"
-  if [[ -f ht.config.js ]] && grep -q HT_RELEASE_DATE ht.config.js; then
-    CF_D="$DATE_HT" node -e 'const f="ht.config.js",fs=require("fs");let s=fs.readFileSync(f,"utf8");s=s.replace(/(HT_RELEASE_DATE\s*:\s*)([\x27"])[^\x27"]*\2/,`$1$2${process.env.CF_D}$2`);fs.writeFileSync(f,s)'
-    echo "    ht.config.js HT_RELEASE_DATE -> $DATE_HT"
-  else
-    echo "    ! HT_RELEASE_DATE not found in ht.config.js - set it to $DATE_HT manually."
-  fi
 fi
 
-# 4. Regenerate lock file
+CURRENT_HT_DATE="$(sed -n "s/.*HT_RELEASE_DATE[[:space:]]*:[[:space:]]*'\([^']*\)'.*/\1/p" ht.config.js 2>/dev/null | head -1)"
+if [[ ! -f ht.config.js ]] || ! grep -q HT_RELEASE_DATE ht.config.js; then
+  echo "    ! HT_RELEASE_DATE not found in ht.config.js - set it to $DATE_HT manually."
+elif [[ "$CURRENT_HT_DATE" == "$DATE_HT" ]]; then
+  skip "ht.config.js HT_RELEASE_DATE already $DATE_HT"
+elif $DRY_RUN; then
+  echo "    (set ht.config.js HT_RELEASE_DATE='$DATE_HT')"
+else
+  CF_D="$DATE_HT" node -e 'const f="ht.config.js",fs=require("fs");let s=fs.readFileSync(f,"utf8");s=s.replace(/(HT_RELEASE_DATE\s*:\s*)([\x27"])[^\x27"]*\2/,`$1$2${process.env.CF_D}$2`);fs.writeFileSync(f,s)'
+  echo "    ht.config.js HT_RELEASE_DATE -> $DATE_HT"
+fi
+
+# 4. Regenerate the lock file. A lock file already naming the new version is
+#    proof it was regenerated after the bump, so a re-run leaves it alone.
 step "4. Reinstall dependencies"
-run rm -rf ./node_modules
-run rm -f package-lock.json
-run npm i
+LOCK_VERSION="$(node -e 'try{process.stdout.write(require("./package-lock.json").version||"")}catch(e){}' 2>/dev/null || true)"
+if [[ "$LOCK_VERSION" == "$VERSION" ]]; then
+  skip "package-lock.json already regenerated for $VERSION"
+else
+  run rm -rf ./node_modules
+  run rm -f package-lock.json
+  run npm i
+fi
 
 # 5. Build / lint / test  (the private test suite was already pointed at this
 #    branch in step 2, and nothing since has changed the branch it follows)

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -769,6 +769,56 @@ else
   run npm publish
   wait_for_npm "$VERSION"
 fi
+
+# 8. Demos consume the published version, so they come after the publish.
+#    Preflight has already proved the clone is usable. No 'trap - ERR' here: a
+#    failure inside this subshell must still name the step.
+step "8. Update hyperformula-demos"
+( cd "$DEMOS_DIR"
+  run git fetch origin
+  sync_branch develop
+  run sh update-hyperformula-in-lock-files.sh
+  if $DRY_RUN || [[ -n "$(git status --porcelain)" ]]; then
+    run git add .
+    run git commit -m "Update hyperformula version in all lock files"
+  else
+    skip "lock files already up to date - nothing to commit"
+  fi
+  run git push origin develop
+
+  # sync_branch, not a raw checkout: the version branch is shared, and pushing
+  # to it without fast-forwarding first is what broke the tests-repo step once.
+  if branch_exists "$VERSION_BRANCH"; then
+    sync_branch "$VERSION_BRANCH"
+  elif remote_branch_exists "$VERSION_BRANCH"; then
+    run git checkout -b "$VERSION_BRANCH" "origin/$VERSION_BRANCH"
+  else
+    run git checkout -b "$VERSION_BRANCH"
+  fi
+  if is_ancestor develop "$VERSION_BRANCH"; then
+    skip "develop already merged into $VERSION_BRANCH"
+  else
+    run git merge --no-ff -m "Merge branch 'develop' into $VERSION_BRANCH" develop
+  fi
+  run git push -u origin "$VERSION_BRANCH" )
+
+# 9. Leave the operator where the next cycle starts.
+step "9. Back to develop"
+run git checkout develop
+
+step "Done - $VERSION is released"
+if $DRY_RUN; then echo "  (dry run - nothing changed; re-run with --real-run to do it for real)"; fi
+
+manual_checklist <<NEXT
+  [ ] Create the GitHub release for $VERSION (body = the $VERSION section of CHANGELOG.md):
+        https://github.com/handsontable/hyperformula/releases/new?tag=$VERSION&title=$VERSION
+  [ ] Check that the docs workflow deployed the documentation to gh-pages
+  [ ] Announce the release in #hyperformula and #release
+  [ ] Close the GitHub and ClickUp tasks in this release, announcing $VERSION,
+      notify everyone involved in the discussions, and check linked issues
+  [ ] Review the deployed docs and test the demos
+NEXT
+exit 0
 }
 
 # ============================================================================

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -212,10 +212,14 @@ INFO
 step "1. Get onto release/$VERSION"
 if branch_exists "release/$VERSION"; then
   skip "release/$VERSION exists locally - resuming the freeze"
-  run git checkout "release/$VERSION"
-  if has_upstream "release/$VERSION"; then run git pull --ff-only; fi
+  sync_branch "release/$VERSION"
 elif remote_branch_exists "release/$VERSION"; then
   skip "release/$VERSION exists on origin - resuming the freeze"
+  # remote_branch_exists asks the remote directly, so the local tracking ref may
+  # not exist yet. Fetch the branch before creating a local one from it, or
+  # resuming in a clone that never saw it - another machine, a fresh clone -
+  # fails on 'origin/release/<version>' not being a commit.
+  run git fetch origin "release/$VERSION"
   run git checkout -b "release/$VERSION" "origin/release/$VERSION"
 else
   run git checkout develop
@@ -248,11 +252,10 @@ run rm -rf ./node_modules
 run rm -f package-lock.json
 run npm i
 
-# 5. Build / private test suite / lint / test
-step "5. Build, fetch the private test suite, lint + test"
+# 5. Build / lint / test  (the private test suite was already pointed at this
+#    branch in step 2, and nothing since has changed the branch it follows)
+step "5. Build, lint + test"
 run npm run bundle-all
-# points test/hyperformula-tests at a branch matching release/$VERSION
-run npm run test:setup-private
 run npm run lint
 run npm run test:jest
 

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -57,8 +57,10 @@ skip() { printf '    = %s\n' "$*"; }
 
 # ---- state checks (idempotency) -------------------------------------------
 # These answer "is this already done?" so every step can be re-run safely.
-# They only read state, so they are also correct during a dry run. Each takes
-# an optional repository path, so the same check works on a sibling clone.
+# They only read state, so they are also correct during a dry run.
+# The two branch predicates - and only those two - take an optional repository
+# path, so the same check works on a sibling clone; an empty string counts as
+# omitted and means the current repository.
 branch_exists()        { git -C "${2:-.}" show-ref --verify --quiet "refs/heads/$1"; }
 # Asks for the full ref, so a name cannot match another branch that merely ends
 # with it ('release/3.4.0' would otherwise also match 'old/release/3.4.0').

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -105,6 +105,19 @@ sync_branch() {
   else skip "$1 has no upstream - nothing to pull"; fi
 }
 
+# Merges a release ref into a target branch, unless it is already in there.
+# Uses --no-ff so the release stays visible as a merge commit, matching what
+# 'git flow release finish' produces.
+merge_release_into() { # merge_release_into <target branch> <release ref> <release tip sha>
+  local target="$1" release_ref="$2" release_tip="$3"
+  sync_branch "$target"
+  if is_ancestor "$release_tip" "$target"; then
+    skip "$release_ref already merged into $target"
+  else
+    run git merge --no-ff -m "Merge branch '$release_ref' into $target" "$release_ref"
+  fi
+}
+
 usage_top() {
 cat <<'USAGE'
 release - HyperFormula release automation.
@@ -644,7 +657,41 @@ cat <<INFO
   mode:         $($DRY_RUN && echo 'DRY RUN (preview; pass --real-run to make changes)' || echo 'REAL RUN (making changes)')
 INFO
 
-exit 0
+# 1-2. master gets the release
+step "1. Merge $RELEASE_REF into master"
+merge_release_into master "$RELEASE_REF" "$RELEASE_TIP"
+
+# 3. Tag the release on master (git flow release finish tags here)
+step "2. Tag $VERSION"
+if tag_exists "$VERSION"; then
+  if is_ancestor "refs/tags/$VERSION" master; then
+    skip "tag $VERSION already exists on master's history"
+  else
+    die "tag $VERSION exists but is not in master's history - check it before continuing."
+  fi
+else
+  run git tag -a "$VERSION" -m "$VERSION"
+fi
+
+# 4. develop gets the release too
+step "3. Merge $RELEASE_REF into develop"
+merge_release_into develop "$RELEASE_REF" "$RELEASE_TIP"
+
+# 5. Build what is about to be published, from master
+step "4. Build + verify the package"
+run git checkout master
+if $SKIP_BUILD; then
+  skip "--skip-build: reusing the build on disk (npm ci + bundle-all not run)"
+else
+  run npm ci
+  run npm run bundle-all
+fi
+run npm run verify:publish-package
+
+# 6. Publish the branches and the tag before the package, so the commit that
+#    npm publish ships is already on origin.
+step "5. Push master, develop and tags"
+run git push origin master develop --tags
 }
 
 # ============================================================================

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -51,6 +51,58 @@ changelog_section_body() {
   ' CHANGELOG.md
 }
 
+# Prints a step that needed no work. The '=' marker mirrors 'run's '$' marker,
+# so a log line says at a glance whether a step acted or was already satisfied.
+skip() { printf '    = %s\n' "$*"; }
+
+# ---- state checks (idempotency) -------------------------------------------
+# These answer "is this already done?" so every step can be re-run safely.
+# They only read state, so they are also correct during a dry run. Each takes
+# an optional repository path, so the same check works on a sibling clone.
+branch_exists()        { git -C "${2:-.}" show-ref --verify --quiet "refs/heads/$1"; }
+# Asks for the full ref, so a name cannot match another branch that merely ends
+# with it ('release/3.4.0' would otherwise also match 'old/release/3.4.0').
+remote_branch_exists() { git -C "${2:-.}" ls-remote --heads origin "refs/heads/$1" 2>/dev/null | grep -q .; }
+is_ancestor()          { git merge-base --is-ancestor "$1" "$2" 2>/dev/null; }
+tag_exists()           { git rev-parse -q --verify "refs/tags/$1" >/dev/null; }
+has_upstream()         { git rev-parse --abbrev-ref "$1@{upstream}" >/dev/null 2>&1; }
+# A false answer means "not visible from here", which a registry outage produces
+# too - so callers must not treat it as proof the version is unpublished. npm
+# itself rejects a duplicate publish, and that rejection is the authority.
+on_npm()               { npm view "hyperformula@$1" version >/dev/null 2>&1; }
+
+# Verifies a sibling clone is usable before a release starts: present, a git
+# work tree, clean, carrying the branches this run will move, with a reachable
+# origin. Failing here costs nothing; failing half-way through leaves one of
+# three repositories in a state someone has to untangle by hand.
+require_repo() { # require_repo <label> <path> <flag> <required branch...>
+  local label="$1" dir="$2" flag="$3" branch; shift 3
+  [[ -n "$dir" && -d "$dir" ]] \
+    || die "$label clone not found at '${dir:-<unset>}' - pass $flag PATH."
+  git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    || die "$dir is not a git repository ($label)."
+  [[ -z "$(git -C "$dir" status --porcelain)" ]] \
+    || die "Working tree in $dir ($label) is dirty - commit or stash there first."
+  git -C "$dir" ls-remote --heads origin >/dev/null 2>&1 \
+    || die "Cannot reach origin of $dir ($label)."
+  for branch in "$@"; do
+    branch_exists "$branch" "$dir" || remote_branch_exists "$branch" "$dir" \
+      || die "$label has no '$branch' branch ($dir)."
+  done
+}
+
+# Checks out a branch and fast-forwards it when it tracks a remote branch.
+# Refuses to create a merge: a release must never invent history on develop or
+# master, so a diverged branch is an error the operator has to look at.
+# Precondition: the calling cmd_* function must have declared DRY_RUN - 'run'
+# reads it through dynamic scoping, and without it the script dies under set -u
+# before the ERR trap can name the failing step.
+sync_branch() {
+  run git checkout "$1"
+  if has_upstream "$1"; then run git pull --ff-only
+  else skip "$1 has no upstream - nothing to pull"; fi
+}
+
 usage_top() {
 cat <<'USAGE'
 release - HyperFormula release automation.

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -245,16 +245,22 @@ else
   echo "    package.json version -> $VERSION"
 fi
 
-CURRENT_HT_DATE="$(sed -n "s/.*HT_RELEASE_DATE[[:space:]]*:[[:space:]]*'\([^']*\)'.*/\1/p" ht.config.js 2>/dev/null | head -1)"
+# Read the current date only once the file is known to exist and carry the key:
+# under 'set -Eeuo pipefail' a sed against a missing file fails the assignment
+# and trips the ERR trap, which would kill the run before the guard below could
+# report the problem in its own words.
 if [[ ! -f ht.config.js ]] || ! grep -q HT_RELEASE_DATE ht.config.js; then
   echo "    ! HT_RELEASE_DATE not found in ht.config.js - set it to $DATE_HT manually."
-elif [[ "$CURRENT_HT_DATE" == "$DATE_HT" ]]; then
-  skip "ht.config.js HT_RELEASE_DATE already $DATE_HT"
-elif $DRY_RUN; then
-  echo "    (set ht.config.js HT_RELEASE_DATE='$DATE_HT')"
 else
-  CF_D="$DATE_HT" node -e 'const f="ht.config.js",fs=require("fs");let s=fs.readFileSync(f,"utf8");s=s.replace(/(HT_RELEASE_DATE\s*:\s*)([\x27"])[^\x27"]*\2/,`$1$2${process.env.CF_D}$2`);fs.writeFileSync(f,s)'
-  echo "    ht.config.js HT_RELEASE_DATE -> $DATE_HT"
+  CURRENT_HT_DATE="$(sed -n "s/.*HT_RELEASE_DATE[[:space:]]*:[[:space:]]*'\([^']*\)'.*/\1/p" ht.config.js | head -1 || true)"
+  if [[ "$CURRENT_HT_DATE" == "$DATE_HT" ]]; then
+    skip "ht.config.js HT_RELEASE_DATE already $DATE_HT"
+  elif $DRY_RUN; then
+    echo "    (set ht.config.js HT_RELEASE_DATE='$DATE_HT')"
+  else
+    CF_D="$DATE_HT" node -e 'const f="ht.config.js",fs=require("fs");let s=fs.readFileSync(f,"utf8");s=s.replace(/(HT_RELEASE_DATE\s*:\s*)([\x27"])[^\x27"]*\2/,`$1$2${process.env.CF_D}$2`);fs.writeFileSync(f,s)'
+    echo "    ht.config.js HT_RELEASE_DATE -> $DATE_HT"
+  fi
 fi
 
 # 4. Regenerate the lock file. A lock file already naming the new version is

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -267,9 +267,9 @@ if [[ -z "$PRE_FREEZE_VERSION" ]]; then
 fi
 IFS='.' read -r nM nm _ <<<"$VERSION"
 IFS='.' read -r cM cm _ <<<"${PRE_FREEZE_VERSION:-0.0.0}"
-if   [[ "$nM" != "$cM" ]]; then RELEASE_TYPE=major
-elif [[ "$nm" != "$cm" ]]; then RELEASE_TYPE=minor
-else RELEASE_TYPE=patch; fi
+if   [[ "$nM" != "$cM" ]]; then RELEASE_TYPE='major'
+elif [[ "$nm" != "$cm" ]]; then RELEASE_TYPE='minor'
+else RELEASE_TYPE='patch'; fi
 VERSION_BRANCH="${nM}.${nm}.x"
 
 # default repo locations (run from the hyperformula repo root):

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -179,16 +179,6 @@ git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "Not inside a git rep
 git show-ref --verify --quiet refs/heads/develop || die "No 'develop' branch."
 command -v npm >/dev/null || die "npm not found."
 
-# stop if the release branch already exists (locally or on origin) - do nothing
-if git show-ref --verify --quiet "refs/heads/release/$VERSION" \
-   || git ls-remote --heads origin "release/$VERSION" 2>/dev/null | grep -q .; then
-  echo "release/$VERSION already exists (local or on origin) - nothing to do."
-  echo "If you want to redo the freeze, delete it first:"
-  echo "    git branch -D release/$VERSION"
-  echo "    git push origin --delete release/$VERSION"
-  exit 0
-fi
-
 # ---- derive dates + release type ----
 # ht.config.js wants DD/MM/YYYY; release notes want "Month D, YYYY".
 DATE_HT="$(CF="$DATE_ISO"   node -e 'const[y,m,d]=process.env.CF.split("-");console.log(`${d}/${m}/${y}`)')"
@@ -217,15 +207,25 @@ cat <<INFO
   mode:         $($DRY_RUN && echo 'DRY RUN (preview; pass --real-run to make changes)' || echo 'REAL RUN (making changes)')
 INFO
 
-# 1. Update develop
-step "1. Update develop + the private test suite"
-run git checkout develop
-run git pull
-run npm run test:setup-private
+# 1. Get onto release/$VERSION - creating it off develop the first time, and
+#    resuming an existing one (local or on origin) on a re-run.
+step "1. Get onto release/$VERSION"
+if branch_exists "release/$VERSION"; then
+  skip "release/$VERSION exists locally - resuming the freeze"
+  run git checkout "release/$VERSION"
+  if has_upstream "release/$VERSION"; then run git pull --ff-only; fi
+elif remote_branch_exists "release/$VERSION"; then
+  skip "release/$VERSION exists on origin - resuming the freeze"
+  run git checkout -b "release/$VERSION" "origin/release/$VERSION"
+else
+  run git checkout develop
+  run git pull
+  run git checkout -b "release/$VERSION" develop
+fi
 
-# 2. Start release branch  (git flow release start = branch off develop)
-step "2. Create release/$VERSION"
-run git checkout -b "release/$VERSION" develop
+# 2. Private test suite (fetch-tests.sh follows the current branch name)
+step "2. Sync the private test suite"
+run npm run test:setup-private
 
 # 3. Bump version + release date
 step "3. Bump version + HT_RELEASE_DATE"

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -35,9 +35,15 @@ preview() { printf '%s\n%s\n%s\n' "$PREVIEW_FENCE" "$1" "$PREVIEW_FENCE"; }
 
 # Prints the list of steps read from stdin in a highlighted box, so that what
 # the script leaves for the operator to do by hand cannot be missed in the log.
+# Whatever the run recorded - what it could not do, then what is worth checking -
+# goes in the same box above the standing steps, because it is the more urgent
+# part of the same list. Printed here rather than substituted into the callers'
+# here-docs, where '$(...)' would strip the blank lines that separate the parts.
 manual_checklist() {
-  printf '\n%s%s\n  WHAT IS LEFT FOR YOU TO DO BY HAND\n%s\n\n%s\n\n%s%s\n' \
-    "$HIGHLIGHT" "$CHECKLIST_RULE" "$CHECKLIST_RULE" "$(cat)" "$CHECKLIST_RULE" "$RESET"
+  printf '\n%s%s\n  WHAT IS LEFT FOR YOU TO DO BY HAND\n%s\n\n' \
+    "$HIGHLIGHT" "$CHECKLIST_RULE" "$CHECKLIST_RULE"
+  recorded_warnings
+  printf '%s\n\n%s%s\n' "$(cat)" "$CHECKLIST_RULE" "$RESET"
 }
 
 # Prints the body of a CHANGELOG.md section: every line between the given
@@ -54,6 +60,70 @@ changelog_section_body() {
 # Prints a step that needed no work. The '=' marker mirrors 'run's '$' marker,
 # so a log line says at a glance whether a step acted or was already satisfied.
 skip() { printf '    = %s\n' "$*"; }
+
+# ---- the warning register --------------------------------------------------
+# Re-prints in the closing checklist anything the run needs the operator to act
+# on. A lone marker line cannot carry that weight on its own: it scrolls by in
+# the middle of a full 'npm i', build and test log, and the run then ends by
+# announcing success.
+# Two registers, because two different things get recorded and only one of them
+# means the run did not do its job:
+#   warn - a soft FAILURE: something the run was asked to do, could not do, and
+#          carried on past. These change the closing banner.
+#   note - an ADVISORY: the run did its job, but something is worth a look.
+#          These are listed but do not change the banner, so that an ordinary
+#          resume does not announce itself as a failure.
+# Backed by files rather than variables so that a recording site inside a
+# '( cd <clone> )' subshell or inside the node here-doc in step 7 can append
+# too - neither can assign to a variable in this shell.
+FAILURES_FILE=""
+NOTES_FILE=""
+
+# Both end in 'return 0': recording is never itself a failure, and without it
+# the '[[ ]]' guard would trip errexit whenever the register is not open.
+warn() { # warn <message>
+  printf '    ! %s\n' "$*"
+  [[ -n "$FAILURES_FILE" ]] && printf '%s\n' "$*" >>"$FAILURES_FILE"
+  return 0
+}
+note() { # note <message>
+  printf '    i %s\n' "$*"
+  [[ -n "$NOTES_FILE" ]] && printf '%s\n' "$*" >>"$NOTES_FILE"
+  return 0
+}
+
+# Opens both registers and exports them, so subshells and node can append too.
+# Called once per command, before the first step.
+start_warning_register() {
+  FAILURES_FILE="$(mktemp)"
+  NOTES_FILE="$(mktemp)"
+  export FAILURES_FILE NOTES_FILE
+  trap 'rm -f "$FAILURES_FILE" "$NOTES_FILE"' EXIT
+}
+
+# Counts soft failures only - advisories must not make a good run look bad.
+warning_count() {
+  [[ -n "$FAILURES_FILE" && -f "$FAILURES_FILE" ]] || { printf '0'; return 0; }
+  awk 'END{printf "%d", NR}' "$FAILURES_FILE"
+}
+
+# Renders one register as checklist items under its heading, or nothing when it
+# is empty. Duplicates are dropped, first occurrence winning, because the same
+# condition can be reported by a preflight check and again by the step that
+# hits it.
+recorded_section() { # recorded_section <file> <heading>
+  [[ -n "$1" && -s "$1" ]] || return 0
+  printf '  %s\n' "$2"
+  awk '!seen[$0]++' "$1" | sed 's/^/  [ ] /'
+  printf '\n'
+}
+
+# Called by 'manual_checklist', so what the run could not do, what is worth
+# checking, and the standing manual steps all land in the same highlighted box.
+recorded_warnings() {
+  recorded_section "$FAILURES_FILE" 'THE SCRIPT COULD NOT DO THESE - they are still yours to do:'
+  recorded_section "$NOTES_FILE"    'WORTH CHECKING:'
+}
 
 # ---- state checks (idempotency) -------------------------------------------
 # These answer "is this already done?" so every step can be re-run safely.
@@ -80,10 +150,10 @@ on_npm()               { npm view "hyperformula@$1" version >/dev/null 2>&1; }
 # Reports the first problem it finds and returns 1 - it does not die itself, so
 # a caller checking both sibling clones can report both in one run rather than
 # stopping at whichever is checked first.
-require_repo() { # require_repo <label> <path> <flag> <required branch...>
-  local label="$1" dir="$2" flag="$3" branch; shift 3
+require_repo() { # require_repo <label> <path> <remedy> <required branch...>
+  local label="$1" dir="$2" remedy="$3" branch; shift 3
   [[ -n "$dir" && -d "$dir" ]] \
-    || { printf 'ERROR: %s\n' "$label clone not found at '${dir:-<unset>}' - pass $flag PATH." >&2; return 1; }
+    || { printf 'ERROR: %s\n' "$label clone not found at '${dir:-<unset>}' - $remedy." >&2; return 1; }
   git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
     || { printf 'ERROR: %s\n' "$dir is not a git repository ($label)." >&2; return 1; }
   [[ -z "$(git -C "$dir" status --porcelain)" ]] \
@@ -96,6 +166,17 @@ require_repo() { # require_repo <label> <path> <flag> <required branch...>
   done
 }
 
+# A sibling clone must also carry the script this run will execute inside it.
+# Checked in the preflight, next to require_repo, because the alternative is
+# finding out when the run is already half-way through three repositories - and
+# in 'publish' the demos script runs after the npm publish that cannot be undone.
+# Reports and returns 1 rather than dying, so it composes with require_repo's
+# report-everything-then-stop pattern.
+require_script() { # require_script <label> <path> <script>
+  [[ -f "$2/$3" ]] \
+    || { printf 'ERROR: %s\n' "$2 ($1) has no $3 - is that the right clone?" >&2; return 1; }
+}
+
 # Checks out a branch and fast-forwards it when it tracks a remote branch.
 # Refuses to create a merge: a release must never invent history on develop or
 # master, so a diverged branch is an error the operator has to look at.
@@ -104,8 +185,117 @@ require_repo() { # require_repo <label> <path> <flag> <required branch...>
 # before the ERR trap can name the failing step.
 sync_branch() {
   run git checkout "$1"
-  if has_upstream "$1"; then run git pull --ff-only
-  else skip "$1 has no upstream - nothing to pull"; fi
+  if has_upstream "$1"; then
+    run git pull --ff-only
+  elif remote_branch_exists "$1"; then
+    # No upstream is not the same as nothing to pull. A branch created with a
+    # plain 'git checkout -b' - which is how this script and 'git flow' both
+    # make them - has no upstream, so 'git pull' has nothing to work from even
+    # though origin may well have moved. Reconcile against origin's copy
+    # explicitly instead of declaring the local branch authoritative: otherwise a
+    # colleague's commit on a shared branch is silently ignored here and
+    # surfaces as a raw non-fast-forward rejection at the next push.
+    run git merge --ff-only "origin/$1"
+  else
+    skip "$1 is not on origin yet - nothing to pull"
+  fi
+}
+
+# Gets onto a branch wherever it currently lives, and leaves it up to date:
+# prefers the local branch (fast-forwarded, never merged), else creates it from
+# origin's, else creates it from <base>. This replaced four hand-written copies
+# of the same decision that had each drifted - one fast-forwarded an existing
+# local branch and one pushed it stale, one fetched the branch first and one
+# trusted a possibly cold remote-tracking ref, one pulled its base --ff-only and
+# one pulled it plain. Every call site now gets the strictest of those.
+#
+# Fetching up front is what makes "does origin have it?" and "is my local copy
+# behind?" answerable at all, so it always runs - safe in a dry run for the same
+# reason publish's preflight fetch is: it writes remote-tracking refs, never the
+# working tree. Marked "(always runs)" because elsewhere a '$' line means "only
+# with --real-run".
+#
+# <base> is required: every caller is a step whose job includes creating the
+# branch if it is not there yet. Where a branch is a PREREQUISITE rather than
+# something to create - publish's release branches - use resolve_branch below,
+# which refuses instead of improvising.
+#
+# Acts on the current repository, so a sibling clone is reached with
+# '( cd <clone> ... )'. Does not push - the call sites differ on that.
+# Precondition: DRY_RUN must be in scope, as for sync_branch.
+checkout_branch() { # checkout_branch <branch> <base>
+  local branch="$1" base="$2"
+  printf '    $ git fetch origin   (always runs)\n'
+  git fetch origin >/dev/null 2>&1 || die "Cannot reach origin from $(pwd)."
+  if branch_exists "$branch"; then
+    skip "$branch already exists here"
+    sync_branch "$branch"
+  elif remote_branch_exists "$branch"; then
+    skip "$branch exists on origin - taking it from there"
+    run git checkout -b "$branch" "origin/$branch"
+  else
+    sync_branch "$base"
+    run git checkout -b "$branch" "$base"
+  fi
+}
+
+# Names the ref a release should be read from - the local branch when there is
+# one, otherwise origin's - and pins the commit it points at, without moving
+# HEAD. Publish's preflight needs exactly that and so cannot use
+# checkout_branch: it has to decide what it will merge, and prove it is the
+# right thing, before anything moves. Pinning matters because sync_branch's pull
+# later refreshes every remote-tracking ref, so the ref could come to name a
+# newer commit than the one this preflight checked and reported.
+# A local branch that disagrees with origin's is fatal rather than a silent
+# choice: someone may have pushed a late fix to the freeze branch, and
+# publishing the local tip would drop it.
+# Sets RESOLVED_REF and RESOLVED_TIP, and dies with <remedy> on a missing
+# branch - so call it directly, never inside a substitution, where 'die' would
+# only exit the subshell.
+resolve_branch() { # resolve_branch <branch> <repo dir> <remedy for a missing branch>
+  local branch="$1" dir="$2" remedy="$3" local_tip origin_tip reconcile where
+  # '.' is this repository. Name it that way in both the prose and the suggested
+  # command, rather than telling the operator something is wrong "in .".
+  if [[ "$dir" == "." ]]; then
+    where="this repo"
+    reconcile="git checkout $branch && git pull --ff-only"
+  else
+    where="$dir"
+    reconcile="git -C $dir checkout $branch && git -C $dir pull --ff-only"
+  fi
+  if branch_exists "$branch" "$dir"; then
+    RESOLVED_REF="$branch"
+    if remote_branch_exists "$branch" "$dir"; then
+      local_tip="$(git -C "$dir" rev-parse "$branch")"
+      origin_tip="$(git -C "$dir" rev-parse "origin/$branch" 2>/dev/null || true)"
+      [[ -n "$origin_tip" && "$local_tip" == "$origin_tip" ]] \
+        || die "Local $branch in $where ($local_tip) differs from origin (${origin_tip:-missing}) - reconcile them first: $reconcile"
+    fi
+  elif remote_branch_exists "$branch" "$dir"; then
+    RESOLVED_REF="origin/$branch"
+  else
+    die "No $branch branch in $where, local or on origin - $remedy."
+  fi
+  RESOLVED_TIP="$(git -C "$dir" rev-parse "$RESOLVED_REF")"
+}
+
+# Carries the demos clone's develop onto its M.m.x version branch and publishes
+# it. Both commands finish their demos step this way - the freeze after setting
+# the version, publish after refreshing the lock files - so the fast-forward and
+# the merge guard live here once instead of in two copies that can drift.
+# On a fresh minor the branch has just been created from develop, so the merge is
+# already an ancestor and skips; on a re-run, or a branch that existed
+# beforehand, this is what gets develop's commit onto it.
+# Precondition: called from inside '( cd <demos clone> )', with DRY_RUN in scope.
+merge_develop_into_version_branch() { # merge_develop_into_version_branch <M.m.x>
+  local version_branch="$1"
+  checkout_branch "$version_branch" develop
+  if is_ancestor develop "$version_branch"; then
+    skip "develop already merged into $version_branch"
+  else
+    run git merge --no-ff -m "Merge branch 'develop' into $version_branch" develop
+  fi
+  run git push -u origin "$version_branch"
 }
 
 # Merges a release ref into a target branch, unless it is already in there.
@@ -179,13 +369,15 @@ Usage: release.sh code-freeze <version> <release-date> [options]
 Starts a HyperFormula code freeze. Previews by default (prints commands,
 changes nothing); add --real-run to make changes.
 
-Requires usable hyperformula-tests and hyperformula-demos clones (present,
-clean, with a reachable origin) - it exits early otherwise.
+Requires usable hyperformula-tests (test/hyperformula-tests) and
+hyperformula-demos clones - present, clean, with a reachable origin - and a clean
+working tree here unless it is resuming a freeze this clone already started.
+It exits early otherwise.
 
 Options:
   --real-run         Actually run the commands (default is a dry-run preview).
+  --dry-run          Preview only. The default; useful to override an alias.
   --demos-dir PATH   hyperformula-demos clone (default: ../hyperformula-demos).
-  --tests-dir PATH   hyperformula-tests clone (default: test/hyperformula-tests).
 
 Examples:
   release.sh code-freeze 2.1.0 2026-08-30              # preview (dry run)
@@ -208,11 +400,11 @@ done, so a failed run is recovered by running the same command again.
 
 Options:
   --real-run         Actually run the commands (default is a dry-run preview).
+  --dry-run          Preview only. The default; useful to override an alias.
   --skip-build       Skip 'npm ci' + 'npm run bundle-all' (the on-disk build is
                      assumed to match the release commit). The package check
                      still runs. Meant for a fast resume after a late failure.
   --demos-dir PATH   hyperformula-demos clone (default: ../hyperformula-demos).
-  --tests-dir PATH   hyperformula-tests clone (default: test/hyperformula-tests).
 
 Examples:
   release.sh publish 2.1.0                          # preview (dry run)
@@ -225,7 +417,8 @@ USAGE
 # Command: code-freeze
 # ============================================================================
 cmd_code_freeze() {
-local DRY_RUN=true DEMOS_DIR="" TESTS_DIR="" VERSION="" DATE_ISO=""
+local DRY_RUN=true DEMOS_DIR="" VERSION="" DATE_ISO=""
+start_warning_register
 
 # ---- args ----
 while [[ $# -gt 0 ]]; do
@@ -233,7 +426,6 @@ while [[ $# -gt 0 ]]; do
     --real-run)     DRY_RUN=false ;;
     --dry-run)      DRY_RUN=true ;;
     --demos-dir)    [[ $# -ge 2 ]] || die "Missing value for $1"; DEMOS_DIR="$2"; shift ;;
-    --tests-dir)    [[ $# -ge 2 ]] || die "Missing value for $1"; TESTS_DIR="$2"; shift ;;
     -h|--help)      usage_code_freeze; exit 0 ;;
     -*)             die "Unknown option: $1" ;;
     *) if   [[ -z "$VERSION"  ]]; then VERSION="$1"
@@ -243,33 +435,74 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-[[ -n "$VERSION"  ]] || read -r -p "New version (e.g. 2.1.0): " VERSION
-[[ -n "$DATE_ISO" ]] || read -r -p "Release date (YYYY-MM-DD): " DATE_ISO
+# Name the no-terminal case rather than letting the ERR trap report a generic
+# "startup" failure, the way confirm_publish does for its prompt.
+[[ -n "$VERSION"  ]] || read -r -p "New version (e.g. 2.1.0): " VERSION \
+  || die "no version given and no terminal to ask on."
+[[ -n "$DATE_ISO" ]] || read -r -p "Release date (YYYY-MM-DD): " DATE_ISO \
+  || die "no release date given and no terminal to ask on."
 [[ "$VERSION"  =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || die "Bad version: $VERSION"
 [[ "$DATE_ISO" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || die "Bad date (want YYYY-MM-DD): $DATE_ISO"
 
-# ---- sanity checks ----
+# The private test suite always lives here: test/fetch-tests.sh and the CI
+# workflows all hardcode this path, so there is nothing to configure and no way
+# for the freeze to end up validating one clone and mutating another.
+TESTS_DIR="test/hyperformula-tests"
+
+# ---- preflight ----
+# Named, as in publish, so a failure in any of the checks below is reported
+# against a step instead of against "startup".
+step "Preflight"
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "Not inside a git repo."
 [[ -f package.json ]] || die "No package.json here - run from the hyperformula repo root."
 branch_exists develop || die "No 'develop' branch."
-command -v npm >/dev/null || die "npm not found."
+# node runs the version, date and release-notes edits; perl rewrites the demo
+# URLs. Both are checked here rather than at first use, where a missing one
+# would surface as an unnamed failure part-way through the freeze.
+for tool in npm node perl; do
+  command -v "$tool" >/dev/null || die "$tool not found."
+done
+# Fetch once, up front, so every check below is answered against fresh refs
+# rather than whatever this clone last saw: the tag guard needs it (a tag someone
+# else pushed is invisible until it is fetched, which is exactly the case the
+# guard exists for), the resume detection needs it, and the release type is
+# classified against origin's develop. '--tags' for the same reason as publish's
+# preflight fetch. Same reasoning, and the same "(always runs)" marker, as that
+# one: it writes refs, never the working tree, so it is safe in a preview.
+printf '    $ git fetch origin --tags   (always runs)\n'
+git fetch origin --tags >/dev/null 2>&1 || die "git fetch origin failed."
+
+# A version that is already tagged has been released. Starting a freeze for it
+# is a typo, not an intention, and it would collide at 'publish' at the latest.
+tag_exists "$VERSION" && die "Tag $VERSION already exists - $VERSION is released. Did you mean a different version?"
 
 # ---- derive dates + release type ----
-# ht.config.js wants DD/MM/YYYY; release notes want "Month D, YYYY".
-DATE_HT="$(CF="$DATE_ISO"   node -e 'const[y,m,d]=process.env.CF.split("-");console.log(`${d}/${m}/${y}`)')"
-DATE_LONG="$(CF="$DATE_ISO" node -e 'console.log(new Date(process.env.CF+"T00:00:00").toLocaleString("en-US",{month:"long",day:"numeric",year:"numeric"}))')"
+# ht.config.js wants DD/MM/YYYY; release notes want "Month D, YYYY". node also
+# rejects a well-formed date that does not exist: 2026-02-30 used to pass the
+# regex above and then reach ht.config.js verbatim as 30/02/2026 while the
+# release notes silently said March 2 and the changelog said 2026-02-30.
+DATE_LONG="$(CF="$DATE_ISO" node -e '
+  const iso = process.env.CF, d = new Date(iso + "T00:00:00Z");
+  if (isNaN(d.getTime()) || d.toISOString().slice(0, 10) !== iso) process.exit(1);
+  process.stdout.write(d.toLocaleString("en-US", { month: "long", day: "numeric", year: "numeric", timeZone: "UTC" }));
+')" || die "No such date: $DATE_ISO."
+DATE_HT="$(CF="$DATE_ISO" node -e 'const[y,m,d]=process.env.CF.split("-");console.log(`${d}/${m}/${y}`)')"
 
-# Read the pre-release version from develop rather than the working tree: on a
-# resumed freeze the tree already carries the bump, which would read as a patch
-# release and silently skip step 8's demos and CodeSandbox work. develop holds
-# the old version until 'publish' merges the release back. Falls back to the
-# tree if develop cannot be read, so an unusual checkout still gets an answer.
-PRE_FREEZE_VERSION="$(git show develop:package.json 2>/dev/null \
-  | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(JSON.parse(s).version||"")}catch(e){}})' 2>/dev/null || true)"
+# Read the pre-release version from origin's develop rather than the working
+# tree: on a resumed freeze the tree already carries the bump, which would read
+# as a patch release and silently skip step 8's demos and CodeSandbox work.
+# develop holds the old version until 'publish' merges the release back, and
+# origin's copy of it is the one that cannot be stale. Falls back to the local
+# develop and then to the tree, so an unusual checkout still gets an answer.
+PRE_FREEZE_VERSION=""
+for ref in origin/develop develop; do
+  PRE_FREEZE_VERSION="$(git show "$ref:package.json" 2>/dev/null \
+    | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(JSON.parse(s).version||"")}catch(e){}})' 2>/dev/null || true)"
+  [[ -n "$PRE_FREEZE_VERSION" ]] && break
+done
 if [[ -z "$PRE_FREEZE_VERSION" ]]; then
   PRE_FREEZE_VERSION="$(node -e 'process.stdout.write(require("./package.json").version||"")' 2>/dev/null || true)"
-  echo "    ! could not read develop's package.json - classifying the release against the checked-out"
-  echo "      version (${PRE_FREEZE_VERSION:-unknown}), which on a resumed freeze can read a minor release as a patch."
+  warn "Could not read develop's package.json, so the release was classified against the checked-out version (${PRE_FREEZE_VERSION:-unknown}) - on a resumed freeze that reads a minor release as a patch and skips the demos and CodeSandbox work. Check whether step 8 should have run."
 fi
 IFS='.' read -r nM nm _ <<<"$VERSION"
 IFS='.' read -r cM cm _ <<<"${PRE_FREEZE_VERSION:-0.0.0}"
@@ -278,11 +511,10 @@ elif [[ "$nm" != "$cm" ]]; then RELEASE_TYPE='minor'
 else RELEASE_TYPE='patch'; fi
 VERSION_BRANCH="${nM}.${nm}.x"
 
-# default repo locations (run from the hyperformula repo root):
-#   demos: sibling ../hyperformula-demos      tests: ./test/hyperformula-tests
+# default demos location (run from the hyperformula repo root): the sibling
+# ../hyperformula-demos. The tests clone is not configurable - see TESTS_DIR.
 PARENT="$(dirname "$PWD")"
-[[ -z "$DEMOS_DIR" && -d "$PARENT/hyperformula-demos"   ]] && DEMOS_DIR="$PARENT/hyperformula-demos"
-[[ -z "$TESTS_DIR" && -d "$PWD/test/hyperformula-tests" ]] && TESTS_DIR="$PWD/test/hyperformula-tests"
+[[ -z "$DEMOS_DIR" && -d "$PARENT/hyperformula-demos" ]] && DEMOS_DIR="$PARENT/hyperformula-demos"
 
 # Both sibling repositories are part of a freeze, so verify them before doing
 # anything: a freeze that half-runs across three repositories is worse than one
@@ -291,9 +523,43 @@ PARENT="$(dirname "$PWD")"
 # Both run unconditionally so a run missing both clones reports both, instead
 # of stopping at whichever is checked first and hiding the second problem.
 SIBLINGS_OK=true
-require_repo hyperformula-tests "$TESTS_DIR" --tests-dir develop || SIBLINGS_OK=false
-require_repo hyperformula-demos "$DEMOS_DIR" --demos-dir develop || SIBLINGS_OK=false
+require_repo hyperformula-tests "$TESTS_DIR" "run 'npm run test:setup-private' first" develop || SIBLINGS_OK=false
+if require_repo hyperformula-demos "$DEMOS_DIR" "pass --demos-dir PATH" develop; then
+  require_script hyperformula-demos "$DEMOS_DIR" set-hyperformula-version.sh || SIBLINGS_OK=false
+else
+  SIBLINGS_OK=false
+fi
 $SIBLINGS_OK || die "Fix the sibling clone problem(s) reported above before continuing."
+
+# A dirty tree is fatal to a fresh REAL freeze, exactly as in 'publish': step 4
+# deletes the lock file outright, and step 9 stages whole paths, so the
+# operator's unrelated work would be destroyed or committed as the release.
+# Checked here, AFTER the sibling-clone checks, so a run that is both dirty and
+# missing a clone reports the clone problem too instead of stopping at the dirty
+# tree - matching the preflight order in release-README.md (sibling clones, then
+# clean tree).
+# Two things stop short of fatal:
+#   - A dry run changes nothing, so it can preview perfectly well from a dirty
+#     tree. Refusing would deny the operator the preview that would tell them
+#     what the freeze is about to stage.
+#   - A freeze already under way IN THIS CLONE, where the dirty tree is the
+#     freeze's own unfinished work and refusing would break the resume this
+#     script promises. The test is deliberately the LOCAL branch only: steps 3
+#     and up are what dirty the tree and step 1 creates the branch before them,
+#     so dirt from this freeze always comes with a local branch. A branch that
+#     exists only on origin means another clone ran the freeze, and this tree's
+#     changes are the operator's own - the case the check exists to catch.
+# Both are advisories, not soft failures: the run does everything it set out to
+# do, so they must not make it report otherwise.
+if [[ -n "$(git status --porcelain)" ]]; then
+  if branch_exists "release/$VERSION"; then
+    note "The working tree was already dirty when this resume started, and the freeze stages whole paths - so check 'git show release/$VERSION' for anything of yours that rode along from package.json, CHANGELOG.md, ht.config.js, package-lock.json or docs/."
+  elif $DRY_RUN; then
+    note "The working tree is dirty. This preview is unaffected, but a --real-run would refuse to start: commit or stash first, or the freeze would stage your work along with its own."
+  else
+    die "Working tree is dirty - commit or stash first (the freeze commits whole paths, so your work would ride along)."
+  fi
+fi
 
 step "Plan"
 cat <<INFO
@@ -307,26 +573,21 @@ INFO
 # 1. Get onto release/$VERSION - creating it off develop the first time, and
 #    resuming an existing one (local or on origin) on a re-run.
 step "1. Get onto release/$VERSION"
-if branch_exists "release/$VERSION"; then
-  skip "release/$VERSION exists locally - resuming the freeze"
-  sync_branch "release/$VERSION"
-elif remote_branch_exists "release/$VERSION"; then
-  skip "release/$VERSION exists on origin - resuming the freeze"
-  # remote_branch_exists asks the remote directly, so the local tracking ref may
-  # not exist yet. Fetch the branch before creating a local one from it. Without
-  # this, resuming in a clone that has not fetched since the branch was pushed -
-  # a colleague's machine, a single-branch or shallow checkout - fails on
-  # 'origin/release/<version>' not being a commit.
-  run git fetch origin "release/$VERSION"
-  run git checkout -b "release/$VERSION" "origin/release/$VERSION"
-else
-  run git checkout develop
-  run git pull
-  run git checkout -b "release/$VERSION" develop
-fi
+checkout_branch "release/$VERSION" develop
 
-# 2. Private test suite (fetch-tests.sh follows the current branch name)
-step "2. Sync the private test suite"
+# 2. Private test suite. The branch has to exist on the tests repo's origin
+#    before fetch-tests.sh runs, because fetch-tests.sh pulls the matching
+#    branch from origin - so a branch an earlier attempt created locally but
+#    never pushed made 'git pull origin release/<version>' fail and blocked
+#    every resume. Creating and pushing it here instead of at the end of the
+#    freeze fixes that, and publishes the branch for CI and for the other
+#    developers who add tests during the freeze that much sooner. ('publish'
+#    merges it back. The process doc still describes the older
+#    'checkout master && pull origin develop' - see release-README.md.)
+step "2. Create release/$VERSION in hyperformula-tests, then sync the suite"
+( cd "$TESTS_DIR"
+  checkout_branch "release/$VERSION" develop
+  run git push -u origin "release/$VERSION" )
 run npm run test:setup-private
 
 # 3. Bump version + release date (each half skipped when already correct, so a
@@ -346,8 +607,10 @@ fi
 # under 'set -Eeuo pipefail' a sed against a missing file fails the assignment
 # and trips the ERR trap, which would kill the run before the guard below could
 # report the problem in its own words.
-if [[ ! -f ht.config.js ]] || ! grep -q HT_RELEASE_DATE ht.config.js; then
-  echo "    ! HT_RELEASE_DATE not found in ht.config.js - set it to $DATE_HT manually."
+if [[ ! -f ht.config.js ]]; then
+  warn "There is no ht.config.js, so the release date was not set anywhere - if the file was moved, set the release date to $DATE_HT in its new home and commit it on release/$VERSION."
+elif ! grep -q HT_RELEASE_DATE ht.config.js; then
+  warn "ht.config.js has no HT_RELEASE_DATE key, so the release date was not set - add HT_RELEASE_DATE: '$DATE_HT' and commit it on release/$VERSION."
 else
   # Accept either quote style, matching the write below: a double-quoted value
   # the read could not see would defeat the skip this step exists to add.
@@ -356,9 +619,14 @@ else
     skip "ht.config.js HT_RELEASE_DATE already $DATE_HT"
   elif $DRY_RUN; then
     echo "    (set ht.config.js HT_RELEASE_DATE='$DATE_HT')"
-  else
-    CF_D="$DATE_HT" node -e 'const f="ht.config.js",fs=require("fs");let s=fs.readFileSync(f,"utf8");s=s.replace(/(HT_RELEASE_DATE\s*:\s*)([\x27"])[^\x27"]*\2/,`$1$2${process.env.CF_D}$2`);fs.writeFileSync(f,s)'
+  elif CF_D="$DATE_HT" node -e 'const f="ht.config.js",fs=require("fs");const s=fs.readFileSync(f,"utf8");const n=s.replace(/(HT_RELEASE_DATE\s*:\s*)([\x27"])[^\x27"]*\2/,`$1$2${process.env.CF_D}$2`);if(n===s)process.exit(1);fs.writeFileSync(f,n)'; then
     echo "    ht.config.js HT_RELEASE_DATE -> $DATE_HT"
+  else
+    # The replace above matched nothing - the value is not a plain quoted string
+    # (a template literal, an extracted constant, a quoted key). The key was
+    # there, so the earlier grep passed; without this branch the file would be
+    # rewritten unchanged and the '-> DATE' success line would still print.
+    warn "ht.config.js HT_RELEASE_DATE is not a plain quoted string, so the release date was not set - set it to $DATE_HT by hand and commit it on release/$VERSION."
   fi
 fi
 
@@ -388,17 +656,22 @@ run npm run test:jest
 # 6. CHANGELOG.md - add version heading under [Unreleased]
 step "6. Update CHANGELOG.md"
 if [[ ! -f CHANGELOG.md ]] || ! grep -q '^## \[Unreleased\]' CHANGELOG.md; then
-  echo "    ! Couldn't find '## [Unreleased]' - add the $VERSION entry manually."
-elif grep -q "^## \[$VERSION\]" CHANGELOG.md; then
+  warn "Could not find '## [Unreleased]' in CHANGELOG.md, so there is no $VERSION section - add it by hand and commit it on release/$VERSION (the release notes and the GitHub release both come from it)."
+elif grep -q "^## \[${VERSION//./\\.}\]" CHANGELOG.md; then
   skip "already has an entry for $VERSION"
 elif $DRY_RUN; then
   echo "    (insert '## [$VERSION] - $DATE_ISO' under [Unreleased] - the new section will read:)"
   preview "$(printf '## [%s] - %s\n\n%s' "$VERSION" "$DATE_ISO" "$(changelog_section_body '## [Unreleased]')")"
 else
-  tmp="$(mktemp)"
+  # Transform through a temp, then copy the bytes back into CHANGELOG.md rather
+  # than 'mv'-ing the temp over it: mv replaces the inode, so the file would
+  # inherit mktemp's 0600 instead of keeping its own mode.
+  local tmp; tmp="$(mktemp)"
   awk -v v="## [$VERSION] - $DATE_ISO" '
     {print}
-    /^## \[Unreleased\]/ && !d {print ""; print v; d=1}' CHANGELOG.md >"$tmp" && mv "$tmp" CHANGELOG.md
+    /^## \[Unreleased\]/ && !d {print ""; print v; d=1}' CHANGELOG.md >"$tmp"
+  cat "$tmp" > CHANGELOG.md
+  rm -f "$tmp"
   echo "    inserted '## [$VERSION] - $DATE_ISO'"
 fi
 
@@ -407,81 +680,109 @@ fi
 step "7. Generate release notes"
 RN="docs/guide/release-notes.md"
 if [[ ! -f CHANGELOG.md || ! -f "$RN" ]]; then
-  echo "    ! CHANGELOG.md or $RN missing - skipping."
+  warn "CHANGELOG.md or $RN is missing, so no release notes were generated - write the $VERSION entry by hand and commit it on release/$VERSION."
 else
+  # Extract the changelog body with the SAME helper step 6's preview uses, then
+  # hand it to node - so CHANGELOG.md is parsed in one place, not two. In a dry
+  # run step 6 has not inserted the version heading yet, so the bullets are still
+  # under [Unreleased]; on a real run they are under the new '## [VERSION]'.
+  if $DRY_RUN; then
+    RN_HEADING='## [Unreleased]'; RN_PATTERN='^## \[Unreleased\]'
+  else
+    RN_HEADING="## [$VERSION]"; RN_PATTERN="^## \[${VERSION//./\\.}\]"
+  fi
+  grep -q "$RN_PATTERN" CHANGELOG.md && RN_FOUND=1 || RN_FOUND=0
   CF_V="$VERSION" CF_LONG="$DATE_LONG" CF_RN="$RN" CF_FENCE="$PREVIEW_FENCE" \
+  CF_FOUND="$RN_FOUND" CF_BODY="$(changelog_section_body "$RN_HEADING")" \
   CF_DRY="$($DRY_RUN && echo 1 || echo '')" node <<'NODE'
 const fs = require('fs');
 const v = process.env.CF_V, long = process.env.CF_LONG, rnPath = process.env.CF_RN;
 const dryRun = process.env.CF_DRY === '1';
 const esc = v.replace(/\./g, '\\.');
 
-// pull this version's block out of the changelog
-const cl = fs.readFileSync('CHANGELOG.md', 'utf8').split('\n');
-let start = cl.findIndex(l => new RegExp('^## \\[' + esc + '\\]').test(l));
-// in a dry run step 6 has not inserted the version heading yet, so the bullets
-// that will end up under it are still the ones under [Unreleased]
-if (start === -1 && dryRun) start = cl.findIndex(l => /^## \[Unreleased\]/.test(l));
-if (start === -1) { console.log('    ! no changelog entry for ' + v + ' - skipping'); process.exit(0); }
-let end = cl.findIndex((l, i) => i > start && /^## \[/.test(l));
-if (end === -1) end = cl.length;
-const body = cl.slice(start + 1, end).join('\n').replace(/^\n+/, '').replace(/\n+$/, '');
+// Same register the shell's 'warn' writes to, so a soft failure raised in here
+// reaches the closing checklist too rather than scrolling past as one '!' line.
+const warningsFile = process.env.FAILURES_FILE || '';
+function warn(message) {
+  console.log('    ! ' + message);
+  if (warningsFile) {
+    try { fs.appendFileSync(warningsFile, message + '\n'); } catch (e) { /* the log line still stands */ }
+  }
+}
+
+// The changelog body was extracted in the shell (changelog_section_body) and
+// passed in through the environment, so this step no longer re-parses the file.
+const found = process.env.CF_FOUND === '1';
+const body = process.env.CF_BODY || '';
+if (!found) {
+  warn('CHANGELOG.md has no ' + v + ' section, so no release notes were generated - write both by hand and commit them on release/' + v + '.');
+  process.exit(0);
+}
 
 const rnLines = fs.readFileSync(rnPath, 'utf8').split('\n');
 if (rnLines.some(l => new RegExp('^## ' + esc + '\\s*$').test(l))) {
   console.log('    = release notes already has ' + v); process.exit(0);
 }
-const entry = '## ' + v + '\n\n**Release date: ' + long + '**\n\n' + body + '\n';
+// An entry with no bullets is a real failure to report, not a footnote on a
+// success line: the release notes would ship a version heading and a date with
+// nothing under them. Raised in both modes, with the same wording, so the dry
+// run warns about it before the real run writes it.
+if (!body) {
+  warn('The [Unreleased] section of CHANGELOG.md is empty, so the ' + v + ' release notes have a heading and a date but no content - fill both in by hand and commit them on release/' + v + '.');
+}
+// Trailing newlines trimmed here, not at the seams below: with an empty body
+// the entry would otherwise end in its own blank line and the seam would add a
+// second, writing three consecutive blank lines into the file.
+const entry = ('## ' + v + '\n\n**Release date: ' + long + '**\n\n' + body).replace(/\s+$/, '');
 if (dryRun) {
-  console.log('    (add to the top of ' + rnPath + ':)' +
-              (body ? '' : '  ! no bullets - [Unreleased] is empty'));
-  console.log(process.env.CF_FENCE + '\n' + entry.replace(/\n+$/, '') + '\n' + process.env.CF_FENCE);
+  console.log('    (add to the top of ' + rnPath + ':)');
+  console.log(process.env.CF_FENCE + '\n' + entry + '\n' + process.env.CF_FENCE);
   process.exit(0);
 }
 let idx = rnLines.findIndex(l => /^## /.test(l));           // before newest existing entry
 if (idx === -1) idx = rnLines.length;                        // or append if none
-const head = rnLines.slice(0, idx).join('\n').replace(/\n+$/, '');
-const tail = rnLines.slice(idx).join('\n');
-let out = head + '\n\n' + entry + '\n' + tail;
-out = out.replace(/\n{3,}/g, '\n\n').replace(/\s+$/, '') + '\n';
-fs.writeFileSync(rnPath, out);
-console.log('    added "## ' + v + '" to ' + rnPath +
-            (body ? '' : ' (no bullets - [Unreleased] was empty)'));
+// Normalise only the two seams this insert creates. Collapsing blank runs
+// across the whole file would silently reformat parts of it the step was never
+// asked to touch - and the dry run above previews the entry, not that.
+const head = rnLines.slice(0, idx).join('\n').replace(/\s+$/, '');
+const tail = rnLines.slice(idx).join('\n').replace(/^\n+/, '').replace(/\s+$/, '');
+fs.writeFileSync(rnPath, head + '\n\n' + entry + '\n\n' + tail + '\n');
+console.log('    added "## ' + v + '" to ' + rnPath);
 NODE
 fi
 
 # 8. Major/minor only: hyperformula-demos + CodeSandbox URLs in docs/
 step "8. Demos + docs URLs (major/minor only)"
 if [[ "$RELEASE_TYPE" == patch ]]; then
-  echo "    skipped (patch release)"
+  skip "patch release - the demos and the CodeSandbox URLs already name $VERSION_BRANCH"
 else
-  # The sanity checks have already proved the demos clone is usable.
+  # The sanity checks have already proved the demos clone is usable and carries
+  # set-hyperformula-version.sh.
   echo "    updating $DEMOS_DIR -> $VERSION, branch $VERSION_BRANCH"
   ( cd "$DEMOS_DIR"
-    run git checkout develop
-    run git pull
+    sync_branch develop
     run sh set-hyperformula-version.sh "$VERSION"
-    run git add .
     if $DRY_RUN || [[ -n "$(git status --porcelain)" ]]; then
+      run git add .
       run git commit -m "Set hyperformula version for all demos"
     else
       skip "demos already at $VERSION - no commit needed"
     fi
-    run git push
-    if branch_exists "$VERSION_BRANCH"; then
-      run git checkout "$VERSION_BRANCH"
-    elif remote_branch_exists "$VERSION_BRANCH"; then
-      run git checkout -b "$VERSION_BRANCH" "origin/$VERSION_BRANCH"
-    else
-      run git checkout -b "$VERSION_BRANCH"
-    fi
-    run git push -u origin "$VERSION_BRANCH" )
-  [[ "$RELEASE_TYPE" == major ]] && echo "    ! major: manually test demos against the rc build."
-  # CodeSandbox demo URLs in this repo's docs/: point every one at the new
-  # branch, whatever branch it names now (old releases left several behind)
-  if [[ -d docs ]]; then
+    run git push origin develop
+    merge_develop_into_version_branch "$VERSION_BRANCH" )
+  # CodeSandbox / StackBlitz demo URLs in this repo's docs: point every one at
+  # the new branch, whatever branch it names now (old releases left several
+  # behind). Scans docs/guide and docs/index.md only - the tracked files that
+  # carry these URLs. Walking all of docs/ would also descend into the gitignored
+  # generated trees (docs/api, docs/functions, docs/.vuepress/dist), whose built
+  # HTML repeats the same URLs but is never committed - it would bury the dry-run
+  # preview under hundreds of lines and inflate the reported file count.
+  DOC_URL_PATHS=()
+  [[ -d docs/guide ]] && DOC_URL_PATHS+=(docs/guide)
+  [[ -f docs/index.md ]] && DOC_URL_PATHS+=(docs/index.md)
+  if [[ ${#DOC_URL_PATHS[@]} -gt 0 ]]; then
     CF_NEW="$VERSION_BRANCH" CF_FENCE="$PREVIEW_FENCE" \
-    CF_DRY="$($DRY_RUN && echo 1 || echo '')" perl - docs <<'PERL'
+    CF_DRY="$($DRY_RUN && echo 1 || echo '')" perl - "${DOC_URL_PATHS[@]}" <<'PERL'
 use strict;
 use warnings;
 use File::Find;
@@ -502,7 +803,7 @@ my $demoUrl = qr{(\Q$treeUrl\E)/($segment)((?:/$segment)?)};
 my %pinnedDemos = map { $_ => 1 } qw(vue-demo);
 
 my @docFiles;
-find(sub { push @docFiles, $File::Find::name if -f && -T }, @ARGV);
+find(sub { push @docFiles, $File::Find::name if -f }, @ARGV);
 
 my (@previewLines, @rewrittenFiles);
 for my $file (sort @docFiles) {
@@ -548,6 +849,8 @@ if (!$count) {
   print "    updated CodeSandbox URLs -> tree/$branch in $count file(s)\n";
 }
 PERL
+  else
+    skip "no docs/guide or docs/index.md here - no demo URLs to rewrite"
   fi
 fi
 
@@ -555,12 +858,17 @@ fi
 step "9. Commit + push release/$VERSION"
 # Named pathspecs, not '.': an unrelated uncommitted change elsewhere in the
 # working tree (something the operator was working on, unrelated to the
-# freeze) must not ride along into the release commit. package-lock.json,
-# ht.config.js and docs/ are each conditional on existing - step 4 deletes and
-# regenerates the lock file, so between an 'npm i' and its write it is briefly
-# gone, and both files can be legitimately absent altogether (see step 3, and
-# t05b for the missing ht.config.js case) - a bare pathspec for any of them
-# would die under 'set -e' when it is not there.
+# freeze) must not ride along into the release commit. These are whole paths
+# though, not a list of files this run wrote, so they cannot tell the freeze's
+# edits from the operator's inside the same path - which is why the preflight
+# refuses to start a fresh freeze on a dirty tree.
+# package-lock.json, ht.config.js and docs/ are each conditional on existing:
+# step 4 deletes and regenerates the lock file, so between an 'npm i' and its
+# write it is briefly gone, and both files can be legitimately absent altogether
+# (see step 3) - a bare pathspec for any of them would die under 'set -e' when
+# it is not there.
+# Anything a future step writes outside these paths will not be committed, so
+# add its path here too.
 ADD_PATHS=(package.json CHANGELOG.md)
 [[ -f package-lock.json ]] && ADD_PATHS+=(package-lock.json)
 [[ -f ht.config.js ]] && ADD_PATHS+=(ht.config.js)
@@ -573,31 +881,17 @@ else
 fi
 run git push -u origin "release/$VERSION"
 
-# 10. hyperformula-tests: give the freeze its own branch there and publish it,
-#     so CI and other developers can add tests during the freeze. 'publish'
-#     merges it back. (The process doc still describes the older
-#     'checkout master && pull origin develop' - see release-README.md.)
-#     The sanity checks have already proved the clone is usable, so there is no
-#     "repo not found" path here.
-step "10. Create + push release/$VERSION in hyperformula-tests"
-( cd "$TESTS_DIR"
-  run git fetch origin
-  if branch_exists "release/$VERSION"; then
-    skip "release/$VERSION already exists in the tests repo"
-    sync_branch "release/$VERSION"
-  elif remote_branch_exists "release/$VERSION"; then
-    skip "release/$VERSION exists on the tests repo's origin"
-    run git checkout -b "release/$VERSION" "origin/release/$VERSION"
-  else
-    run git checkout develop
-    run git pull --ff-only
-    run git checkout -b "release/$VERSION"
-  fi
-  run git push -u origin "release/$VERSION" )
-
-step "Done - release/$VERSION is ready for the freeze"
+# A freeze that could not do part of its job must not sign off as if it had.
+FREEZE_WARNINGS="$(warning_count)"
+if [[ "$FREEZE_WARNINGS" == 0 ]]; then
+  step "Done - release/$VERSION is ready for the freeze"
+else
+  step "Finished, but $FREEZE_WARNINGS thing(s) could not be done - release/$VERSION is NOT ready yet"
+fi
 if $DRY_RUN; then echo "  (dry run - nothing changed; re-run with --real-run to do it for real)"; fi
 
+# Recorded soft failures first: they are the work that has to happen before the
+# freeze is really under way, and they belong on the same list as the rest of it.
 manual_checklist <<NEXT
   [ ] Post a heads-up about the code freeze in #hyperformula and #release
 
@@ -605,7 +899,7 @@ manual_checklist <<NEXT
   [ ] Review the docs changes (GitHub compare)
   [ ] Test the code examples on staging
   [ ] Work with marketing on the blog post and social media content
-
+$( [[ "$RELEASE_TYPE" == major ]] && printf '  [ ] Major release: test the demos by hand against the rc build\n' )
   [ ] Check that CI is green on release/$VERSION before publishing (the freeze runs
       the unit tests locally; the browser suite runs in CI on the pushed branch)
 NEXT
@@ -616,7 +910,8 @@ exit 0
 # Command: publish
 # ============================================================================
 cmd_publish() {
-local DRY_RUN=true SKIP_BUILD=false DEMOS_DIR="" TESTS_DIR="" VERSION=""
+local DRY_RUN=true SKIP_BUILD=false DEMOS_DIR="" VERSION=""
+start_warning_register
 
 # ---- args ----
 while [[ $# -gt 0 ]]; do
@@ -625,7 +920,6 @@ while [[ $# -gt 0 ]]; do
     --dry-run)      DRY_RUN=true ;;
     --skip-build)   SKIP_BUILD=true ;;
     --demos-dir)    [[ $# -ge 2 ]] || die "Missing value for $1"; DEMOS_DIR="$2"; shift ;;
-    --tests-dir)    [[ $# -ge 2 ]] || die "Missing value for $1"; TESTS_DIR="$2"; shift ;;
     -h|--help)      usage_publish; exit 0 ;;
     -*)             die "Unknown option: $1" ;;
     *) if [[ -z "$VERSION" ]]; then VERSION="$1"
@@ -634,31 +928,47 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-[[ -n "$VERSION" ]] || read -r -p "Version to publish (e.g. 2.1.0): " VERSION
+[[ -n "$VERSION" ]] || read -r -p "Version to publish (e.g. 2.1.0): " VERSION \
+  || die "no version given and no terminal to ask on."
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || die "Bad version: $VERSION"
 
+# Not configurable, as in code-freeze: test/fetch-tests.sh and the CI workflows
+# all hardcode this path.
+TESTS_DIR="test/hyperformula-tests"
+
 # ---- sanity checks ----
+# Named, as in code-freeze, so a failure in any of the checks below is reported
+# against a step instead of against "startup".
+step "Preflight"
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "Not inside a git repo."
 [[ -f package.json ]] || die "No package.json here - run from the hyperformula repo root."
-command -v npm >/dev/null || die "npm not found."
+# node reads package.json on the release ref in the preflight below.
+for tool in npm node; do
+  command -v "$tool" >/dev/null || die "$tool not found."
+done
 branch_exists master  || die "No 'master' branch."
 branch_exists develop || die "No 'develop' branch."
 [[ -z "$(git status --porcelain)" ]] || die "Working tree is dirty - commit or stash first."
 
-# default repo locations, as in code-freeze
+# default demos location, as in code-freeze
 PARENT="$(dirname "$PWD")"
-[[ -z "$DEMOS_DIR" && -d "$PARENT/hyperformula-demos"   ]] && DEMOS_DIR="$PARENT/hyperformula-demos"
-[[ -z "$TESTS_DIR" && -d "$PWD/test/hyperformula-tests" ]] && TESTS_DIR="$PWD/test/hyperformula-tests"
+[[ -z "$DEMOS_DIR" && -d "$PARENT/hyperformula-demos" ]] && DEMOS_DIR="$PARENT/hyperformula-demos"
 
 # Both sibling repositories are written to during a publish, so both are
 # required - same rule as code-freeze. The tests repo also needs master, which
 # step 6 merges into. Both run unconditionally, same reason as code-freeze.
+# The demos script is checked here for a sharper reason than in the freeze: it
+# runs in step 8, after the npm publish that cannot be undone, so a wrong
+# --demos-dir has to be caught now or not at all.
 SIBLINGS_OK=true
-require_repo hyperformula-tests "$TESTS_DIR" --tests-dir master develop || SIBLINGS_OK=false
-require_repo hyperformula-demos "$DEMOS_DIR" --demos-dir develop || SIBLINGS_OK=false
+require_repo hyperformula-tests "$TESTS_DIR" "run 'npm run test:setup-private' first" master develop || SIBLINGS_OK=false
+if require_repo hyperformula-demos "$DEMOS_DIR" "pass --demos-dir PATH" develop; then
+  require_script hyperformula-demos "$DEMOS_DIR" update-hyperformula-in-lock-files.sh || SIBLINGS_OK=false
+else
+  SIBLINGS_OK=false
+fi
 $SIBLINGS_OK || die "Fix the sibling clone problem(s) reported above before continuing."
 
-step "Preflight"
 # Fetching writes only refs the release reads (remote-tracking branches, and
 # local tags via --tags), never the working tree - so it is safe in a dry run,
 # and every "is this already done?" check below needs the fresh state. Marked
@@ -668,26 +978,12 @@ git fetch origin --tags >/dev/null 2>&1 || die "git fetch origin failed."
 
 # Both release branches are prerequisites: 'publish' finishes a freeze, it never
 # improvises one. A missing branch means the freeze did not run for this version,
-# so it is an error rather than a step to skip. Prefer the local branch and fall
-# back to origin's, so publishing works from a fresh clone too.
-if branch_exists "release/$VERSION"; then
-  RELEASE_REF="release/$VERSION"
-elif remote_branch_exists "release/$VERSION"; then
-  RELEASE_REF="origin/release/$VERSION"
-else
-  die "No release/$VERSION branch (local or on origin) - run 'release.sh code-freeze $VERSION <date>' first."
-fi
-
-# A local release branch can be stale - someone may have pushed a late fix to
-# the freeze branch. Publishing the local tip would silently drop it, so require
-# the two to agree rather than guessing which is wanted.
-if [[ "$RELEASE_REF" == "release/$VERSION" ]] && remote_branch_exists "release/$VERSION"; then
-  LOCAL_TIP="$(git rev-parse "release/$VERSION")"
-  ORIGIN_TIP="$(git rev-parse "origin/release/$VERSION" 2>/dev/null || true)"
-  [[ -n "$ORIGIN_TIP" && "$LOCAL_TIP" == "$ORIGIN_TIP" ]] \
-    || die "Local release/$VERSION ($LOCAL_TIP) differs from origin ($ORIGIN_TIP) - reconcile them first: git checkout release/$VERSION && git pull --ff-only"
-fi
-RELEASE_TIP="$(git rev-parse "$RELEASE_REF")"
+# so it is an error rather than a step to skip. resolve_branch prefers the local
+# branch, falls back to origin's so publishing works from a fresh clone too, and
+# refuses a local branch that has drifted from origin's.
+resolve_branch "release/$VERSION" . "run 'release.sh code-freeze $VERSION <date>' first"
+RELEASE_REF="$RESOLVED_REF"
+RELEASE_TIP="$RESOLVED_TIP"
 # Tolerant read, then explicit checks: under 'pipefail' an unreadable file or a
 # throwing JSON.parse would fail this assignment and trip the ERR trap, which
 # reports far less than the two messages below.
@@ -699,30 +995,13 @@ REF_VERSION="$(git show "$RELEASE_REF:package.json" 2>/dev/null \
   || die "package.json on $RELEASE_REF says $REF_VERSION, not $VERSION."
 
 # Same requirement in the tests repo, checked here so the run fails before it
-# touches master, rather than half-way through the merge-back. Use the shared
-# predicates with their repo-path argument: a raw 'ls-remote --heads origin
-# release/X' matches by path component, so an unrelated 'old/release/X' would
-# satisfy it - the collision remote_branch_exists exists to prevent.
+# touches master, rather than half-way through the merge-back. The same helper,
+# so the two guards cannot drift apart: they used to be two hand-written copies.
 printf '    $ git -C %s fetch origin   (always runs)\n' "$TESTS_DIR"
 git -C "$TESTS_DIR" fetch origin >/dev/null 2>&1 || die "git fetch failed in $TESTS_DIR."
-if branch_exists "release/$VERSION" "$TESTS_DIR"; then
-  TESTS_REF="release/$VERSION"
-elif remote_branch_exists "release/$VERSION" "$TESTS_DIR"; then
-  TESTS_REF="origin/release/$VERSION"
-else
-  die "No release/$VERSION branch in the tests repo ($TESTS_DIR) - the freeze did not create it."
-fi
-# Same divergence guard as the public repo above: a stale local branch here
-# would silently drop a test pushed to the freeze branch by someone else.
-if [[ "$TESTS_REF" == "release/$VERSION" ]] && remote_branch_exists "release/$VERSION" "$TESTS_DIR"; then
-  LOCAL_TESTS_TIP="$(git -C "$TESTS_DIR" rev-parse "release/$VERSION")"
-  ORIGIN_TESTS_TIP="$(git -C "$TESTS_DIR" rev-parse "origin/release/$VERSION" 2>/dev/null || true)"
-  [[ -n "$ORIGIN_TESTS_TIP" && "$LOCAL_TESTS_TIP" == "$ORIGIN_TESTS_TIP" ]] \
-    || die "Local release/$VERSION in the tests repo ($LOCAL_TESTS_TIP) differs from origin ($ORIGIN_TESTS_TIP) - reconcile them first: git -C $TESTS_DIR checkout release/$VERSION && git -C $TESTS_DIR pull --ff-only"
-fi
-# Pinned here, like RELEASE_TIP: the merge below must use the commit this
-# preflight verified, not whatever the ref names once sync_branch has pulled.
-TESTS_TIP="$(git -C "$TESTS_DIR" rev-parse "$TESTS_REF")"
+resolve_branch "release/$VERSION" "$TESTS_DIR" "the freeze did not create it"
+TESTS_REF="$RESOLVED_REF"
+TESTS_TIP="$RESOLVED_TIP"
 
 NPM_USER="$(npm whoami 2>/dev/null || true)"
 if [[ -z "$NPM_USER" ]]; then
@@ -733,11 +1012,34 @@ fi
 IFS='.' read -r nM nm _ <<<"$VERSION"
 VERSION_BRANCH="${nM}.${nm}.x"
 
+# A plain x.y.z is a normal release: it takes npm's 'latest' dist-tag and, on
+# GitHub, "latest release". Anything with a prerelease/build suffix (an rc, say)
+# must NOT - the version regex above deliberately accepts those, and a bare
+# 'npm publish' would move 'latest' to it, so every 'npm install hyperformula'
+# would resolve to the rc. Publish those under 'next' and flag the GitHub
+# release as a pre-release in the closing checklist below.
+if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  NPM_TAG='latest'; IS_PRERELEASE=false
+else
+  NPM_TAG='next'; IS_PRERELEASE=true
+fi
+
+# The demos version branch is written to in step 8, which runs after the npm
+# publish. Report a missing one now, while the operator can still act on it -
+# but as a warning, not an error: by the time step 8 runs the release is out,
+# so refusing there would leave a published package and a dead script. A branch
+# that is missing at publish time usually means the freeze's demos step never
+# completed, which also means the CodeSandbox URLs in docs/ were never rewritten.
+if ! branch_exists "$VERSION_BRANCH" "$DEMOS_DIR" && ! remote_branch_exists "$VERSION_BRANCH" "$DEMOS_DIR"; then
+  note "hyperformula-demos has no $VERSION_BRANCH branch, so step 8 will create it from develop. For a major or minor release the freeze's demos step should already have created it, so check that the CodeSandbox URLs in docs/ name tree/$VERSION_BRANCH as well. For the first patch on a new minor line there may simply be nothing there yet."
+fi
+
 step "Plan"
 cat <<INFO
   version:      $VERSION
   release ref:  $RELEASE_REF
   npm user:     $NPM_USER
+  npm dist-tag: $NPM_TAG$($IS_PRERELEASE && echo '   (prerelease - not tagged latest; GitHub release flagged pre-release)')
   demos repo:   $DEMOS_DIR  (branch $VERSION_BRANCH)
   tests repo:   $TESTS_DIR  ($TESTS_REF)
   build:        $($SKIP_BUILD && echo 'SKIPPED (--skip-build; package check still runs)' || echo 'npm ci + bundle-all + package check')
@@ -751,10 +1053,16 @@ merge_release_into master "$RELEASE_REF" "$RELEASE_TIP"
 # 2. Tag the release on master (git flow release finish tags here)
 step "2. Tag $VERSION"
 if tag_exists "$VERSION"; then
-  if is_ancestor "refs/tags/$VERSION" master; then
+  # Accept the tag when it sits on master's history OR origin/master's. In a real
+  # run step 1 has already fast-forwarded local master, so the two agree; in a dry
+  # run nothing has moved master, so a local copy left behind by anyone who has
+  # not pulled since the release would otherwise fail this check on a tag that is
+  # perfectly fine on origin. The preflight's 'git fetch origin --tags' already
+  # refreshed origin/master, so consulting it here needs no pull of its own.
+  if is_ancestor "refs/tags/$VERSION" master || is_ancestor "refs/tags/$VERSION" origin/master; then
     skip "tag $VERSION already exists on master's history"
   else
-    die "tag $VERSION exists but is not in master's history - check it before continuing."
+    die "tag $VERSION exists but is not in master's or origin/master's history - check it before continuing."
   fi
 else
   run git tag -a "$VERSION" -m "$VERSION"
@@ -800,10 +1108,10 @@ step "7. Publish hyperformula@$VERSION to npm"
 if on_npm "$VERSION"; then
   skip "hyperformula@$VERSION is already on npm - not publishing again"
 elif $DRY_RUN; then
-  echo "    (would ask for confirmation, then run: npm publish)"
+  echo "    (would ask for confirmation, then run: npm publish --tag $NPM_TAG)"
 else
   confirm_publish "$VERSION" "$NPM_USER"
-  run npm publish
+  run npm publish --tag "$NPM_TAG"
   wait_for_npm "$VERSION"
 fi
 
@@ -812,7 +1120,6 @@ fi
 #    failure inside this subshell must still name the step.
 step "8. Update hyperformula-demos"
 ( cd "$DEMOS_DIR"
-  run git fetch origin
   sync_branch develop
   run sh update-hyperformula-in-lock-files.sh
   if $DRY_RUN || [[ -n "$(git status --porcelain)" ]]; then
@@ -823,21 +1130,10 @@ step "8. Update hyperformula-demos"
   fi
   run git push origin develop
 
-  # sync_branch, not a raw checkout: the version branch is shared, and pushing
-  # to it without fast-forwarding first is what broke the tests-repo step once.
-  if branch_exists "$VERSION_BRANCH"; then
-    sync_branch "$VERSION_BRANCH"
-  elif remote_branch_exists "$VERSION_BRANCH"; then
-    run git checkout -b "$VERSION_BRANCH" "origin/$VERSION_BRANCH"
-  else
-    run git checkout -b "$VERSION_BRANCH"
-  fi
-  if is_ancestor develop "$VERSION_BRANCH"; then
-    skip "develop already merged into $VERSION_BRANCH"
-  else
-    run git merge --no-ff -m "Merge branch 'develop' into $VERSION_BRANCH" develop
-  fi
-  run git push -u origin "$VERSION_BRANCH"
+  # A branch the freeze failed to create is created here rather than stranding a
+  # published release; the preflight has already noted that case, while the
+  # operator could still act on it.
+  merge_develop_into_version_branch "$VERSION_BRANCH"
   # All three clones end on develop - see step 9 below for this repo. Unlike
   # code-freeze, there is no reason to leave the operator on the version branch
   # here: the freeze just created it, but publish only ever revisits it.
@@ -847,12 +1143,15 @@ step "8. Update hyperformula-demos"
 step "9. Back to develop"
 run git checkout develop
 
+# No step in publish records a soft failure: every failure path here uses 'die',
+# and the one soft report - a missing demos version branch - is a 'note', which
+# by design does not change this banner. So the banner is always the plain Done.
 step "Done - $VERSION is released"
 if $DRY_RUN; then echo "  (dry run - nothing changed; re-run with --real-run to do it for real)"; fi
 
 manual_checklist <<NEXT
   [ ] Create the GitHub release for $VERSION (body = the $VERSION section of CHANGELOG.md):
-        https://github.com/handsontable/hyperformula/releases/new?tag=$VERSION&title=$VERSION
+        https://github.com/handsontable/hyperformula/releases/new?tag=$VERSION&title=$VERSION$($IS_PRERELEASE && printf '&prerelease=1\n      (prerelease - leave the "Set as the latest release" box unchecked)')
   [ ] Check that the docs workflow deployed the documentation to gh-pages
   [ ] Announce the release in #hyperformula and #release
   [ ] Close the GitHub and ClickUp tasks in this release, announcing $VERSION,
@@ -865,15 +1164,11 @@ exit 0
 # ============================================================================
 # Dispatch
 # ============================================================================
-# Only dispatch when executed. Sourcing the script (the test harness does this)
-# just defines the helpers, so they can be exercised on their own.
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-  if [[ $# -eq 0 ]]; then usage_top; exit 0; fi
-  COMMAND="$1"; shift
-  case "$COMMAND" in
-    code-freeze)    cmd_code_freeze "$@" ;;
-    publish)        cmd_publish "$@" ;;
-    -h|--help|help) usage_top ;;
-    *) printf 'Unknown command: %s\n\n' "$COMMAND" >&2; usage_top >&2; exit 1 ;;
-  esac
-fi
+if [[ $# -eq 0 ]]; then usage_top; exit 0; fi
+COMMAND="$1"; shift
+case "$COMMAND" in
+  code-freeze)    cmd_code_freeze "$@" ;;
+  publish)        cmd_publish "$@" ;;
+  -h|--help|help) usage_top ;;
+  *) printf 'Unknown command: %s\n\n' "$COMMAND" >&2; usage_top >&2; exit 1 ;;
+esac

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -176,6 +176,9 @@ Usage: release.sh code-freeze <version> <release-date> [options]
 Starts a HyperFormula code freeze. Previews by default (prints commands,
 changes nothing); add --real-run to make changes.
 
+Requires usable hyperformula-tests and hyperformula-demos clones (present,
+clean, with a reachable origin) - it exits early otherwise.
+
 Options:
   --real-run         Actually run the commands (default is a dry-run preview).
   --demos-dir PATH   hyperformula-demos clone (default: ../hyperformula-demos).

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -216,9 +216,10 @@ if branch_exists "release/$VERSION"; then
 elif remote_branch_exists "release/$VERSION"; then
   skip "release/$VERSION exists on origin - resuming the freeze"
   # remote_branch_exists asks the remote directly, so the local tracking ref may
-  # not exist yet. Fetch the branch before creating a local one from it, or
-  # resuming in a clone that never saw it - another machine, a fresh clone -
-  # fails on 'origin/release/<version>' not being a commit.
+  # not exist yet. Fetch the branch before creating a local one from it. Without
+  # this, resuming in a clone that has not fetched since the branch was pushed -
+  # a colleague's machine, a single-branch or shallow checkout - fails on
+  # 'origin/release/<version>' not being a commit.
   run git fetch origin "release/$VERSION"
   run git checkout -b "release/$VERSION" "origin/release/$VERSION"
 else

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -191,8 +191,11 @@ DATE_LONG="$(CF="$DATE_ISO" node -e 'console.log(new Date(process.env.CF+"T00:00
 # tree if develop cannot be read, so an unusual checkout still gets an answer.
 PRE_FREEZE_VERSION="$(git show develop:package.json 2>/dev/null \
   | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(JSON.parse(s).version||"")}catch(e){}})' 2>/dev/null || true)"
-[[ -n "$PRE_FREEZE_VERSION" ]] \
-  || PRE_FREEZE_VERSION="$(node -e 'process.stdout.write(require("./package.json").version||"")' 2>/dev/null || true)"
+if [[ -z "$PRE_FREEZE_VERSION" ]]; then
+  PRE_FREEZE_VERSION="$(node -e 'process.stdout.write(require("./package.json").version||"")' 2>/dev/null || true)"
+  echo "    ! could not read develop's package.json - classifying the release against the checked-out"
+  echo "      version (${PRE_FREEZE_VERSION:-unknown}), which on a resumed freeze can read a minor release as a patch."
+fi
 IFS='.' read -r nM nm _ <<<"$VERSION"
 IFS='.' read -r cM cm _ <<<"${PRE_FREEZE_VERSION:-0.0.0}"
 if   [[ "$nM" != "$cM" ]]; then RELEASE_TYPE=major
@@ -373,7 +376,11 @@ else
       run git pull
       run sh set-hyperformula-version.sh "$VERSION"
       run git add .
-      run git commit -m "Set hyperformula version for all demos"
+      if $DRY_RUN || [[ -n "$(git status --porcelain)" ]]; then
+        run git commit -m "Set hyperformula version for all demos"
+      else
+        skip "demos already at $VERSION - no commit needed"
+      fi
       run git push
       if git show-ref --verify --quiet "refs/heads/$VERSION_BRANCH"; then
         run git checkout "$VERSION_BRANCH"

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -220,8 +220,8 @@ step "Plan"
 cat <<INFO
   version:      $VERSION   (was ${PRE_FREEZE_VERSION:-unknown}, $RELEASE_TYPE release)
   release date: $DATE_ISO  (ht.config.js: $DATE_HT | release notes: $DATE_LONG)
-  demos repo:   ${DEMOS_DIR:-<none, will print manual steps>}$( [[ $RELEASE_TYPE == patch ]] && echo '  (skipped: patch)')
-  tests repo:   ${TESTS_DIR:-<none, will print manual steps>}
+  demos repo:   $DEMOS_DIR$( [[ $RELEASE_TYPE == patch ]] && echo '  (skipped: patch)')
+  tests repo:   $TESTS_DIR
   mode:         $($DRY_RUN && echo 'DRY RUN (preview; pass --real-run to make changes)' || echo 'REAL RUN (making changes)')
 INFO
 
@@ -378,7 +378,7 @@ if [[ "$RELEASE_TYPE" == patch ]]; then
 else
   # The sanity checks have already proved the demos clone is usable.
   echo "    updating $DEMOS_DIR -> $VERSION, branch $VERSION_BRANCH"
-  ( trap - ERR; cd "$DEMOS_DIR"
+  ( cd "$DEMOS_DIR"
     run git checkout develop
     run git pull
     run sh set-hyperformula-version.sh "$VERSION"
@@ -487,11 +487,11 @@ run git push -u origin "release/$VERSION"
 #     The sanity checks have already proved the clone is usable, so there is no
 #     "repo not found" path here.
 step "10. Create + push release/$VERSION in hyperformula-tests"
-( trap - ERR; cd "$TESTS_DIR"
+( cd "$TESTS_DIR"
   run git fetch origin
   if branch_exists "release/$VERSION"; then
     skip "release/$VERSION already exists in the tests repo"
-    run git checkout "release/$VERSION"
+    sync_branch "release/$VERSION"
   elif remote_branch_exists "release/$VERSION"; then
     skip "release/$VERSION exists on the tests repo's origin"
     run git checkout -b "release/$VERSION" "origin/release/$VERSION"

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -184,7 +184,15 @@ command -v npm >/dev/null || die "npm not found."
 DATE_HT="$(CF="$DATE_ISO"   node -e 'const[y,m,d]=process.env.CF.split("-");console.log(`${d}/${m}/${y}`)')"
 DATE_LONG="$(CF="$DATE_ISO" node -e 'console.log(new Date(process.env.CF+"T00:00:00").toLocaleString("en-US",{month:"long",day:"numeric",year:"numeric"}))')"
 
-PRE_FREEZE_VERSION="$(node -e 'process.stdout.write(require("./package.json").version||"")' 2>/dev/null || true)"
+# Read the pre-release version from develop rather than the working tree: on a
+# resumed freeze the tree already carries the bump, which would read as a patch
+# release and silently skip step 8's demos and CodeSandbox work. develop holds
+# the old version until 'publish' merges the release back. Falls back to the
+# tree if develop cannot be read, so an unusual checkout still gets an answer.
+PRE_FREEZE_VERSION="$(git show develop:package.json 2>/dev/null \
+  | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(JSON.parse(s).version||"")}catch(e){}})' 2>/dev/null || true)"
+[[ -n "$PRE_FREEZE_VERSION" ]] \
+  || PRE_FREEZE_VERSION="$(node -e 'process.stdout.write(require("./package.json").version||"")' 2>/dev/null || true)"
 IFS='.' read -r nM nm _ <<<"$VERSION"
 IFS='.' read -r cM cm _ <<<"${PRE_FREEZE_VERSION:-0.0.0}"
 if   [[ "$nM" != "$cM" ]]; then RELEASE_TYPE=major

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -184,9 +184,9 @@ command -v npm >/dev/null || die "npm not found."
 DATE_HT="$(CF="$DATE_ISO"   node -e 'const[y,m,d]=process.env.CF.split("-");console.log(`${d}/${m}/${y}`)')"
 DATE_LONG="$(CF="$DATE_ISO" node -e 'console.log(new Date(process.env.CF+"T00:00:00").toLocaleString("en-US",{month:"long",day:"numeric",year:"numeric"}))')"
 
-CURRENT_VERSION="$(node -e 'process.stdout.write(require("./package.json").version||"")' 2>/dev/null || true)"
+PRE_FREEZE_VERSION="$(node -e 'process.stdout.write(require("./package.json").version||"")' 2>/dev/null || true)"
 IFS='.' read -r nM nm _ <<<"$VERSION"
-IFS='.' read -r cM cm _ <<<"${CURRENT_VERSION:-0.0.0}"
+IFS='.' read -r cM cm _ <<<"${PRE_FREEZE_VERSION:-0.0.0}"
 if   [[ "$nM" != "$cM" ]]; then RELEASE_TYPE=major
 elif [[ "$nm" != "$cm" ]]; then RELEASE_TYPE=minor
 else RELEASE_TYPE=patch; fi
@@ -200,7 +200,7 @@ PARENT="$(dirname "$PWD")"
 
 step "Plan"
 cat <<INFO
-  version:      $VERSION   (was ${CURRENT_VERSION:-unknown}, $RELEASE_TYPE release)
+  version:      $VERSION   (was ${PRE_FREEZE_VERSION:-unknown}, $RELEASE_TYPE release)
   release date: $DATE_ISO  (ht.config.js: $DATE_HT | release notes: $DATE_LONG)
   demos repo:   ${DEMOS_DIR:-<none, will print manual steps>}$( [[ $RELEASE_TYPE == patch ]] && echo '  (skipped: patch)')
   tests repo:   ${TESTS_DIR:-<none, will print manual steps>}
@@ -252,7 +252,9 @@ fi
 if [[ ! -f ht.config.js ]] || ! grep -q HT_RELEASE_DATE ht.config.js; then
   echo "    ! HT_RELEASE_DATE not found in ht.config.js - set it to $DATE_HT manually."
 else
-  CURRENT_HT_DATE="$(sed -n "s/.*HT_RELEASE_DATE[[:space:]]*:[[:space:]]*'\([^']*\)'.*/\1/p" ht.config.js | head -1 || true)"
+  # Accept either quote style, matching the write below: a double-quoted value
+  # the read could not see would defeat the skip this step exists to add.
+  CURRENT_HT_DATE="$(sed -n "s/.*HT_RELEASE_DATE[[:space:]]*:[[:space:]]*['\"]\([^'\"]*\)['\"].*/\1/p" ht.config.js | head -1 || true)"
   if [[ "$CURRENT_HT_DATE" == "$DATE_HT" ]]; then
     skip "ht.config.js HT_RELEASE_DATE already $DATE_HT"
   elif $DRY_RUN; then
@@ -263,11 +265,15 @@ else
   fi
 fi
 
-# 4. Regenerate the lock file. A lock file already naming the new version is
-#    proof it was regenerated after the bump, so a re-run leaves it alone.
+# 4. Regenerate the lock file. A lock file naming the new version alongside an
+#    installed node_modules is a reasonable signal that the reinstall already
+#    ran; it does not prove the dependency tree is still current. Both are
+#    required, because an interrupted 'npm i' can leave the lock file written
+#    while node_modules is missing - and skipping then would take a broken
+#    install straight into the build.
 step "4. Reinstall dependencies"
 LOCK_VERSION="$(node -e 'try{process.stdout.write(require("./package-lock.json").version||"")}catch(e){}' 2>/dev/null || true)"
-if [[ "$LOCK_VERSION" == "$VERSION" ]]; then
+if [[ "$LOCK_VERSION" == "$VERSION" && -d node_modules ]]; then
   skip "package-lock.json already regenerated for $VERSION"
 else
   run rm -rf ./node_modules

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -27,7 +27,7 @@ if [[ -t 1 ]]; then HIGHLIGHT=$'\033[1;33m'; RESET=$'\033[0m'; else HIGHLIGHT=''
 
 step() { CURRENT_STEP="$*"; printf '\n==> %s\n' "$*"; }
 die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
-run()  { printf '    $ %s\n' "$*"; $DRY_RUN || "$@"; }
+run()  { printf '    $ %s\n' "$(printf '%q ' "$@" | sed 's/ $//')"; $DRY_RUN || "$@"; }
 
 # Shows generated file content verbatim (unindented, so a dry run displays
 # exactly what would be written), fenced to mark where it starts and ends.
@@ -77,19 +77,22 @@ on_npm()               { npm view "hyperformula@$1" version >/dev/null 2>&1; }
 # work tree, clean, carrying the branches this run will move, with a reachable
 # origin. Failing here costs nothing; failing half-way through leaves one of
 # three repositories in a state someone has to untangle by hand.
+# Reports the first problem it finds and returns 1 - it does not die itself, so
+# a caller checking both sibling clones can report both in one run rather than
+# stopping at whichever is checked first.
 require_repo() { # require_repo <label> <path> <flag> <required branch...>
   local label="$1" dir="$2" flag="$3" branch; shift 3
   [[ -n "$dir" && -d "$dir" ]] \
-    || die "$label clone not found at '${dir:-<unset>}' - pass $flag PATH."
+    || { printf 'ERROR: %s\n' "$label clone not found at '${dir:-<unset>}' - pass $flag PATH." >&2; return 1; }
   git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
-    || die "$dir is not a git repository ($label)."
+    || { printf 'ERROR: %s\n' "$dir is not a git repository ($label)." >&2; return 1; }
   [[ -z "$(git -C "$dir" status --porcelain)" ]] \
-    || die "Working tree in $dir ($label) is dirty - commit or stash there first."
+    || { printf 'ERROR: %s\n' "Working tree in $dir ($label) is dirty - commit or stash there first." >&2; return 1; }
   git -C "$dir" ls-remote --heads origin >/dev/null 2>&1 \
-    || die "Cannot reach origin of $dir ($label)."
+    || { printf 'ERROR: %s\n' "Cannot reach origin of $dir ($label)." >&2; return 1; }
   for branch in "$@"; do
     branch_exists "$branch" "$dir" || remote_branch_exists "$branch" "$dir" \
-      || die "$label has no '$branch' branch ($dir)."
+      || { printf 'ERROR: %s\n' "$label has no '$branch' branch ($dir)." >&2; return 1; }
   done
 }
 
@@ -248,7 +251,7 @@ done
 # ---- sanity checks ----
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "Not inside a git repo."
 [[ -f package.json ]] || die "No package.json here - run from the hyperformula repo root."
-git show-ref --verify --quiet refs/heads/develop || die "No 'develop' branch."
+branch_exists develop || die "No 'develop' branch."
 command -v npm >/dev/null || die "npm not found."
 
 # ---- derive dates + release type ----
@@ -285,8 +288,12 @@ PARENT="$(dirname "$PWD")"
 # anything: a freeze that half-runs across three repositories is worse than one
 # that refuses to start. The demos clone is required even for a patch release
 # (where step 8 is skipped) - the check is about the environment being complete.
-require_repo hyperformula-tests "$TESTS_DIR" --tests-dir develop
-require_repo hyperformula-demos "$DEMOS_DIR" --demos-dir develop
+# Both run unconditionally so a run missing both clones reports both, instead
+# of stopping at whichever is checked first and hiding the second problem.
+SIBLINGS_OK=true
+require_repo hyperformula-tests "$TESTS_DIR" --tests-dir develop || SIBLINGS_OK=false
+require_repo hyperformula-demos "$DEMOS_DIR" --demos-dir develop || SIBLINGS_OK=false
+$SIBLINGS_OK || die "Fix the sibling clone problem(s) reported above before continuing."
 
 step "Plan"
 cat <<INFO
@@ -383,7 +390,7 @@ step "6. Update CHANGELOG.md"
 if [[ ! -f CHANGELOG.md ]] || ! grep -q '^## \[Unreleased\]' CHANGELOG.md; then
   echo "    ! Couldn't find '## [Unreleased]' - add the $VERSION entry manually."
 elif grep -q "^## \[$VERSION\]" CHANGELOG.md; then
-  echo "    = already has an entry for $VERSION"
+  skip "already has an entry for $VERSION"
 elif $DRY_RUN; then
   echo "    (insert '## [$VERSION] - $DATE_ISO' under [Unreleased] - the new section will read:)"
   preview "$(printf '## [%s] - %s\n\n%s' "$VERSION" "$DATE_ISO" "$(changelog_section_body '## [Unreleased]')")"
@@ -550,7 +557,7 @@ run git add .
 if $DRY_RUN || [[ -n "$(git status --porcelain)" ]]; then
   run git commit -m "$VERSION"
 else
-  echo "    nothing to commit"
+  skip "nothing to commit"
 fi
 run git push -u origin "release/$VERSION"
 
@@ -630,9 +637,11 @@ PARENT="$(dirname "$PWD")"
 
 # Both sibling repositories are written to during a publish, so both are
 # required - same rule as code-freeze. The tests repo also needs master, which
-# step 6 merges into.
-require_repo hyperformula-tests "$TESTS_DIR" --tests-dir master develop
-require_repo hyperformula-demos "$DEMOS_DIR" --demos-dir develop
+# step 6 merges into. Both run unconditionally, same reason as code-freeze.
+SIBLINGS_OK=true
+require_repo hyperformula-tests "$TESTS_DIR" --tests-dir master develop || SIBLINGS_OK=false
+require_repo hyperformula-demos "$DEMOS_DIR" --demos-dir develop || SIBLINGS_OK=false
+$SIBLINGS_OK || die "Fix the sibling clone problem(s) reported above before continuing."
 
 step "Preflight"
 # Fetching writes only refs the release reads (remote-tracking branches, and


### PR DESCRIPTION
## Summary

Implements the `publish` half of the release automation and makes `code-freeze` genuinely re-runnable.

On the base branch, `release.sh publish` is a placeholder that prints *"not implemented yet"* and exits 1 — everything after the freeze (the merges, the tag, the npm publish, the sibling-repo updates) was still manual. This PR implements it end to end, and hardens `code-freeze` so a run that fails part-way resumes instead of starting over.

Both commands mirror the [ClickUp release process doc](https://app.clickup.com/9015210959/v/dc/8cnjcyf-9495/8cnjcyf-12135), with the deliberate deviations listed below.

> [!NOTE]
> **Base is `release/3.4.0`, not `develop`** — this is an exception. The release-script work is stacked on the 3.4.0 freeze commit (`bad1bfa1`), so `release/3.4.0` is the only base that yields a clean two-file diff. Targeting `develop` would drag in the 3.4.0 version bump, its CHANGELOG/release-notes entries and ~1,950 lines of lock-file churn.

| | Base | This PR |
|---|---|---|
| `script/release/release.sh` | 430 lines | 1,174 lines |
| `script/release/release-README.md` | 106 lines | 380 lines |
| `publish` command | stub, `exit 1` | fully implemented |

No files outside `script/release/` are touched.

## What's new — the `publish` command

| Step | Does |
|---|---|
| 1 | Merges `release/<version>` into `master` as a merge commit, unless already merged |
| 2 | Annotated tag `<version>` on `master`, unless it already exists in `master`'s (or `origin/master`'s) history |
| 3 | Merges `release/<version>` into `develop` |
| 4 | Reinstalls, rebuilds and runs `verify:publish-package` from `master` |
| 5 | Pushes `master`, `develop` and the tag in **one atomic push**, before the npm publish |
| 6 | Merges the release branch back in `hyperformula-tests` (into `master` and `develop`), pushed atomically |
| 7 | **The point of no return** — typed confirmation, then `npm publish`, then waits for registry visibility |
| 8 | Updates `hyperformula-demos`: lock files on `develop`, then merges into the `M.m.x` branch |
| 9 | Leaves you on `develop`, where the next cycle starts |

## `code-freeze` hardening

- **Resumable.** Every step checks whether it is already done and skips with a `=` marker, so a failed run is recovered by re-running the same command rather than unpicking a half-finished freeze.
- **The tests-repo branch moved from step 10 to step 2.** `test/fetch-tests.sh` pulls the matching branch *from origin*, so a `release/<version>` that an earlier attempt created locally but never pushed made every resume fail. Creating and pushing it before `test:setup-private` runs fixes that, and publishes the branch for CI and for whoever adds tests during the freeze that much sooner.
- **The release type is classified against `origin/develop`**, not the working tree — on a resumed freeze the tree already carries the bump, which used to read as a patch and silently skip the demos and CodeSandbox work.
- **Stages named paths, not `git add .`**, so unrelated work in your tree cannot ride along into the release commit.
- **Rejects a date that does not exist.** `2026-02-30` passed the `YYYY-MM-DD` regex and reached `ht.config.js` verbatim while the release notes said March 2.

## Safety model

- **Dry run is the default.** Nothing changes without `--real-run`. Every mutating command is printed as a `$` line; generated content (the new CHANGELOG section, the release-notes entry, every rewritten demo URL as `-`/`+`) is previewed so it can be proofread first.
- **Three-repo preflight.** Both sibling clones must be present, clean, on a reachable `origin`, carrying the branches the run will move *and* the script it will execute inside them. This is checked before anything moves — in `publish` the demos script runs *after* the irreversible npm publish, so a wrong `--demos-dir` has to be caught up front or not at all.
- **Divergence is an error, never a merge.** Getting onto a branch fast-forwards or creates; it never invents a merge commit on `develop` or a shared version branch. A local `release/<v>` that disagrees with origin's is fatal, so a late fix pushed to the freeze branch cannot be silently dropped.
- **The merged commit is pinned in the preflight**, so the later steps merge exactly the commit the checks verified.
- **Prereleases stay off `latest`.** A plain `x.y.z` publishes under `latest`; anything with an rc suffix publishes under `next` and the GitHub release link carries `&prerelease=1`.

## Recorded failures

Anything you need to act on is recorded and re-printed as a `[ ]` item at the top of the closing checklist — a lone marker line mid-run scrolls past in an output that also holds a full install, build and test log. Two kinds, and only one means the run fell short:

- **`!` the script could not do it** — a target file has been restructured, or `[Unreleased]` is empty. These change the closing banner, so a freeze that fell short cannot sign off as if it hadn't.
- **`i` worth checking** — the run did its job, but something deserves a look (a resume from a dirty tree, a demos branch `publish` had to create). Listed without changing the banner, so an ordinary resume does not announce itself as a failure.

## Deliberate deviations from the process doc

- **`hyperformula-tests` gets its own `release/<version>` branch**, which `publish` merges back into `master` and `develop`. The doc still describes pointing its `master` at `develop` by hand. **The ClickUp doc needs updating to match.**
- **`release/<v>` is never deleted** — the branch is kept in both repositories, unlike `git flow release finish`.
- **Deploying the docs to staging is not automated** and is not on either checklist; the "test the code examples on staging" item assumes you have done it.

## How to verify

Dry run is the default, so both commands can be previewed safely against a real clone:

```bash
npm run release -- code-freeze 3.5.0 2026-09-30
```

```bash
npm run release -- publish 3.4.0
```

Each prints its preflight, a plan, every command it would run, and the exact content it would write. `shellcheck` is clean and `bash -n` passes.

## Review status

A full review of the final implementation was run against the process doc. Four findings are fixed in this branch:

- Perl's `-T` text heuristic could silently drop a real markdown file from the demo-URL rewrite, under-reporting the file count with no warning.
- `publish`'s preflight checks ran before `step "Preflight"`, so a failure reaching the ERR trap was attributed to `"startup"` instead — inconsistent with `code-freeze`.
- The README described the tag check as `master`-only, where the script also accepts `origin/master`'s history.
- The README claimed the script prints *every* command; read-only state checks and the in-place `node`/`perl` edits are not echoed verbatim.

## Follow-ups (not in this PR)

- `git push --atomic origin master develop --tags` pushes **all** local tags, not just `refs/tags/<version>`. A stray local tag gets published as a side effect, and one tag conflicting with origin aborts the entire release push.
- The staging-deploy step is neither automated nor on the manual checklist, while the checklist still says "test the code examples on staging" — the prerequisite is invisible.
- Publishing from a clone with no local release branch produces merge messages reading `Merge branch 'origin/release/<v>'` instead of `release/<v>`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes automate irreversible npm publish and multi-repo git merges/tags; mitigations include dry-run default, preflight pinning, typed confirmation, and atomic pushes, but operator error or partial failure still needs careful resume.
> 
> **Overview**
> Replaces the **`publish` stub** with an end-to-end flow: merge `release/<version>` into **`master`** and **`develop`**, tag, build and run **`verify:publish-package`**, **atomic push** of branches and tags (before npm), merge back in **`hyperformula-tests`**, typed **npm publish** confirmation ( **`latest`** vs **`next`** for prereleases), then update **`hyperformula-demos`**.
> 
> **`code-freeze`** is reworked to be **resumable** (skip steps with `=` when already done) instead of exiting when `release/<version>` exists. The **tests repo branch** is created and **pushed in step 2** (before `test:setup-private`). **Major/minor** detection uses **`origin/develop`**, commits use **named paths** not `git add .`, and **invalid calendar dates** are rejected.
> 
> Both commands share new infrastructure: **warning register** (`!` / `i` in the closing checklist), **`checkout_branch`** / **`resolve_branch`** / **`merge_release_into`**, strict **sibling-repo preflight** (fixed **`test/hyperformula-tests`** path; demos script verified before publish), and expanded **`release-README.md`** documenting behavior vs the script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc55734b492c1038f36df8bd109a7aa477ea40e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->