### PR TITLE
Remove the static function metadata API (HF-349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Added the `getAvailableFunctions()` and `getFunctionDetails()` methods (both static and instance) for retrieving function metadata. [#1692](https://github.com/handsontable/hyperformula/pull/1692)
+- Added the `getAvailableFunctions()` and `getFunctionDetails()` instance methods for retrieving function metadata. [#1692](https://github.com/handsontable/hyperformula/pull/1692)
 - Added new functions: VSTACK, HSTACK. [#1698](https://github.com/handsontable/hyperformula/pull/1698)
 - Added a new function: `XIRR`. [#1701](https://github.com/handsontable/hyperformula/pull/1701)
 - Added the UNIQUE function. [#1708](https://github.com/handsontable/hyperformula/pull/1708)

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,13 +81,6 @@ The built-in functions guide page `docs/guide/built-in-functions.md` is a **buil
   HyperFormula's API (`getAvailableFunctions`/`getFunctionDetails`), i.e. from the catalogue in
   `src/interpreter/functionMetadata/`, in a single pass &mdash; so the list links to exactly the sections the page has.
 
-That API is instance-scoped, so the generator builds an engine to read it &mdash; a default-config one, because the
-function total printed on the page is computed separately, from the global registry, in `docs/.vuepress/config.js`.
-The engine is built with the `gpl-v3` license key. Today that only keeps the build quiet (an engine built without a
-key logs a missing-license warning); function availability is not license-gated. Once entitlement lands, the key will
-decide which functions the metadata API reports, and naming the fully-entitled one here is what keeps the published
-reference documenting every built-in instead of narrowing to a tier.
-
 `npm run docs:generate-function-docs` splices both regions into the template and writes the gitignored page; it runs
 automatically as the first step of `npm run docs:build` and `npm run docs:dev`. To change the wording, edit the
 template; to change a function's row, edit its catalogue metadata.

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,9 +81,12 @@ The built-in functions guide page `docs/guide/built-in-functions.md` is a **buil
   HyperFormula's API (`getAvailableFunctions`/`getFunctionDetails`), i.e. from the catalogue in
   `src/interpreter/functionMetadata/`, in a single pass &mdash; so the list links to exactly the sections the page has.
 
-That API is instance-scoped, so the generator builds an engine to read it. It builds that engine with the `gpl-v3`
-license key, which grants the complete function set: the published reference must document every built-in rather than
-narrow to the tier of whichever key the build environment happens to supply.
+That API is instance-scoped, so the generator builds an engine to read it &mdash; a default-config one, because the
+function total printed on the page is computed separately, from the global registry, in `docs/.vuepress/config.js`.
+The engine is built with the `gpl-v3` license key. Today that only keeps the build quiet (an engine built without a
+key logs a missing-license warning); function availability is not license-gated. Once entitlement lands, the key will
+decide which functions the metadata API reports, and naming the fully-entitled one here is what keeps the published
+reference documenting every built-in instead of narrowing to a tier.
 
 `npm run docs:generate-function-docs` splices both regions into the template and writes the gitignored page; it runs
 automatically as the first step of `npm run docs:build` and `npm run docs:dev`. To change the wording, edit the

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,10 @@ The built-in functions guide page `docs/guide/built-in-functions.md` is a **buil
   HyperFormula's API (`getAvailableFunctions`/`getFunctionDetails`), i.e. from the catalogue in
   `src/interpreter/functionMetadata/`, in a single pass &mdash; so the list links to exactly the sections the page has.
 
+That API is instance-scoped, so the generator builds an engine to read it. It builds that engine with the `gpl-v3`
+license key, which grants the complete function set: the published reference must document every built-in rather than
+narrow to the tier of whichever key the build environment happens to supply.
+
 `npm run docs:generate-function-docs` splices both regions into the template and writes the gitignored page; it runs
 automatically as the first step of `npm run docs:build` and `npm run docs:dev`. To change the wording, edit the
 template; to change a function's row, edit its catalogue metadata.

--- a/docs/guide/release-notes.md
+++ b/docs/guide/release-notes.md
@@ -12,7 +12,7 @@ HyperFormula adheres to
 
 ### Added
 
-- Added the `getAvailableFunctions()` and `getFunctionDetails()` methods (both static and instance) for retrieving function metadata. [#1692](https://github.com/handsontable/hyperformula/pull/1692)
+- Added the `getAvailableFunctions()` and `getFunctionDetails()` instance methods for retrieving function metadata. [#1692](https://github.com/handsontable/hyperformula/pull/1692)
 - Added new functions: VSTACK, HSTACK. [#1698](https://github.com/handsontable/hyperformula/pull/1698)
 - Added a new function: `XIRR`. [#1701](https://github.com/handsontable/hyperformula/pull/1701)
 - Added the UNIQUE function. [#1708](https://github.com/handsontable/hyperformula/pull/1708)

--- a/script/generate-builtin-functions-doc.ts
+++ b/script/generate-builtin-functions-doc.ts
@@ -24,16 +24,23 @@ const TEMPLATE_PATH = path.join(REPO_ROOT, 'docs/guide/built-in-functions.tmpl.m
 const DOC_PATH = path.join(REPO_ROOT, 'docs/guide/built-in-functions.md')
 const LANGUAGE = 'enGB'
 /**
- * The GPLv3 key, which grants the complete function set. The metadata API is instance-scoped, so this page is
- * generated against an engine rather than against the package, and the engine's entitlement therefore decides which
- * functions reach the page. Naming the fully-entitled key here — instead of leaving it to whatever key the build
- * environment happens to supply — is what keeps the published reference documenting every built-in rather than
- * narrowing to one tier (HF-349).
+ * The GPLv3 key. Two reasons to name a key here, one current and one not yet:
+ *
+ * - Today it only keeps the build quiet. Function availability is **not** license-gated: every key, and no key at
+ *   all, yields the same function set. But the metadata API is instance-scoped, so this page is now generated from
+ *   an engine, and constructing one without a key logs "The license key for HyperFormula is missing." — noise the
+ *   static path never produced, because it built no engine.
+ * - Once entitlement lands (HF-307), the engine's key *will* decide which functions the metadata API reports.
+ *   Naming the fully-entitled key now means that change cannot silently narrow the published reference to one tier;
+ *   the page must always document the complete function set (HF-349).
  */
 const LICENSE_KEY = 'gpl-v3'
 
 /** Reads the committed template and returns the page with both generated regions spliced in. */
 function buildUpdatedFile(): string {
+  // Deliberately a default-config engine: its registry must stay the global one, because the function total printed
+  // on the page is computed separately, from the global registry, in docs/.vuepress/config.js. Restricting this
+  // engine with `functionPlugins` would give the table a different function set from the total above it.
   const engine = HyperFormula.buildEmpty({language: LANGUAGE, licenseKey: LICENSE_KEY})
   const entries = engine.getAvailableFunctions()
   const detailsFor = (canonicalName: string) => engine.getFunctionDetails(canonicalName)

--- a/script/generate-builtin-functions-doc.ts
+++ b/script/generate-builtin-functions-doc.ts
@@ -23,11 +23,20 @@ const REPO_ROOT = path.resolve(__dirname, '..')
 const TEMPLATE_PATH = path.join(REPO_ROOT, 'docs/guide/built-in-functions.tmpl.md')
 const DOC_PATH = path.join(REPO_ROOT, 'docs/guide/built-in-functions.md')
 const LANGUAGE = 'enGB'
+/**
+ * The GPLv3 key, which grants the complete function set. The metadata API is instance-scoped, so this page is
+ * generated against an engine rather than against the package, and the engine's entitlement therefore decides which
+ * functions reach the page. Naming the fully-entitled key here — instead of leaving it to whatever key the build
+ * environment happens to supply — is what keeps the published reference documenting every built-in rather than
+ * narrowing to one tier (HF-349).
+ */
+const LICENSE_KEY = 'gpl-v3'
 
 /** Reads the committed template and returns the page with both generated regions spliced in. */
 function buildUpdatedFile(): string {
-  const entries = HyperFormula.getAvailableFunctions(LANGUAGE)
-  const detailsFor = (canonicalName: string) => HyperFormula.getFunctionDetails(canonicalName, LANGUAGE)
+  const engine = HyperFormula.buildEmpty({language: LANGUAGE, licenseKey: LICENSE_KEY})
+  const entries = engine.getAvailableFunctions()
+  const detailsFor = (canonicalName: string) => engine.getFunctionDetails(canonicalName)
   const generated = renderBuiltinFunctionsMarkdown(entries, detailsFor)
   const template = fs.readFileSync(TEMPLATE_PATH, 'utf8')
   return spliceBuiltinFunctionsMarkdown(template, generated)

--- a/script/renderBuiltinFunctionsTable.ts
+++ b/script/renderBuiltinFunctionsTable.ts
@@ -85,7 +85,7 @@ function escapeCell(text: string): string {
  * rather than skipped — silently dropping it would leave the page short of a row while the printed function total,
  * which is computed independently in `docs/.vuepress/config.js`, still claimed it.
  *
- * @param {FunctionListEntry[]} entries - the function set to document (e.g. `HyperFormula.getAvailableFunctions`)
+ * @param {FunctionListEntry[]} entries - the function set to document (e.g. an engine's `getAvailableFunctions`)
  * @param {(canonicalName: string) => FunctionDetails | undefined} detailsFor - resolves a function's details
  * @returns {BuiltinFunctionsMarkdown} the markdown of both regions (no surrounding markers, LF, trailing newline)
  * @throws {Error} when a listed entry has no resolvable details

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -4508,6 +4508,10 @@ export class HyperFormula implements TypedEmitter {
    * function id, so a custom plugin registered *over* a built-in id inherits that id's entry and is listed with the
    * built-in's category and description.
    *
+   * That registry is a snapshot taken when the instance was built, not a live view of the global one: a function
+   * registered with [[registerFunctionPlugin]] or [[registerFunction]] afterwards reaches only the engines built
+   * later, so an engine kept across a late registration keeps reporting the set it was built with.
+   *
    * A function with no translation entry for the configured language is omitted: the interpreter refuses to evaluate
    * an untranslated id, so listing it would advertise a function that cannot be called — in practice, a custom
    * plugin registered without translations for that language. A translation set to an empty string is not a missing

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -654,115 +654,13 @@ export class HyperFormula implements TypedEmitter {
   }
 
   /**
-   * Returns metadata of all functions available for a given language, as a short list suitable for a function
-   * picker. Each entry contains the translated name, the language-independent canonical name, the category, and a
-   * short description. Entries are sorted alphabetically by their localized name, using the collation rules of the
-   * host environment, so the exact order of names that differ only by case or diacritics may vary between hosts.
-   *
-   * The list reflects the global registry: the built-in functions and every custom function registered with
-   * [[registerFunctionPlugin]] or [[registerFunction]], plus their aliases. An alias is listed under its own id,
-   * borrowing its target's category and description, with the target id exposed as `aliasOf`. Custom functions
-   * ship no catalogue entry, so they are listed with `category: 'Custom'` and no `shortDescription` — with one
-   * exception: the catalogue is keyed by function id, so a custom plugin registered *over* a built-in id inherits
-   * that id's entry and is listed with the built-in's category and description. Use the instance method
-   * [[getAvailableFunctions]] for one engine's own registry, which differs from the global one when the instance
-   * was built with the `functionPlugins` configuration option.
-   *
-   * A function with no translation entry for `code` is omitted: the interpreter refuses to evaluate an untranslated
-   * id, so listing it would advertise a function that cannot be called. A translation set to an empty string is not
-   * a missing entry — it falls back to the canonical id, so the function stays listed under its canonical name.
-   *
-   * @param {string} code - language code, e.g. `'enGB'`
-   *
-   * @throws [[ExpectedValueOfTypeError]] if any of its basic type argument is of wrong type
-   * @throws [[LanguageNotRegisteredError]] when the given language is not registered
-   *
-   * @example
-   * ```js
-   * // get the list of available functions, translated for enGB
-   * const functions = HyperFormula.getAvailableFunctions('enGB');
-   * ```
-   *
-   * @category Static Methods
-   */
-  public static getAvailableFunctions(code: string): FunctionListEntry[] {
-    validateArgToType(code, 'string', 'code')
-    return HyperFormula.buildAvailableFunctions(
-      FunctionRegistry.getListableFunctionIds(),
-      (id) => FunctionRegistry.getFunctionPlugin(id),
-      HyperFormula.getLanguage(code),
-    )
-  }
-
-  /**
-   * Returns the full metadata of a single function for a given language: the parameter list (with per-parameter
-   * optionality), the number of trailing parameters that repeat (`repeatLastArgs`), the category, a short
-   * description, and the documentation link (`documentationUrl`) and usage examples (`examples`) — every built-in
-   * authors both. Returns `undefined` when the function id is unknown, not registered, or has no translation entry
-   * for `code` (an untranslated id cannot be evaluated, so it is not described either, which keeps this method
-   * consistent with [[getAvailableFunctions]]).
-   *
-   * The static method resolves everything in the global registry: the built-in functions, their aliases, and the
-   * custom (user-registered) ones. An alias reports its target's metadata (including examples, which spell the
-   * target's name) under the alias id, with the target id exposed as `aliasOf`. A custom function has no catalogue
-   * entry, so it reports `category: 'Custom'`, no `shortDescription`, `documentationUrl` or `examples`, and
-   * positional parameter names (`Arg1`, `Arg2`, ...). A custom plugin registered over a built-in id is the
-   * exception: the catalogue is keyed by function id, so it reports that built-in's authored metadata alongside
-   * the parameter list of the implementation actually registered. Use the instance method
-   * [[getFunctionDetails]] for one engine's own registry, which differs from the global one when the instance was
-   * built with the `functionPlugins` configuration option.
-   *
-   * `canonicalName` is matched exactly, in two ways worth knowing:
-   * - It is **case-sensitive**, unlike formula syntax. `'SUMIF'` resolves; `'sumif'` and `'SumIf'` return
-   *   `undefined`, even though `=sumif(...)` evaluates.
-   * - It must be the **canonical (English) id, never a localized name**. `localizedName` is output only:
-   *   `getFunctionDetails('SUMIF', 'plPL')` reports `localizedName: 'SUMA.JEŻELI'`, but passing `'SUMA.JEŻELI'` back
-   *   in returns `undefined`. To look up an entry from [[getAvailableFunctions]], pass its `canonicalName`.
-   *
-   * @param {string} canonicalName - the language-independent function id, e.g. `'SUMIF'`
-   * @param {string} code - language code, e.g. `'enGB'`
-   *
-   * @throws [[ExpectedValueOfTypeError]] if any of its basic type argument is of wrong type
-   * @throws [[LanguageNotRegisteredError]] when the given language is not registered
-   *
-   * @example
-   * ```js
-   * // get the details of the SUMIF function, translated for enGB
-   * const details = HyperFormula.getFunctionDetails('SUMIF', 'enGB');
-   * ```
-   *
-   * @category Static Methods
-   */
-  public static getFunctionDetails(canonicalName: string, code: string): FunctionDetails | undefined {
-    validateArgToType(canonicalName, 'string', 'canonicalName')
-    validateArgToType(code, 'string', 'code')
-    // Validated before the registry lookup so an unregistered language throws for every function id, rather than
-    // only for the ids that reach a later exit path (an unknown or custom id used to return `undefined` instead).
-    const language = this.getLanguage(code)
-    const plugin = FunctionRegistry.getFunctionPlugin(canonicalName)
-    // Protected ids (VERSION, OFFSET) have no registered plugin by design (`getFunctionPlugin` always returns
-    // `undefined` for them), but the metadata API still describes them — resolved from the authored catalogue doc,
-    // so getFunctionDetails agrees with getAvailableFunctions. Anything else with no plugin is genuinely unknown.
-    // `buildFunctionDetailsFor` returns `undefined` for a protected id without a catalogue doc, so the list and the
-    // details stay consistent for those too.
-    if (plugin === undefined && !FunctionRegistry.functionIsProtected(canonicalName)) {
-      return undefined
-    }
-    // Every registered id is described, exactly as `FunctionRegistry.getListableFunctionIds` lists it, so the two
-    // tiers cannot disagree about which functions exist. `resolveFunctionMetadata` decides separately what the id
-    // is described with: the catalogue entry authored for it, or — for an id the catalogue does not cover — the
-    // implementation alone, reported as a custom function.
-    return HyperFormula.buildFunctionDetailsFor(canonicalName, plugin, language)
-  }
-
-  /**
    * Resolves the structural metadata and catalogue doc for a registered function id, following aliases to their
    * target. Returns `undefined` only when the id is not registered. The catalogue doc is attached whenever the
    * catalogue holds an entry for the resolved id, whichever plugin currently provides it: the catalogue is keyed by
    * id, not by implementation, so a user-registered plugin that shadows a built-in id inherits that built-in's
    * authored metadata. When the catalogue has no entry for the id, `doc` is `undefined`, only the structural
    * metadata is available, and the function is described as custom. Shared by the list and the details builders so
-   * they always agree. The `getPlugin` callback abstracts over the static and the instance registry.
+   * they always agree.
    *
    * A catalogue doc whose parameter count disagrees with the implementation is still returned, not withheld:
    * [[buildFunctionDetails]] resolves the disagreement in the implementation's favour, reporting its arguments
@@ -802,28 +700,27 @@ export class HyperFormula implements TypedEmitter {
   }
 
   /**
-   * Builds the function list for a set of registered ids. Documented functions use their catalogue entry; custom
-   * functions are listed with their name only. Sorted by localized name with `localeCompare`, so the order follows
-   * the host's collation rules, with the language-independent canonical name as a stable tiebreaker for entries
-   * that share a localized name.
+   * Builds the function list for every id registered in an engine's own registry. Documented functions use their
+   * catalogue entry; custom functions are listed with their name only. Sorted by localized name with
+   * `localeCompare`, so the order follows the host's collation rules, with the language-independent canonical name
+   * as a stable tiebreaker for entries that share a localized name.
    *
    * Takes the [[TranslationPackage]] rather than deriving it from a language code: an instance must describe its
    * functions under the package its own evaluator uses (`Config.translationPackage`), which is a snapshot taken
    * when the instance was built and can differ from whatever is registered globally for the same code today.
    * Deriving it here instead would let this method report a localized name the instance refuses to evaluate.
    *
-   * @param {string[]} functionIds - the registered ids to describe
-   * @param {(id: string) => FunctionPluginDefinition | undefined} getPlugin - resolves the plugin registered for an id
+   * @param {FunctionRegistry} functionRegistry - the engine's registry, the source of both the ids and their plugins
    * @param {TranslationPackage} language - the translation package to translate the names under
    */
-  private static buildAvailableFunctions(functionIds: string[], getPlugin: (id: string) => FunctionPluginDefinition | undefined, language: TranslationPackage): FunctionListEntry[] {
+  private static buildAvailableFunctions(functionRegistry: FunctionRegistry, language: TranslationPackage): FunctionListEntry[] {
     const translate = (id: string) => language.getMaybeFunctionTranslation(id)
-    return functionIds
+    return functionRegistry.getListableFunctionIds()
       // The interpreter refuses to evaluate ids the active language has no translation entry for
       // (FunctionRegistry.getFunction), so an untranslated function would be advertised but uncallable.
       .filter(id => language.isFunctionTranslated(id))
       .map(id => {
-        const resolved = HyperFormula.resolveFunctionMetadata(id, getPlugin(id))
+        const resolved = HyperFormula.resolveFunctionMetadata(id, functionRegistry.getFunctionPlugin(id))
         if (resolved === undefined) {
           return undefined
         }
@@ -839,16 +736,21 @@ export class HyperFormula implements TypedEmitter {
   }
 
   /**
-   * Builds the full details for a single registered id, or `undefined` when it is unknown/not registered.
-   * Documented functions use their catalogue entry; custom functions report their structural metadata only.
+   * Builds the full details for a single id registered in an engine's own registry, or `undefined` when it is
+   * unknown/not registered. Documented functions use their catalogue entry; custom functions report their
+   * structural metadata only.
+   *
+   * @param {string} functionId - the language-independent function id (canonical id or alias)
+   * @param {FunctionRegistry} functionRegistry - the engine's registry, which resolves the id to its plugin
+   * @param {TranslationPackage} language - the translation package to translate the names under
    */
-  private static buildFunctionDetailsFor(functionId: string, plugin: FunctionPluginDefinition | undefined, language: TranslationPackage): FunctionDetails | undefined {
+  private static buildFunctionDetailsFor(functionId: string, functionRegistry: FunctionRegistry, language: TranslationPackage): FunctionDetails | undefined {
     // Mirrors the filter in buildAvailableFunctions: an id the active language cannot evaluate
     // (no translation entry) gets no details either, so the list and the details always agree.
     if (!language.isFunctionTranslated(functionId)) {
       return undefined
     }
-    const resolved = HyperFormula.resolveFunctionMetadata(functionId, plugin)
+    const resolved = HyperFormula.resolveFunctionMetadata(functionId, functionRegistry.getFunctionPlugin(functionId))
     if (resolved === undefined) {
       return undefined
     }
@@ -4602,7 +4504,9 @@ export class HyperFormula implements TypedEmitter {
    * The list reflects this instance's own registry: the built-in functions and any custom (user-registered)
    * functions, plus their aliases. An alias is listed under its own id, borrowing its target's category and
    * description, with the target id exposed as `aliasOf`. Custom functions ship no catalogue entry, so their
-   * `category` is `'Custom'` and they carry no `shortDescription`.
+   * `category` is `'Custom'` and they carry no `shortDescription` — with one exception: the catalogue is keyed by
+   * function id, so a custom plugin registered *over* a built-in id inherits that id's entry and is listed with the
+   * built-in's category and description.
    *
    * A function with no translation entry for the configured language is omitted: the interpreter refuses to evaluate
    * an untranslated id, so listing it would advertise a function that cannot be called — in practice, a custom
@@ -4621,8 +4525,7 @@ export class HyperFormula implements TypedEmitter {
    */
   public getAvailableFunctions(): FunctionListEntry[] {
     return HyperFormula.buildAvailableFunctions(
-      this._functionRegistry.getListableFunctionIds(),
-      (id) => this._functionRegistry.getFunctionPlugin(id),
+      this._functionRegistry,
       // The instance's own package, the one its evaluator uses — not a fresh global lookup, which could describe
       // the functions under a package this instance never adopted.
       this._config.translationPackage,
@@ -4640,7 +4543,9 @@ export class HyperFormula implements TypedEmitter {
    * has no translation entry for the configured language (an untranslated id cannot be evaluated, so it is not
    * described either, which keeps this method consistent with [[getAvailableFunctions]]).
    * For a custom function, `category` is `'Custom'`, there is no `shortDescription`, `documentationUrl` or
-   * `examples`, and parameters are reported positionally (`Arg1`, `Arg2`, ...).
+   * `examples`, and parameters are reported positionally (`Arg1`, `Arg2`, ...). A custom plugin registered over a
+   * built-in id is the exception: the catalogue is keyed by function id, so it reports that built-in's authored
+   * metadata alongside the parameter list of the implementation actually registered.
    *
    * `canonicalName` is matched exactly, in two ways worth knowing:
    * - It is **case-sensitive**, unlike formula syntax. `'SUMIF'` resolves; `'sumif'` and `'SumIf'` return
@@ -4666,7 +4571,7 @@ export class HyperFormula implements TypedEmitter {
   public getFunctionDetails(canonicalName: string): FunctionDetails | undefined {
     validateArgToType(canonicalName, 'string', 'canonicalName')
     // The instance's own package, the one its evaluator uses — see getAvailableFunctions.
-    return HyperFormula.buildFunctionDetailsFor(canonicalName, this._functionRegistry.getFunctionPlugin(canonicalName), this._config.translationPackage)
+    return HyperFormula.buildFunctionDetailsFor(canonicalName, this._functionRegistry, this._config.translationPackage)
   }
 
   /**

--- a/src/interpreter/FunctionRegistry.ts
+++ b/src/interpreter/FunctionRegistry.ts
@@ -120,24 +120,6 @@ export class FunctionRegistry {
     return Array.from(new Set(this.plugins.values()).values())
   }
 
-  /**
-   * Returns the ids of all functions the function-metadata API (`getAvailableFunctions`/`getFunctionDetails`)
-   * should describe: everything globally registered — built-ins, their aliases, and custom functions registered
-   * under a brand-new id alike — plus the protected ids (e.g. `VERSION`, `OFFSET`), which are kept out of
-   * `this.plugins` so they can never be unregistered or shadowed but remain callable from a formula (HF-249).
-   *
-   * Callability is the whole rule: `registerFunctionPlugin` registers globally, so every id in this set can be
-   * used in a formula by any instance, and omitting one would hide a working function from a function picker.
-   * Whether a listed id is *described as* a built-in depends on whether a catalogue entry exists for that id.
-   *
-   * That set is exactly the one {@link getRegisteredFunctionIds} already answers, so it is delegated rather than
-   * recomputed: letting the two drift would make `getAvailableFunctions` and `getRegisteredFunctionNames` disagree
-   * about which functions exist.
-   */
-  public static getListableFunctionIds(): string[] {
-    return this.getRegisteredFunctionIds()
-  }
-
   public static getFunctionPlugin(functionId: string): Maybe<FunctionPluginDefinition> {
     if (this.functionIsProtected(functionId)) {
       return undefined
@@ -252,15 +234,18 @@ export class FunctionRegistry {
   }
 
   /**
-   * Returns the ids of all functions the instance-level function-metadata API should describe: every function
-   * registered in this instance (aliases and any custom/user-registered functions included), plus the protected
-   * ids (e.g. `VERSION`, `OFFSET`). `instancePlugins` already contains `VERSION` (the constructor loads any
-   * protected id that has a plugin, unprotected, so it can be executed), but not `OFFSET` (it has no plugin at
-   * all — it is transformed at parse time). Appending `FunctionRegistry._protectedPlugins`'s keys explicitly, the
-   * same way the static {@link FunctionRegistry.getListableFunctionIds} does, covers both uniformly instead of
-   * relying on the constructor's incidental loading; de-duplicated via `Set` because `VERSION` would otherwise be
-   * listed twice (once from `instancePlugins`, once from `_protectedPlugins`). A user can see these ids via
+   * Returns the ids of all functions the function-metadata API (`getAvailableFunctions`/`getFunctionDetails`)
+   * should describe: every function registered in this instance (aliases and any custom/user-registered functions
+   * included), plus the protected ids (e.g. `VERSION`, `OFFSET`). `instancePlugins` already contains `VERSION`
+   * (the constructor loads any protected id that has a plugin, unprotected, so it can be executed), but not
+   * `OFFSET` (it has no plugin at all — it is transformed at parse time). Appending
+   * `FunctionRegistry._protectedPlugins`'s keys explicitly covers both uniformly instead of relying on the
+   * constructor's incidental loading; de-duplicated via `Set` because `VERSION` would otherwise be listed twice
+   * (once from `instancePlugins`, once from `_protectedPlugins`). A user can see these ids via
    * `getAvailableFunctions`/`getFunctionDetails` even though they can never be unregistered (HF-249).
+   *
+   * Callability is the whole rule: omitting an id would hide a working function from a function picker. Whether a
+   * listed id is *described as* a built-in depends on whether a catalogue entry exists for that id.
    */
   public getListableFunctionIds(): string[] {
     return Array.from(new Set([...this.instancePlugins.keys(), ...FunctionRegistry._protectedPlugins.keys()]))


### PR DESCRIPTION
### Context

[HF-349](https://app.clickup.com/t/9015210959/HF-349) — a blocker for the 3.4.0 release, under [HF-307](https://app.clickup.com/t/9015210959/HF-307) (feature packages and add-ons), decision D2.

`getAvailableFunctions` and `getFunctionDetails` shipped in both a static and an instance form. License-based entitlement splits the two apart: an instance knows its license key, so it can answer for the engine the caller actually holds; a static method has no key to read, so it can only ever answer for the package as a whole. Only the instance answer is the one integrators need — the static one invites a function picker to advertise functions that then fail on evaluation, and nothing errors at integration time.

Both methods are unreleased, which is the only free moment to remove them.

**This PR removes the static variants. The function metadata API is instance-scoped only.**

Code removed as dead after that change:

- `FunctionRegistry.getListableFunctionIds` (static) — its only caller was the static `getAvailableFunctions`
- the `getPlugin` callback threaded through `buildAvailableFunctions` — it existed only to abstract over the static and the instance registry. Both private builders now take the engine's own `FunctionRegistry`, which also removes the possibility of ids and plugins being resolved from two different sources.

**Docs generator.** The built-in functions guide page is generated from this API, so `script/generate-builtin-functions-doc.ts` now builds an engine and reads the instance methods. It builds that engine with the `gpl-v3` license key — the fully-entitled one — so the published reference keeps documenting every built-in instead of narrowing to the tier of whichever key the build environment happens to supply. The ADR calls this out as a real risk introduced by the decision, so the key is named in the script rather than left to the environment, with the reasoning recorded there and in `docs/README.md`.

**Changelog.** The 3.4.0 entry that introduced these methods is amended (`(both static and instance)` → `instance methods`) rather than accompanied by a "Removed" note: nothing was ever released to remove, and announcing the removal of a method 3.4.0 never shipped would only confuse readers. Same edit in `docs/guide/release-notes.md`.

Tests live in the private repo — companion PR: handsontable/hyperformula-tests#29. Both target `release/3.4.0` and must land together.

The two JSDoc nuances the removed static docs carried (a custom plugin registered *over* a built-in id inherits that id's catalogue entry, in both the list and the details) were folded into the instance methods' JSDoc, so the generated API reference does not lose behaviour that is still tested.

### How did you test your changes?

- `npm run test:ci` with the private suite attached: **502/502 suites, 6180 tests passing**
- `npm run lint`: clean (exit 0, no errors)
- `npx tsc --noEmit`: clean
- `npm run bundle:typings`: succeeds; the emitted `HyperFormula.d.ts` exposes only the instance `getAvailableFunctions()` / `getFunctionDetails(canonicalName)`
- `npm run docs:generate-function-docs`: the generated `built-in-functions.md` is **byte-identical** to the one the static path produced (diffed before/after), 423 rows — matching the count `docs/.vuepress/config.js` prints on the page

Not run in this environment: `npm run test:browser`. Karma is configured for `ChromeHeadless` **and** `FirefoxHeadless`, and no Firefox is available here. The change is not environment-specific and the same specs pass under Jest.

### Types of changes
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [x] Change to the documentation

Marked breaking because the methods disappear from the public surface. In practice nothing released ever exposed them, so no published version is affected and no migration guide entry is needed.

### Related issues:
1. HF-349 — Static methods cannot read functions granted by license key
2. HF-307 — Implement feature packages and add-ons in HF (decision D2)
3. Companion test PR: handsontable/hyperformula-tests#29

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [ ] My change is compatible with Microsoft Excel.
- [ ] My change is compatible with Google Sheets.
- [x] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [x] My changes require a documentation update.
- [ ] My changes require a migration guide.

The three OpenDocument/Excel/Google Sheets boxes are left unticked as not applicable: this change touches no formula semantics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API removal (static metadata methods), though unreleased in 3.4.0; integrators must use an engine instance, which is intentional for upcoming license-gated function lists.
> 
> **Overview**
> **Removes the static** `getAvailableFunctions` **and** `getFunctionDetails` **API** so function metadata is only available on a `HyperFormula` instance (with language taken from that engine’s config). That aligns metadata with license key and per-instance `functionPlugins` / registry snapshots instead of the global registry.
> 
> Private list/detail builders now take the engine’s `FunctionRegistry` directly; static `FunctionRegistry.getListableFunctionIds` is dropped. Instance JSDoc picks up behaviour notes that lived on the removed static methods (registry snapshotting, custom plugins shadowing built-in ids).
> 
> The built-in functions doc generator builds an empty engine (`gpl-v3` license key, default registry) and calls the instance metadata methods. **CHANGELOG** and release notes for 3.4.0 are edited to describe **instance methods only** (no separate “Removed” entry for unreleased static APIs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fe2aaf38d0039add264cf8067239de340940bbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->