### PR TITLE
Feature/choosecols function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added the `CHOOSECOLS` dynamic-array function.
+
 ## [3.4.0] - 2026-08-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Added the `CHOOSECOLS` dynamic-array function. [#1734](https://github.com/handsontable/hyperformula/pull/1734)
+
 ### Fixed
 
 - Fixed the `AVERAGEIF` function returning a division-by-zero error when the calculated average was `0`. [#1733](https://github.com/handsontable/hyperformula/pull/1733)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Added the `CHOOSECOLS` dynamic-array function.
+- Added the `CHOOSECOLS` dynamic-array function. [#1734](https://github.com/handsontable/hyperformula/pull/1734)
 
 ## [3.4.0] - 2026-08-10
 

--- a/docs/guide/known-limitations.md
+++ b/docs/guide/known-limitations.md
@@ -51,6 +51,14 @@ a circular reference.
 
 * Ordering (including mixed types, empty cells, and text collation) follows HyperFormula's own comparison rules, which honor the `caseSensitive` and `accentSensitive` configuration options. Numbers sort before text, and text before logical values.
 
+### CHOOSECOLS function
+
+* Column indexes must be supplied as separate scalar arguments. Passing multiple indexes through an array or range argument is not supported.
+
+* A whole-column source produces an unbounded-height result, which HyperFormula cannot allocate as a direct spill. Such a formula returns `#VALUE!`; finite-height sources are supported.
+
+* HyperFormula reserves a dynamic array's predicted spill range before evaluating the formula. If that range is blocked, a runtime error in a source or non-literal column-index expression can therefore be reported as `#SPILL!`. Errors in literal column indexes are detected before spill allocation.
+
 ### OFFSET function
 
 HyperFormula resolves the OFFSET function at parse time rather than during evaluation. The parser inspects the arguments and rewrites the expression into a plain cell reference or range. This keeps the dependency graph accurate but imposes several restrictions.

--- a/docs/guide/known-limitations.md
+++ b/docs/guide/known-limitations.md
@@ -55,7 +55,7 @@ a circular reference.
 
 * Column indexes must be supplied as separate scalar arguments. Passing multiple indexes through an array or range argument is not supported.
 
-* A whole-column source produces an unbounded-height result, which HyperFormula cannot allocate as a direct spill. Such a formula returns `#VALUE!`; if the source sheet has no populated rows, it returns `#N/A` because the effective source range is empty. Finite-height sources are supported.
+* A same-sheet whole-column source can spill when the formula is in the first row. Cross-sheet whole-column sources and same-sheet formulas below the first row return `#SPILL!` because HyperFormula cannot reserve their unbounded result range. An empty cross-sheet source returns `#N/A` because its effective source range is empty. Finite-height sources are supported.
 
 * HyperFormula reserves a dynamic array's predicted spill range before evaluating the formula. If that range is blocked, a runtime error in a source or non-literal column-index expression can therefore be reported as `#SPILL!`. Errors in literal column indexes are detected before spill allocation.
 

--- a/docs/guide/known-limitations.md
+++ b/docs/guide/known-limitations.md
@@ -55,7 +55,7 @@ a circular reference.
 
 * Column indexes must be supplied as separate scalar arguments. Passing multiple indexes through an array or range argument is not supported.
 
-* A same-sheet whole-column source can spill when the formula is in the first row. Cross-sheet whole-column sources and same-sheet formulas below the first row return `#SPILL!` because HyperFormula cannot reserve their unbounded result range. An empty cross-sheet source returns `#N/A` because its effective source range is empty. Finite-height sources are supported.
+* A whole-column source produces an unbounded-height result, which HyperFormula cannot allocate as a direct spill. Such a formula returns `#VALUE!`; if the source sheet has no populated rows, it returns `#N/A` because the effective source range is empty. Finite-height sources are supported.
 
 * HyperFormula reserves a dynamic array's predicted spill range before evaluating the formula. If that range is blocked, a runtime error in a source or non-literal column-index expression can therefore be reported as `#SPILL!`. Errors in literal column indexes are detected before spill allocation.
 

--- a/docs/guide/known-limitations.md
+++ b/docs/guide/known-limitations.md
@@ -55,7 +55,7 @@ a circular reference.
 
 * Column indexes must be supplied as separate scalar arguments. Passing multiple indexes through an array or range argument is not supported.
 
-* A whole-column source produces an unbounded-height result, which HyperFormula cannot allocate as a direct spill. Such a formula returns `#VALUE!`; if the source sheet has no populated rows, it returns `#N/A` because the effective source range is empty. Finite-height sources are supported.
+* A whole-column source can spill when the formula is in the first row, regardless of whether the source is on the same sheet. A formula below the first row returns `#SPILL!` because its result would extend beyond the worksheet edge. An empty source returns `#N/A` because its effective range is empty. Finite-height sources are supported.
 
 * HyperFormula reserves a dynamic array's predicted spill range before evaluating the formula. If that range is blocked, a runtime error in a source or non-literal column-index expression can therefore be reported as `#SPILL!`. Errors in literal column indexes are detected before spill allocation.
 

--- a/docs/guide/known-limitations.md
+++ b/docs/guide/known-limitations.md
@@ -55,7 +55,7 @@ a circular reference.
 
 * Column indexes must be supplied as separate scalar arguments. Passing multiple indexes through an array or range argument is not supported.
 
-* A whole-column source produces an unbounded-height result, which HyperFormula cannot allocate as a direct spill. Such a formula returns `#VALUE!`; finite-height sources are supported.
+* A whole-column source produces an unbounded-height result, which HyperFormula cannot allocate as a direct spill. Such a formula returns `#VALUE!`; if the source sheet has no populated rows, it returns `#N/A` because the effective source range is empty. Finite-height sources are supported.
 
 * HyperFormula reserves a dynamic array's predicted spill range before evaluating the formula. If that range is blocked, a runtime error in a source or non-literal column-index expression can therefore be reported as `#SPILL!`. Errors in literal column indexes are detected before spill allocation.
 

--- a/docs/guide/list-of-differences.md
+++ b/docs/guide/list-of-differences.md
@@ -106,7 +106,7 @@ To remove the differences, create [custom implementations](custom-functions.md) 
 | NORMSDIST     | =NORMSDIST(0, TRUE())                                          |          0.5 |  Wrong number |    Wrong number |
 | ADDRESS       | =ADDRESS(1,1,4, TRUE(), "")                                    |          !A1 |         ''!A1 |             !A1 |
 | SEQUENCE      | =SEQUENCE(0)                                                   |        VALUE |           N/A |           CALC  |
-| CHOOSECOLS    | =CHOOSECOLS(Data!A:A, 1)                                      |        VALUE | Spills the whole column when space is available. | Spills the whole column when space is available. |
+| CHOOSECOLS    | =CHOOSECOLS(Data!A:A, 1)                                      | Spills the whole column from row 1; returns SPILL below row 1. | Spills the whole column when space is available. | Spills the whole column from row 1; returns SPILL below row 1. |
 | INT           | =INT(-8.9)                                                     |           -8 |            -9 |              -9 |
 | MOD           | =MOD(-10, 3)                                                   |           -1 |             2 |               2 |
 | ISEVEN        | =ISEVEN(2.5)                                                   |        FALSE |          TRUE |            TRUE |

--- a/docs/guide/list-of-differences.md
+++ b/docs/guide/list-of-differences.md
@@ -106,7 +106,7 @@ To remove the differences, create [custom implementations](custom-functions.md) 
 | NORMSDIST     | =NORMSDIST(0, TRUE())                                          |          0.5 |  Wrong number |    Wrong number |
 | ADDRESS       | =ADDRESS(1,1,4, TRUE(), "")                                    |          !A1 |         ''!A1 |             !A1 |
 | SEQUENCE      | =SEQUENCE(0)                                                   |        VALUE |           N/A |           CALC  |
-| CHOOSECOLS    | =CHOOSECOLS(Data!A:A, 1)                                      |        VALUE | Spills the whole column when space is available. | Spills the whole column when space is available. |
+| CHOOSECOLS    | =CHOOSECOLS(Data!A:A, 1)                                      |        SPILL | Spills the whole column when space is available. |           SPILL |
 | INT           | =INT(-8.9)                                                     |           -8 |            -9 |              -9 |
 | MOD           | =MOD(-10, 3)                                                   |           -1 |             2 |               2 |
 | ISEVEN        | =ISEVEN(2.5)                                                   |        FALSE |          TRUE |            TRUE |

--- a/docs/guide/list-of-differences.md
+++ b/docs/guide/list-of-differences.md
@@ -106,6 +106,7 @@ To remove the differences, create [custom implementations](custom-functions.md) 
 | NORMSDIST     | =NORMSDIST(0, TRUE())                                          |          0.5 |  Wrong number |    Wrong number |
 | ADDRESS       | =ADDRESS(1,1,4, TRUE(), "")                                    |          !A1 |         ''!A1 |             !A1 |
 | SEQUENCE      | =SEQUENCE(0)                                                   |        VALUE |           N/A |           CALC  |
+| CHOOSECOLS    | =CHOOSECOLS(Data!A:A, 1)                                      |        VALUE | Spills the whole column when space is available. | Spills the whole column when space is available. |
 | INT           | =INT(-8.9)                                                     |           -8 |            -9 |              -9 |
 | MOD           | =MOD(-10, 3)                                                   |           -1 |             2 |               2 |
 | ISEVEN        | =ISEVEN(2.5)                                                   |        FALSE |          TRUE |            TRUE |

--- a/docs/guide/list-of-differences.md
+++ b/docs/guide/list-of-differences.md
@@ -106,7 +106,7 @@ To remove the differences, create [custom implementations](custom-functions.md) 
 | NORMSDIST     | =NORMSDIST(0, TRUE())                                          |          0.5 |  Wrong number |    Wrong number |
 | ADDRESS       | =ADDRESS(1,1,4, TRUE(), "")                                    |          !A1 |         ''!A1 |             !A1 |
 | SEQUENCE      | =SEQUENCE(0)                                                   |        VALUE |           N/A |           CALC  |
-| CHOOSECOLS    | =CHOOSECOLS(Data!A:A, 1)                                      |        SPILL | Spills the whole column when space is available. |           SPILL |
+| CHOOSECOLS    | =CHOOSECOLS(Data!A:A, 1)                                      |        VALUE | Spills the whole column when space is available. | Spills the whole column when space is available. |
 | INT           | =INT(-8.9)                                                     |           -8 |            -9 |              -9 |
 | MOD           | =MOD(-10, 3)                                                   |           -1 |             2 |               2 |
 | ISEVEN        | =ISEVEN(2.5)                                                   |        FALSE |          TRUE |            TRUE |

--- a/src/i18n/languages/csCZ.ts
+++ b/src/i18n/languages/csCZ.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#HODNOTA!',
   },
   functions: {
+    CHOOSECOLS: 'ZVOLITSLOUPCE',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/daDK.ts
+++ b/src/i18n/languages/daDK.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VÆRDI!',
   },
   functions: {
+    CHOOSECOLS: 'VÆLGKOL',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/deDE.ts
+++ b/src/i18n/languages/deDE.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#WERT!',
   },
   functions: {
+    CHOOSECOLS: 'SPALTENWAHL',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/enGB.ts
+++ b/src/i18n/languages/enGB.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALUE!',
   },
   functions: {
+    CHOOSECOLS: 'CHOOSECOLS',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/esES.ts
+++ b/src/i18n/languages/esES.ts
@@ -18,6 +18,7 @@ export const dictionary: RawTranslationPackage = {
     VALUE: '#¡VALOR!',
   },
   functions: {
+    CHOOSECOLS: 'ELEGIRCOLS',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/fiFI.ts
+++ b/src/i18n/languages/fiFI.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ARVO!',
   },
   functions: {
+    CHOOSECOLS: 'VALITSESARAKKEET',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/frFR.ts
+++ b/src/i18n/languages/frFR.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALEUR!',
   },
   functions: {
+    CHOOSECOLS: 'CHOISIRCOLS',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/huHU.ts
+++ b/src/i18n/languages/huHU.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ÉRTÉK!',
   },
   functions: {
+    CHOOSECOLS: 'OSZLOPVÁLASZTÁS',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/idID.ts
+++ b/src/i18n/languages/idID.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#NILAI!',
   },
   functions: {
+    CHOOSECOLS: 'CHOOSECOLS',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/itIT.ts
+++ b/src/i18n/languages/itIT.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALORE!',
   },
   functions: {
+    CHOOSECOLS: 'SCEGLI.COL',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/nbNO.ts
+++ b/src/i18n/languages/nbNO.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VERDI!',
   },
   functions: {
+    CHOOSECOLS: 'VELGKOL',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/nlNL.ts
+++ b/src/i18n/languages/nlNL.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#WAARDE!',
   },
   functions: {
+    CHOOSECOLS: 'KIES.KOLOMMEN',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/plPL.ts
+++ b/src/i18n/languages/plPL.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ARG!',
   },
   functions: {
+    CHOOSECOLS: 'WYBIERZ.KOLUMNY',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/ptPT.ts
+++ b/src/i18n/languages/ptPT.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALOR!',
   },
   functions: {
+    CHOOSECOLS: 'ESCOLHERCOLS',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/ruRU.ts
+++ b/src/i18n/languages/ruRU.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ЗНАЧ!',
   },
   functions: {
+    CHOOSECOLS: 'ВЫБОРСТОЛБЦ',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/svSE.ts
+++ b/src/i18n/languages/svSE.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VÄRDEFEL!',
   },
   functions: {
+    CHOOSECOLS: 'VÄLJKOL',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/i18n/languages/trTR.ts
+++ b/src/i18n/languages/trTR.ts
@@ -18,6 +18,7 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#DEĞER!',
   },
   functions: {
+    CHOOSECOLS: 'SÜTUNSEÇ',
     FILTER: 'FILTER',
     VSTACK: 'VSTACK',
     HSTACK: 'HSTACK',

--- a/src/interpreter/functionMetadata/categories/lookup-and-reference.ts
+++ b/src/interpreter/functionMetadata/categories/lookup-and-reference.ts
@@ -25,6 +25,13 @@ export const LOOKUP_AND_REFERENCE_DOCS: Record<string, FunctionDoc> = {
     documentationUrl: 'https://hyperformula.handsontable.com/docs/guide/built-in-functions.html',
     examples: ['=CHOOSE(2, "apple", "banana", "cherry")', '=CHOOSE(1, A1, A2, A3)'],
   },
+  CHOOSECOLS: {
+    category: 'Lookup and reference',
+    shortDescription: 'Returns specified columns from an array.',
+    parameters: [{name: 'array', description: 'The array or range containing the columns to return.'}, {name: 'col_num1', description: 'The first column to return. Positive values count from the left and negative values count from the right. Further column indexes can be passed as additional arguments.'}],
+    documentationUrl: 'https://hyperformula.handsontable.com/docs/guide/built-in-functions.html',
+    examples: ['=CHOOSECOLS(A1:E5, 1, 3, 5)', '=CHOOSECOLS(A1:D5, -1, -2)'],
+  },
   COLUMN: {
     category: 'Lookup and reference',
     shortDescription: 'Returns column number of a given reference or formula reference if argument not provided.',

--- a/src/interpreter/plugin/ArrayPlugin.ts
+++ b/src/interpreter/plugin/ArrayPlugin.ts
@@ -227,6 +227,7 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
    *
    * @param {ProcedureAst} ast - The parsed function-call AST node.
    * @param {InterpreterState} state - The current interpreter evaluation state.
+   * @returns {InterpreterValue} The selected source columns or a spreadsheet error.
    */
   public choosecols(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
     return this.runFunction(ast.args, state, this.metadata('CHOOSECOLS'),
@@ -251,6 +252,14 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
         )
 
         const sourceRange = range.range
+        const startsBelowFirstRow = sourceRange !== undefined
+          && !Number.isFinite(sourceRange.height())
+          && state.formulaAddress.row !== 0
+
+        if (startsBelowFirstRow) {
+          return new CellError(ErrorType.SPILL, ErrorMessage.NoSpaceForArrayResult)
+        }
+
         if (sourceRange !== undefined) {
           const selectedColumns = zeroBasedColumnIndexes.map(columnIndex => {
             const columnRange = AbsoluteCellRange.spanFrom(
@@ -277,11 +286,13 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
   /**
    * Predicts the CHOOSECOLS spill size from the source height and index count.
    *
-   * Invalid literals and unbounded result heights are rejected before spill
-   * allocation so a neighboring cell cannot mask a statically known error.
+   * Invalid literals are rejected before spill allocation. A whole-column
+   * result is valid only in the first output row, then its source range
+   * supplies the materialized spill height.
    *
    * @param {ProcedureAst} ast - The parsed function-call AST node.
    * @param {InterpreterState} state - The current interpreter evaluation state.
+   * @returns {ArraySize} The predicted result dimensions or an invalid size.
    */
   public choosecolsArraySize(ast: ProcedureAst, state: InterpreterState): ArraySize {
     if (ast.args.length < 2) {
@@ -294,7 +305,15 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
       new InterpreterState(state.formulaAddress, state.arraysFlag || (metadata?.enableArrayArithmeticForArguments ?? false)),
     )
 
-    if (!Number.isFinite(sourceSize.height) || sourceSize.height < 1) {
+    const startsBelowFirstRow = !Number.isFinite(sourceSize.height) && state.formulaAddress.row !== 0
+    const sourceRange = ast.args[0].type === AstNodeType.COLUMN_RANGE
+      ? AbsoluteCellRange.fromAstOrUndef(ast.args[0], state.formulaAddress)
+      : undefined
+    const effectiveHeight = !Number.isFinite(sourceSize.height) && sourceRange !== undefined
+      ? sourceRange.effectiveHeight(this.dependencyGraph)
+      : sourceSize.height
+
+    if (startsBelowFirstRow || effectiveHeight < 1) {
       return ArraySize.error()
     }
 
@@ -312,7 +331,7 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
       }
     }
 
-    return new ArraySize(ast.args.length - 1, sourceSize.height)
+    return new ArraySize(ast.args.length - 1, effectiveHeight)
   }
 
   /**

--- a/src/interpreter/plugin/ArrayPlugin.ts
+++ b/src/interpreter/plugin/ArrayPlugin.ts
@@ -233,6 +233,11 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
       (range: SimpleRangeValue, ...columnNumbers: number[]) => {
         const sourceWidth = range.width()
         const sourceHeight = range.height()
+
+        if (sourceHeight === 0 || sourceWidth === 0) {
+          return new CellError(ErrorType.NA, ErrorMessage.EmptyRange)
+        }
+
         const columnIndexes = columnNumbers.map(columnNumber => Math.trunc(columnNumber))
 
         if (columnIndexes.some(columnIndex =>

--- a/src/interpreter/plugin/ArrayPlugin.ts
+++ b/src/interpreter/plugin/ArrayPlugin.ts
@@ -40,12 +40,19 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
       return {kind: 'value', value: Math.trunc(getRawValue(coercedValue))}
     }
 
-    if (argument.type === AstNodeType.PLUS_UNARY_OP && argument.value.type === AstNodeType.NUMBER) {
-      return {kind: 'value', value: Math.trunc(argument.value.value)}
+    if (argument.type === AstNodeType.ERROR || argument.type === AstNodeType.ERROR_WITH_RAW_INPUT) {
+      return {kind: 'invalid'}
     }
 
-    if (argument.type === AstNodeType.MINUS_UNARY_OP && argument.value.type === AstNodeType.NUMBER) {
-      return {kind: 'value', value: Math.trunc(-argument.value.value)}
+    if (argument.type === AstNodeType.PLUS_UNARY_OP || argument.type === AstNodeType.MINUS_UNARY_OP) {
+      const index = this.parseChooseColsLiteralIndex(argument.value)
+      if (index.kind !== 'value') {
+        return index
+      }
+      return {
+        kind: 'value',
+        value: argument.type === AstNodeType.MINUS_UNARY_OP ? -index.value : index.value,
+      }
     }
 
     if (argument.type === AstNodeType.PARENTHESIS) {

--- a/src/interpreter/plugin/ArrayPlugin.ts
+++ b/src/interpreter/plugin/ArrayPlugin.ts
@@ -40,7 +40,7 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
       return {kind: 'value', value: Math.trunc(getRawValue(coercedValue))}
     }
 
-    if (argument.type === AstNodeType.ERROR || argument.type === AstNodeType.ERROR_WITH_RAW_INPUT) {
+    if (argument.type === AstNodeType.EMPTY || argument.type === AstNodeType.ERROR || argument.type === AstNodeType.ERROR_WITH_RAW_INPUT) {
       return {kind: 'invalid'}
     }
 

--- a/src/interpreter/plugin/ArrayPlugin.ts
+++ b/src/interpreter/plugin/ArrayPlugin.ts
@@ -3,17 +3,58 @@
  * Copyright (c) 2025 Handsoncode. All rights reserved.
  */
 
+import {AbsoluteCellRange} from '../../AbsoluteCellRange'
 import {ArraySize} from '../../ArraySize'
 import {CellError, ErrorType} from '../../Cell'
 import {ErrorMessage} from '../../error-message'
-import {AstNodeType, ProcedureAst} from '../../parser'
+import {Ast, AstNodeType, ProcedureAst} from '../../parser'
 import {coerceScalarToBoolean} from '../ArithmeticHelper'
 import {InterpreterState} from '../InterpreterState'
-import {InternalScalarValue, InterpreterValue} from '../InterpreterValue'
+import {getRawValue, InternalScalarValue, InterpreterValue} from '../InterpreterValue'
 import {SimpleRangeValue} from '../../SimpleRangeValue'
 import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
+/** A CHOOSECOLS index classified without evaluating a formula expression. */
+type ChooseColsLiteralIndex =
+  | {kind: 'value', value: number}
+  | {kind: 'invalid'}
+  | {kind: 'unresolved'}
+
 export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypecheck<ArrayPlugin> {
+  /**
+   * Classifies an index literal for static CHOOSECOLS result-size prediction.
+   *
+   * @param {Ast} argument - The column-index argument to inspect without evaluating formulas.
+   * @returns {ChooseColsLiteralIndex} A coerced literal value, an invalid marker, or an unresolved marker.
+   */
+  private parseChooseColsLiteralIndex(argument: Ast): ChooseColsLiteralIndex {
+    if (argument.type === AstNodeType.NUMBER) {
+      return {kind: 'value', value: Math.trunc(argument.value)}
+    }
+
+    if (argument.type === AstNodeType.STRING) {
+      const coercedValue = this.arithmeticHelper.coerceToMaybeNumber(argument.value)
+      if (coercedValue === undefined) {
+        return {kind: 'invalid'}
+      }
+      return {kind: 'value', value: Math.trunc(getRawValue(coercedValue))}
+    }
+
+    if (argument.type === AstNodeType.PLUS_UNARY_OP && argument.value.type === AstNodeType.NUMBER) {
+      return {kind: 'value', value: Math.trunc(argument.value.value)}
+    }
+
+    if (argument.type === AstNodeType.MINUS_UNARY_OP && argument.value.type === AstNodeType.NUMBER) {
+      return {kind: 'value', value: Math.trunc(-argument.value.value)}
+    }
+
+    if (argument.type === AstNodeType.PARENTHESIS) {
+      return this.parseChooseColsLiteralIndex(argument.expression)
+    }
+
+    return {kind: 'unresolved'}
+  }
+
   public static implementedFunctions: ImplementedFunctions = {
     'ARRAYFORMULA': {
       method: 'arrayformula',
@@ -42,6 +83,17 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
         {argumentType: FunctionArgumentType.RANGE},
       ],
       repeatLastArgs: 1,
+    },
+    'CHOOSECOLS': {
+      method: 'choosecols',
+      sizeOfResultArrayMethod: 'choosecolsArraySize',
+      enableArrayArithmeticForArguments: true,
+      parameters: [
+        {argumentType: FunctionArgumentType.RANGE},
+        {argumentType: FunctionArgumentType.NUMBER},
+      ],
+      repeatLastArgs: 1,
+      vectorizationForbidden: true,
     },
     'VSTACK': {
       method: 'vstack',
@@ -164,6 +216,98 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
     const width = Math.max(...(subChecks).map(val => val.width))
     const height = Math.max(...(subChecks).map(val => val.height))
     return new ArraySize(width, height)
+  }
+
+  /**
+   * Corresponds to CHOOSECOLS(array, col_num1, [col_num2], ...).
+   *
+   * Returns the requested source columns in argument order. Positive indexes
+   * count from the left, negative indexes count from the right, and duplicate
+   * indexes duplicate their columns in the result.
+   *
+   * @param {ProcedureAst} ast - The parsed function-call AST node.
+   * @param {InterpreterState} state - The current interpreter evaluation state.
+   */
+  public choosecols(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(ast.args, state, this.metadata('CHOOSECOLS'),
+      (range: SimpleRangeValue, ...columnNumbers: number[]) => {
+        const sourceWidth = range.width()
+        const sourceHeight = range.height()
+        const columnIndexes = columnNumbers.map(columnNumber => Math.trunc(columnNumber))
+
+        if (columnIndexes.some(columnIndex =>
+          !Number.isFinite(columnIndex) || columnIndex === 0 || Math.abs(columnIndex) > sourceWidth
+        )) {
+          return new CellError(ErrorType.VALUE, ErrorMessage.IndexBounds)
+        }
+
+        const zeroBasedColumnIndexes = columnIndexes.map(columnIndex =>
+          columnIndex > 0 ? columnIndex - 1 : sourceWidth + columnIndex
+        )
+
+        const sourceRange = range.range
+        if (sourceRange !== undefined) {
+          const selectedColumns = zeroBasedColumnIndexes.map(columnIndex => {
+            const columnRange = AbsoluteCellRange.spanFrom(
+              sourceRange.getAddress(columnIndex, 0),
+              1,
+              sourceHeight,
+            )
+            return SimpleRangeValue.onlyRange(columnRange, this.dependencyGraph).data
+          })
+          const result = Array.from({length: sourceHeight}, (_, row) =>
+            selectedColumns.map(column => column[row][0])
+          )
+          return SimpleRangeValue.onlyValues(result)
+        }
+
+        const result = range.data.map(row =>
+          zeroBasedColumnIndexes.map(columnIndex => row[columnIndex])
+        )
+        return SimpleRangeValue.onlyValues(result)
+      }
+    )
+  }
+
+  /**
+   * Predicts the CHOOSECOLS spill size from the source height and index count.
+   *
+   * Invalid literals and unbounded result heights are rejected before spill
+   * allocation so a neighboring cell cannot mask a statically known error.
+   *
+   * @param {ProcedureAst} ast - The parsed function-call AST node.
+   * @param {InterpreterState} state - The current interpreter evaluation state.
+   */
+  public choosecolsArraySize(ast: ProcedureAst, state: InterpreterState): ArraySize {
+    if (ast.args.length < 2) {
+      return ArraySize.error()
+    }
+
+    const metadata = this.metadata('CHOOSECOLS')
+    const sourceSize = this.arraySizeForAst(
+      ast.args[0],
+      new InterpreterState(state.formulaAddress, state.arraysFlag || (metadata?.enableArrayArithmeticForArguments ?? false)),
+    )
+
+    if (!Number.isFinite(sourceSize.height) || sourceSize.height < 1) {
+      return ArraySize.error()
+    }
+
+    for (const argument of ast.args.slice(1)) {
+      const index = this.parseChooseColsLiteralIndex(argument)
+      if (
+        index.kind === 'invalid'
+        || (index.kind === 'value' && (
+          !Number.isFinite(index.value)
+          || index.value === 0
+          || Math.abs(index.value) > sourceSize.width
+        ))
+      ) {
+        return ArraySize.error()
+      }
+    }
+
+    return new ArraySize(ast.args.length - 1, sourceSize.height)
   }
 
   /**

--- a/src/interpreter/plugin/ArrayPlugin.ts
+++ b/src/interpreter/plugin/ArrayPlugin.ts
@@ -251,6 +251,14 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
         )
 
         const sourceRange = range.range
+        if (
+          sourceRange !== undefined
+          && !Number.isFinite(sourceRange.height())
+          && (sourceRange.sheet !== state.formulaAddress.sheet || state.formulaAddress.row !== 0)
+        ) {
+          return new CellError(ErrorType.SPILL, ErrorMessage.NoSpaceForArrayResult)
+        }
+
         if (sourceRange !== undefined) {
           const selectedColumns = zeroBasedColumnIndexes.map(columnIndex => {
             const columnRange = AbsoluteCellRange.spanFrom(
@@ -277,8 +285,10 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
   /**
    * Predicts the CHOOSECOLS spill size from the source height and index count.
    *
-   * Invalid literals and unbounded result heights are rejected before spill
-   * allocation so a neighboring cell cannot mask a statically known error.
+   * Invalid literals and unsupported unbounded result heights are rejected
+   * before spill allocation so a neighboring cell cannot mask a statically
+   * known error. Same-sheet whole-column results can retain their unbounded
+   * height when anchored in the first row.
    *
    * @param {ProcedureAst} ast - The parsed function-call AST node.
    * @param {InterpreterState} state - The current interpreter evaluation state.
@@ -294,7 +304,14 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
       new InterpreterState(state.formulaAddress, state.arraysFlag || (metadata?.enableArrayArithmeticForArguments ?? false)),
     )
 
-    if (!Number.isFinite(sourceSize.height) || sourceSize.height < 1) {
+    const sourceRange = ast.args[0].type === AstNodeType.COLUMN_RANGE
+      ? AbsoluteCellRange.fromAstOrUndef(ast.args[0], state.formulaAddress)
+      : undefined
+    const isSupportedWholeColumnResult = sourceSize.height === Number.POSITIVE_INFINITY
+      && sourceRange?.sheet === state.formulaAddress.sheet
+      && state.formulaAddress.row === 0
+
+    if ((!Number.isFinite(sourceSize.height) && !isSupportedWholeColumnResult) || sourceSize.height < 1) {
       return ArraySize.error()
     }
 

--- a/src/interpreter/plugin/ArrayPlugin.ts
+++ b/src/interpreter/plugin/ArrayPlugin.ts
@@ -306,8 +306,12 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
     )
 
     const startsBelowFirstRow = !Number.isFinite(sourceSize.height) && state.formulaAddress.row !== 0
-    const sourceRange = ast.args[0].type === AstNodeType.COLUMN_RANGE
-      ? AbsoluteCellRange.fromAstOrUndef(ast.args[0], state.formulaAddress)
+    let sourceAst = ast.args[0]
+    while (sourceAst.type === AstNodeType.PARENTHESIS) {
+      sourceAst = sourceAst.expression
+    }
+    const sourceRange = sourceAst.type === AstNodeType.COLUMN_RANGE
+      ? AbsoluteCellRange.fromAstOrUndef(sourceAst, state.formulaAddress)
       : undefined
     const effectiveHeight = !Number.isFinite(sourceSize.height) && sourceRange !== undefined
       ? sourceRange.effectiveHeight(this.dependencyGraph)

--- a/src/interpreter/plugin/ArrayPlugin.ts
+++ b/src/interpreter/plugin/ArrayPlugin.ts
@@ -251,14 +251,6 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
         )
 
         const sourceRange = range.range
-        if (
-          sourceRange !== undefined
-          && !Number.isFinite(sourceRange.height())
-          && (sourceRange.sheet !== state.formulaAddress.sheet || state.formulaAddress.row !== 0)
-        ) {
-          return new CellError(ErrorType.SPILL, ErrorMessage.NoSpaceForArrayResult)
-        }
-
         if (sourceRange !== undefined) {
           const selectedColumns = zeroBasedColumnIndexes.map(columnIndex => {
             const columnRange = AbsoluteCellRange.spanFrom(
@@ -285,10 +277,8 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
   /**
    * Predicts the CHOOSECOLS spill size from the source height and index count.
    *
-   * Invalid literals and unsupported unbounded result heights are rejected
-   * before spill allocation so a neighboring cell cannot mask a statically
-   * known error. Same-sheet whole-column results can retain their unbounded
-   * height when anchored in the first row.
+   * Invalid literals and unbounded result heights are rejected before spill
+   * allocation so a neighboring cell cannot mask a statically known error.
    *
    * @param {ProcedureAst} ast - The parsed function-call AST node.
    * @param {InterpreterState} state - The current interpreter evaluation state.
@@ -304,14 +294,7 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
       new InterpreterState(state.formulaAddress, state.arraysFlag || (metadata?.enableArrayArithmeticForArguments ?? false)),
     )
 
-    const sourceRange = ast.args[0].type === AstNodeType.COLUMN_RANGE
-      ? AbsoluteCellRange.fromAstOrUndef(ast.args[0], state.formulaAddress)
-      : undefined
-    const isSupportedWholeColumnResult = sourceSize.height === Number.POSITIVE_INFINITY
-      && sourceRange?.sheet === state.formulaAddress.sheet
-      && state.formulaAddress.row === 0
-
-    if ((!Number.isFinite(sourceSize.height) && !isSupportedWholeColumnResult) || sourceSize.height < 1) {
+    if (!Number.isFinite(sourceSize.height) || sourceSize.height < 1) {
       return ArraySize.error()
     }
 


### PR DESCRIPTION
### Context

This PR adds `CHOOSECOLS`, allowing columns to be selected from an array with positive or negative indexes while preserving the requested order and duplicate indexes.

The implementation remains local to `ArrayPlugin`; `CHOOSEROWS` is outside this PR's scope. It includes function metadata, translations, changelog and compatibility documentation.

### Behavior covered

- Positive, negative, mixed, duplicate, fractional, coerced, referenced, and calculated indexes.
- Scalar, range, whole-row, whole-column, and calculated-array inputs.
- Static spill-size prediction, including validating an empty or literal-error index before spill allocation.
- Bounds checks, error propagation, blocked spills, lazy reads, and argument validation.
- Whole-column sources spill from row 1 and return `#SPILL!` below row 1.

### Validation

Companion tests: handsontable/hyperformula-tests#34

- 46/46 focused `CHOOSECOLS` tests passed.
- 150/150 relevant metadata and localization tests passed.
- TypeScript compilation, targeted lint, and `git diff --check` passed.
- Excel Online confirmed same-sheet and cross-sheet whole-column behavior, whole-row index behavior, and that an empty column index returns `#VALUE!` even when the predicted spill range is blocked.

### Types of changes

- [ ] Breaking change
- [x] New feature or improvement
- [ ] Bug fix
- [x] Additional language file or translation change
- [x] Documentation change

### Checklist

- [x] The code follows the HyperFormula contribution guidelines and project style.
- [ ] I have signed the Contributor License Agreement.
- [ ] The change is compliant with OpenDocument 1.3.
- [x] The change is compatible with Microsoft Excel, subject to documented differences.
- [x] The change is compatible with Google Sheets, subject to documented differences.
- [x] The change is described in `CHANGELOG.md`.
- [x] Documentation has been updated.
- [ ] A migration guide is required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New dynamic-array spill logic touches array sizing and worksheet-edge behavior; mistakes could cause incorrect spills or error masking, but scope is isolated to ArrayPlugin with documented Excel-aligned edge cases.
> 
> **Overview**
> Adds Excel-style **`CHOOSECOLS`** so formulas can return selected columns from a range in a given order, including positive/negative indexing and repeated column numbers.
> 
> The runtime and spill-size logic live in **`ArrayPlugin`**: evaluation maps indexes to source columns (with bounds and empty-range handling), while **`choosecolsArraySize`** predicts spill dimensions and statically validates **literal** column indexes via **`parseChooseColsLiteralIndex`**. Whole-column sources may spill only from row 1; lower rows get **`#SPILL!`**, and documented limits cover scalar-only index arguments and spill-vs-error ordering when the spill range is blocked.
> 
> Ships with lookup metadata, **16** localized function names, changelog entry, and compatibility/limitation docs (including a **`CHOOSECOLS`** row in the differences table vs Google Sheets on whole-column spill).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58f0cbc7cd96bd1ed0150ea1c52bdc35e39c865b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->