### PR TITLE
HF-307: entitlement model, capability registry, gate B (PR 1/4)

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -20,11 +20,24 @@ import {checkLicenseKeyValidity, LicenseKeyValidityState} from './helpers/licens
 import {HyperFormula} from './HyperFormula'
 import {TranslationPackage} from './i18n'
 import {FunctionPluginDefinition} from './interpreter'
+import {CapabilityRegistry, ResolvedCapabilities} from './license/CapabilityRegistry'
+import {unrestrictedEntitlement} from './license/LicenseEntitlement'
 import {Maybe} from './Maybe'
 import {ParserConfig} from './parser/ParserConfig'
 import {ConfigParams, ConfigParamsList} from './ConfigParams'
 
-const privatePool: WeakMap<Config, { licenseKeyValidityState: LicenseKeyValidityState }> = new WeakMap()
+/**
+ * The license-derived state kept off the public `ConfigParams` surface — see
+ * {@link Config.licenseCapabilities}.
+ */
+interface LicensePrivateState {
+  licenseKeyValidityState: LicenseKeyValidityState,
+  licenseCapabilities: ResolvedCapabilities,
+  isLicenseGateActive: boolean,
+  capabilityRegistry: CapabilityRegistry,
+}
+
+const privatePool: WeakMap<Config, LicensePrivateState> = new WeakMap()
 
 export class Config implements ConfigParams, ParserConfig {
 
@@ -266,8 +279,19 @@ export class Config implements ConfigParams, ParserConfig {
     validateNumberToBeAtLeast(this.maxColumns, 'maxColumns', 1)
     this.context = context
 
+    const licenseKeyValidityState = checkLicenseKeyValidity(this.licenseKey)
+    const capabilityRegistry = new CapabilityRegistry()
+    // PR 1 (HF-307) ships the gate infrastructure without a real license-key payload adapter —
+    // that lands in PR 3 as src/license/payloadAdapter.ts. Until then every entitlement resolves
+    // as unrestricted, so isLicenseGateActive below reduces to today's licenseKeyValidityState
+    // check and gate B in the interpreter never actually restricts a function.
+    const licenseCapabilities = capabilityRegistry.resolve(unrestrictedEntitlement())
+
     privatePool.set(this, {
-      licenseKeyValidityState: checkLicenseKeyValidity(this.licenseKey)
+      licenseKeyValidityState,
+      licenseCapabilities,
+      isLicenseGateActive: licenseKeyValidityState !== LicenseKeyValidityState.VALID || !licenseCapabilities.unrestricted,
+      capabilityRegistry,
     })
 
     configCheckIfParametersNotInConflict(
@@ -305,7 +329,40 @@ export class Config implements ConfigParams, ParserConfig {
    * @internal
    */
   public get licenseKeyValidityState(): LicenseKeyValidityState {
-    return (privatePool.get(this) as Config).licenseKeyValidityState
+    return (privatePool.get(this) as LicensePrivateState).licenseKeyValidityState
+  }
+
+  /**
+   * The functions and features this config's license entitles it to, already resolved from
+   * whatever tokens the license key carries. Proxied to its private counterpart for the same
+   * reason as {@link licenseKeyValidityState}: it must never become part of {@link getConfig}.
+   *
+   * @internal
+   */
+  public get licenseCapabilities(): ResolvedCapabilities {
+    return (privatePool.get(this) as LicensePrivateState).licenseCapabilities
+  }
+
+  /**
+   * Whether gate B (the entitlement check in the interpreter) needs to run at all for this
+   * config. `false` — the common case, for `gpl-v3`, legacy keys, and an unrestricted typed
+   * key — is a single boolean read, cheaper than the string-enum comparison it replaces.
+   *
+   * @internal
+   */
+  public get isLicenseGateActive(): boolean {
+    return (privatePool.get(this) as LicensePrivateState).isLicenseGateActive
+  }
+
+  /**
+   * The registry used to resolve this config's entitlement into {@link licenseCapabilities}.
+   * Exposed so the interpreter can tell a custom, instance-registered function apart from a
+   * built-in outside the capability table without constructing a second registry.
+   *
+   * @internal
+   */
+  public get capabilityRegistry(): CapabilityRegistry {
+    return (privatePool.get(this) as LicensePrivateState).capabilityRegistry
   }
 
   public getConfig(): ConfigParams {

--- a/src/error-message.ts
+++ b/src/error-message.ts
@@ -77,4 +77,5 @@ export class ErrorMessage {
   public static FunctionName = (arg: string) => `Function name ${arg} not recognized.`
   public static NamedExpressionName = (arg: string) => `Named expression ${arg} not recognized.`
   public static LicenseKey = (arg: string) => `License key is ${arg}.`
+  public static LicenseCapability = (functionName: string) => `Function ${functionName} is not included in your license.`
 }

--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -13,6 +13,7 @@ import {DependencyGraph} from '../DependencyGraph'
 import {FormulaVertex} from '../DependencyGraph/FormulaVertex'
 import {ErrorMessage} from '../error-message'
 import {LicenseKeyValidityState} from '../helpers/licenseKeyValidator'
+import {allowsFunction} from '../license/CapabilityRegistry'
 import {ColumnSearchStrategy} from '../Lookup/SearchStrategy'
 import {Maybe} from '../Maybe'
 import {NamedExpressions} from '../NamedExpressions'
@@ -59,6 +60,17 @@ export class Interpreter {
   ) {
     this.functionRegistry.initializePlugins(this)
     this.criterionBuilder = new CriterionBuilder(config)
+  }
+
+  /**
+   * Resolves a function id to the name it is covered by in the capability table. A function
+   * registered purely as an alias of another one (`plugin.aliases`) must gate identically to
+   * its canonical name — otherwise calling a gated function through its alias would silently
+   * bypass the entitlement check.
+   */
+  private canonicalFunctionId(functionId: string): string {
+    const plugin = this.functionRegistry.getFunctionPlugin(functionId)
+    return plugin?.aliases?.[functionId] ?? functionId
   }
 
   public evaluateAst(ast: Ast, state: InterpreterState): InterpreterValue {
@@ -177,8 +189,17 @@ export class Interpreter {
         return this.unaryRangeWrapper(this.percentOp, result, state)
       }
       case AstNodeType.FUNCTION_CALL: {
-        if (this.config.licenseKeyValidityState !== LicenseKeyValidityState.VALID && !FunctionRegistry.functionIsProtected(ast.procedureName)) {
-          return new CellError(ErrorType.LIC, ErrorMessage.LicenseKey(this.config.licenseKeyValidityState))
+        if (this.config.isLicenseGateActive && !FunctionRegistry.functionIsProtected(ast.procedureName)) {
+          const validityState = this.config.licenseKeyValidityState
+          if (validityState !== LicenseKeyValidityState.VALID) {
+            return new CellError(ErrorType.LIC, ErrorMessage.LicenseKey(validityState))
+          }
+
+          const canonicalId = this.canonicalFunctionId(ast.procedureName)
+          if (this.config.capabilityRegistry.capabilityOf(canonicalId) !== undefined
+              && !allowsFunction(this.config.licenseCapabilities, canonicalId)) {
+            return new CellError(ErrorType.LIC, ErrorMessage.LicenseCapability(ast.procedureName))
+          }
         }
         const pluginFunction = this.functionRegistry.getFunction(ast.procedureName)
         if (pluginFunction !== undefined) {

--- a/src/license/CapabilityRegistry.ts
+++ b/src/license/CapabilityRegistry.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright (c) 2025 Handsoncode. All rights reserved.
+ */
+
+import {FeatureId, LicenseEntitlement} from './LicenseEntitlement'
+import {CAPABILITY_TABLE, CapabilityGrant, refreshCoreGrant} from './capabilities'
+
+/**
+ * The capabilities a resolved {@link LicenseEntitlement} grants, ready for gate B (the
+ * interpreter) and PR 2's `ensureCapability` to query through {@link allowsFunction} and
+ * {@link allowsFeature}.
+ */
+export interface ResolvedCapabilities {
+  /** `true` short-circuits both {@link allowsFunction} and {@link allowsFeature} to `true`. */
+  unrestricted: boolean,
+  functions: ReadonlySet<string>,
+  features: ReadonlySet<FeatureId>,
+}
+
+/**
+ * Expands a {@link LicenseEntitlement}'s capability tokens against a table of
+ * {@link CapabilityGrant}s into the concrete functions and features they grant, and answers
+ * which token, if any, covers a given function id.
+ */
+export class CapabilityRegistry {
+  private readonly table: ReadonlyMap<string, CapabilityGrant>
+  private readonly reverseIndex: ReadonlyMap<string, string>
+
+  /**
+   * @param {ReadonlyMap<string, CapabilityGrant>} [table] - capability table to resolve
+   * against. Omit to use the production {@link CAPABILITY_TABLE}; tests inject their own so the
+   * suite does not depend on its placeholder content.
+   */
+  constructor(table?: ReadonlyMap<string, CapabilityGrant>) {
+    if (table === undefined) {
+      refreshCoreGrant()
+    }
+    this.table = table ?? CAPABILITY_TABLE
+    this.reverseIndex = CapabilityRegistry.buildReverseIndex(this.table)
+  }
+
+  /**
+   * Inverts a capability table from token → grant into function id → token, so
+   * {@link capabilityOf} is a single lookup instead of a scan. The first token that lists a
+   * given function id wins, in table iteration order.
+   *
+   * @param {ReadonlyMap<string, CapabilityGrant>} table - the table to invert
+   */
+  private static buildReverseIndex(table: ReadonlyMap<string, CapabilityGrant>): ReadonlyMap<string, string> {
+    const index = new Map<string, string>()
+    for (const [token, grant] of table) {
+      for (const functionId of grant.functions) {
+        if (!index.has(functionId)) {
+          index.set(functionId, token)
+        }
+      }
+    }
+    return index
+  }
+
+  /**
+   * Expands an entitlement's capability tokens into the concrete functions and features they
+   * grant. An `unrestricted` entitlement short-circuits to an unrestricted result without
+   * consulting the table at all. Expansion through `implies` is transitive and cycle-safe (a
+   * visited set guards against a token implying itself, directly or through others); an
+   * unrecognized token is skipped without an error.
+   *
+   * @param {LicenseEntitlement} entitlement - the entitlement to resolve, e.g. one built by
+   * hand in a test or produced by PR 3's license-key payload adapter
+   */
+  public resolve(entitlement: LicenseEntitlement): ResolvedCapabilities {
+    if (entitlement.unrestricted) {
+      return {unrestricted: true, functions: new Set<string>(), features: new Set<FeatureId>()}
+    }
+
+    const functions = new Set<string>()
+    const features = new Set<FeatureId>()
+    const visited = new Set<string>()
+    const queue = [...entitlement.capabilities]
+
+    while (queue.length > 0) {
+      const token = queue.shift() as string
+      if (visited.has(token)) {
+        continue
+      }
+      visited.add(token)
+
+      const grant = this.table.get(token)
+      if (grant === undefined) {
+        continue
+      }
+      grant.functions.forEach((functionId) => functions.add(functionId))
+      grant.features.forEach((feature) => features.add(feature))
+      grant.implies?.forEach((impliedToken) => queue.push(impliedToken))
+    }
+
+    return {unrestricted: false, functions, features}
+  }
+
+  /**
+   * Returns the capability token a function id is covered by, or `undefined` if this registry's
+   * table does not cover it. The completeness invariant in
+   * `unit/license/capability-registry.spec.ts` guarantees every built-in registered in the
+   * static function registry is covered by the table, the core token, or the protected list —
+   * so `undefined` for a function known to the current instance's function registry means it is
+   * a custom, instance-registered function rather than an unlisted built-in.
+   */
+  public capabilityOf(functionId: string): string | undefined {
+    return this.reverseIndex.get(functionId)
+  }
+}
+
+/**
+ * Whether a resolved entitlement allows calling the given function.
+ */
+export function allowsFunction(resolved: ResolvedCapabilities, functionId: string): boolean {
+  return resolved.unrestricted || resolved.functions.has(functionId)
+}
+
+/**
+ * Whether a resolved entitlement allows using the given feature area of the public API.
+ */
+export function allowsFeature(resolved: ResolvedCapabilities, feature: FeatureId): boolean {
+  return resolved.unrestricted || resolved.features.has(feature)
+}

--- a/src/license/LicenseEntitlement.ts
+++ b/src/license/LicenseEntitlement.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright (c) 2025 Handsoncode. All rights reserved.
+ */
+
+/**
+ * Identifies a feature area of the public API that a license entitlement can gate.
+ *
+ * `CustomFunctions` and `ImportExport` are reserved vocabulary: they exist so a license payload
+ * is free to carry them, but no capability grant in this release maps to either of them yet.
+ * HF-307 decision D1 drops function-registration gating (and the `CustomFunctions` grant) from
+ * this release; `ImportExport` has no gated methods until HF-107 lands.
+ */
+export const enum FeatureId {
+  NamedExpressions = 'named_expressions',
+  Clipboard = 'clipboard',
+  Crud = 'crud',
+  UndoRedo = 'undo_redo',
+  Batching = 'batching',
+  CustomFunctions = 'custom_functions',
+  ImportExport = 'import_export',
+}
+
+/**
+ * Describes when a license entitlement stops being valid.
+ *
+ * Per key-spec rev 3 §1.3, `date` is kept as a calendar string rather than an epoch, and is
+ * INCLUSIVE of its last valid day:
+ * - `kind === 'usage'`: `date` is compared against the client's LOCAL calendar date — deliberately
+ *   not UTC, the date means the date, wherever the customer is.
+ * - `kind === 'release'`: `date` is compared LEXICOGRAPHICALLY, as text, against the library's
+ *   build date; no clock is involved.
+ * - `kind === 'none'`: the entitlement does not expire.
+ */
+export interface LicenseExpiry {
+  kind: 'usage' | 'release' | 'none',
+  /** ISO 'YYYY-MM-DD', or `null` when `kind` is `'none'`. */
+  date: string | null,
+  noticeDays: number,
+  graceDays: number,
+}
+
+/**
+ * The resolved set of things a license grants, independent of how the underlying license key
+ * was parsed.
+ *
+ * This is the contract every later HF-307 task consumes: {@link CapabilityRegistry} turns it
+ * into a `ResolvedCapabilities` set, gate B in the interpreter reads that set, and PR 2's
+ * `ensureCapability` reads it for the public API. Until PR 3 lands the real license-key payload
+ * adapter, instances of this are built by hand in tests rather than read from a real key.
+ */
+export interface LicenseEntitlement {
+  /** `true` for every key this library fully understands today (`gpl-v3`, legacy keys). */
+  unrestricted: boolean,
+  /** Capability tokens this entitlement grants, recognized by this library version. */
+  capabilities: ReadonlySet<string>,
+  /**
+   * Tokens present on the license payload that this library version does not recognize.
+   * Kept for diagnostics and tests; per HF-307 decision D3 nothing public reads this field — an
+   * unrecognized token never grants a capability, and it does so silently.
+   */
+  unrecognizedCapabilities: readonly string[],
+  expiry: LicenseExpiry,
+  /**
+   * When `true`, resolving this entitlement must not print a console message of any kind.
+   * HF-307 decision D3 (fail-closed, silent): a typed key with no recognized token resolves
+   * like an explicit `capabilities: []` — core and protected functions only, without a message,
+   * a warning, or a diagnostics getter.
+   */
+  silent: boolean,
+  isTrial: boolean,
+}
+
+/**
+ * The unrestricted entitlement: legacy keys and `gpl-v3` resolve to this today.
+ *
+ * HF-307 decision D3 (fail-closed, silent) means a typed key whose tokens this library version
+ * does not recognize at all no longer maps here — it resolves to an entitlement with an empty,
+ * silent capability set instead of falling back to unrestricted access. Do not reuse this
+ * function for that case.
+ */
+export function unrestrictedEntitlement(): LicenseEntitlement {
+  return {
+    unrestricted: true,
+    capabilities: new Set<string>(),
+    unrecognizedCapabilities: [],
+    expiry: {kind: 'none', date: null, noticeDays: 0, graceDays: 0},
+    silent: false,
+    isTrial: false,
+  }
+}

--- a/src/license/capabilities.ts
+++ b/src/license/capabilities.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright (c) 2025 Handsoncode. All rights reserved.
+ */
+
+import {FunctionRegistry} from '../interpreter/FunctionRegistry'
+import {FeatureId} from './LicenseEntitlement'
+
+/** The single capability token every built-in currently falls under, see {@link CAPABILITY_TABLE}. */
+export const CORE_TOKEN = 'core'
+
+/**
+ * Describes what a capability token grants: a set of function ids, a set of {@link FeatureId}
+ * values, and optionally other tokens it implies. `implies` is expanded recursively by
+ * `CapabilityRegistry.resolve`, not by anything in this file.
+ */
+export interface CapabilityGrant {
+  functions: string[],
+  features: FeatureId[],
+  implies?: string[],
+}
+
+const coreGrant: CapabilityGrant = {
+  functions: [],
+  features: [FeatureId.NamedExpressions, FeatureId.Clipboard, FeatureId.Crud, FeatureId.UndoRedo, FeatureId.Batching],
+}
+
+/**
+ * The production capability table.
+ *
+ * Placeholder content pending HF-331/HF-329 (the real per-package token vocabulary): every
+ * built-in function, plus the features already wired for gating in PR 2, fall under the single
+ * {@link CORE_TOKEN}. `FeatureId.CustomFunctions` and `FeatureId.ImportExport` are deliberately
+ * absent — reserved vocabulary with no grant yet (HF-307 decision D1; HF-107 for ImportExport).
+ *
+ * `coreGrant.functions` starts empty and is refreshed on every {@link refreshCoreGrant} call
+ * rather than populated once here: `src/index.ts` registers HyperFormula's built-in plugins as a
+ * side effect of being imported, and it does so AFTER `Config` and `Interpreter` — and so this
+ * module — have already been fully evaluated. Reading the function registry at module-load time
+ * would capture an empty registry.
+ */
+export const CAPABILITY_TABLE: ReadonlyMap<string, CapabilityGrant> = new Map([[CORE_TOKEN, coreGrant]])
+
+/**
+ * Refreshes the placeholder `core` grant with every function currently in the static function
+ * registry. Called from `CapabilityRegistry`'s constructor every time it is constructed without
+ * an explicit table — not just the first time: the static registry can change after the first
+ * engine is built (`HyperFormula.registerFunctionPlugin`/`unregisterFunctionPlugin` are public,
+ * documented APIs), and a one-time snapshot would silently go stale for every engine built
+ * afterward. Cheap (a single array copy from an existing map's keys) and only ever runs once per
+ * `Config`/engine construction, never on the per-formula hot path, so re-running it every time
+ * costs nothing worth guarding against with memoization.
+ */
+export function refreshCoreGrant(): void {
+  coreGrant.functions = FunctionRegistry.getRegisteredFunctionIds()
+}


### PR DESCRIPTION
### Context

HF-307 (feature packages / entitlement gating). This is PR 1 of 4: the entitlement model, the capability registry, and gate B in the interpreter. It only touches `src/`, has zero dependency on the (not-yet-shared) license-key package, and does not change behaviour for any key this library recognizes today (`gpl-v3`, legacy keys) — gate A (existing key-validity check) is untouched.

New:
- `src/license/LicenseEntitlement.ts` — `FeatureId`, `LicenseExpiry`, `LicenseEntitlement`, `unrestrictedEntitlement()`
- `src/license/capabilities.ts` — `CapabilityGrant`, `CAPABILITY_TABLE` (placeholder: every built-in under a single `core` token, refreshed from the static function registry on every `CapabilityRegistry` construction — see the comment on why it can't be built eagerly at module load)
- `src/license/CapabilityRegistry.ts` — `resolve()` (transitive, cycle-safe `implies` expansion), `capabilityOf()`, `allowsFunction()`, `allowsFeature()`

Modified:
- `src/Config.ts` — license-derived state added to the existing private pool, never exposed through `getConfig()`
- `src/interpreter/Interpreter.ts` — gate B added after gate A in the `FUNCTION_CALL` case, with a custom-function exemption (a function not covered by the capability table is treated as instance-registered/custom, not gated) and alias canonicalization (an alias must gate identically to its canonical function name)
- `src/error-message.ts` — `ErrorMessage.LicenseCapability`

This PR ships without a real license-key payload adapter (that's a later PR), so `Config` always resolves an unrestricted entitlement today — gate B is a correct, independently-testable no-op in production until that adapter lands. `FeatureId.CustomFunctions` is kept in the enum as reserved vocabulary (no grant maps to it this release) per team decision to drop function-registration gating from this pass; happy to remove it instead if reviewers prefer.

### How did you test your changes?

- `tsc --noEmit` and `tsc -p tsconfig.test.json`: clean.
- `eslint` on all new/changed files: clean.
- `test/smoke.spec.ts`: passes.
- Manual verification against the built engine (not committed, ts-node scratch scripts): `gpl-v3` and missing/invalid-key behaviour unchanged (gate A untouched, exact same `#LIC!` messages); `getConfig()` does not expose the new license-derived state; a function outside a restricted entitlement's granted set returns `#LIC!` with the new message while a function inside it computes normally; `VERSION`/`OFFSET` (protected) bypass the gate regardless of restriction; a custom function (`config.functionPlugins`) is exempt from gate B; calling a gated built-in through an alias (e.g. `VAR` vs. canonical `VAR.S`) gates identically to the canonical name, not the alias string; `CapabilityRegistry.resolve()` handles transitive `implies`, cycles, and unknown tokens correctly.
**Update:** private test suite pushed — [hyperformula-tests#30](https://github.com/handsontable/hyperformula-tests/pull/30) (`unit/license/{entitlement,capability-registry,config-wiring}.spec.ts` + a gate-B section appended to `unit/licence.spec.ts`, the 2 existing cases untouched). Against the paired branch: the new license specs pass, and the **full existing suite (505 suites / 6204 tests, 0 failures)** is unaffected. CI on this PR now runs the real suite (pushed directly here rather than from a fork, so the private-repo checkout has secrets access) — `build`/`lint`/`unit-tests`/`browser-tests`/`Test performance`/`CodeQL`/audit/Snyk all pass.

**Task 1.5 benchmark**, from this PR's own CI run (`Test performance` job, base `61ead730` vs head `0a966e35`):

```
                                     testName |    base |    head |  change
---------------------------------------------------------------------------
                                      Sheet A |  499.81 |  501.66 |  +0.37%
                                      Sheet B |  156.27 |  167.13 |  +6.95%
                                      Sheet T |  138.85 |  147.87 |  +6.50%
                                Column ranges |  469.57 |  485.16 |  +3.32%
                                Sorted lookup | 14182.7 | 14444.5 |  +1.85%
Sheet A:  change value, add/remove row/column |   15.32 |   17.05 | +11.29%
 Sheet B: change value, add/remove row/column |  132.54 |  139.87 |  +5.53%
                   Column ranges - add column |  147.38 |  156.86 |  +6.43%
                Column ranges - without batch |  459.94 |  464.95 |  +1.09%
                        Column ranges - batch |  114.68 |  112.74 |  -1.69%
```

Reporting this as-is rather than smoothing it over: Sheet A (the highest-resolution signal) is flat (+0.37%), but several rows show a consistent single-digit-percent slowdown on this one run, on shared GitHub Actions runners rather than the codespace the spike's own noise-floor numbers were calibrated against. I have not repeated the run to separate signal from noise — happy to re-run `Test performance` a second time before merge if reviewers want more confidence than a single sample gives. The structural claim I *can* stand behind: the common path (`isLicenseGateActive === false`, checked before gate B does anything) is one boolean read replacing today's string-enum comparison, so there's no new work on the hot path for `gpl-v3`/legacy keys — that part is a code-inspection fact, not a benchmark claim.

Codecov: patch coverage is 58.1% (`CapabilityRegistry.ts` 48.7%, `Interpreter.ts` 41.7%, `Config.ts` 71.4%) and project coverage -0.19%, both **still red**. This is checked against `develop`, but the new private tests exercise the paired branch, not this diff directly through Codecov's own accounting — worth a look before merge, though the "full suite green" result above is the stronger correctness signal.

### Types of changes
- [ ] Breaking change
- [x] New feature or improvement
- [ ] Bug fix
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Related issues:
1. HF-307 (internal tracker; no public GitHub issue for this one)

### Checklist:
- [x] I have reviewed the guidelines about Contributing to HyperFormula and I confirm that my code follows the code style of this project.
- [ ] I have signed the Contributor License Agreement. *(please confirm/attach on your end — I can't verify this from here)*
- [ ] My change is compliant with the OpenDocument standard. *(N/A — no worksheet function behaviour changes in this PR)*
- [ ] My change is compatible with Microsoft Excel. *(N/A — same reason)*
- [ ] My change is compatible with Google Sheets. *(N/A — same reason)*
- [ ] I described my changes in the CHANGELOG.md file. *(intentionally not done — internal-only change, no user-visible behaviour yet; a CHANGELOG entry lands with the PR that actually activates gate B for customers)*
- [ ] My changes require a documentation update. *(no — nothing user-visible yet)*
- [ ] My changes require a migration guide. *(no)*

**Ready for review.** The paragraph that used to sit here said this was opening as a draft pending the private suite, the benchmark and the `FeatureId.CustomFunctions` question — all three are resolved: the suite is pushed (hyperformula-tests#30), the benchmark ran, and Kuba settled the token with decision D1 (dropped from this release, kept as reserved vocabulary).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the per-formula `FUNCTION_CALL` path and license enforcement, though the common unrestricted path is a single boolean skip; real customer impact waits on the payload adapter in a follow-up PR.
> 
> **Overview**
> Introduces the **HF-307 license entitlement infrastructure** (PR 1 of 4): entitlement types, a capability table/registry, and a second interpreter gate on function calls—without wiring real license-key payloads yet.
> 
> **New `src/license/` modules** define `LicenseEntitlement` / `FeatureId`, a placeholder `CAPABILITY_TABLE` (all built-ins under a `core` token, refreshed from the static function registry at `CapabilityRegistry` construction), and `CapabilityRegistry.resolve()` with transitive `implies` handling plus `allowsFunction` / `allowsFeature`.
> 
> **`Config`** stores license-derived state in its private pool (`licenseCapabilities`, `isLicenseGateActive`, `capabilityRegistry`) and today always resolves **`unrestrictedEntitlement()`**, so production behavior for recognized keys stays the same until a later payload adapter lands.
> 
> **`Interpreter`** replaces the single invalid-key check with **`isLicenseGateActive`**: still enforces key validity (gate A), then optionally blocks built-ins not covered by resolved capabilities with **`ErrorMessage.LicenseCapability`**, with **alias canonicalization** and an exemption for functions not listed in the capability table (treated as custom/instance-registered).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8db1a21ccba13883097956d7476214d121581a5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

