### PR TITLE
chore: isolate public repo from internal MCP connectors (HOT-15476)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "deny": [
+      "mcp__claude_ai_ClickUp__*",
+      "mcp__claude_ai_Gmail__*",
+      "mcp__claude_ai_Google_Calendar__*",
+      "mcp__claude_ai_Google_Drive__*",
+      "mcp__claude_ai_Slack__*",
+      "mcp__claude_ai_Fireflies__*"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,13 @@ docs/guide/built-in-functions.md
 # Wrangler (Cloudflare Workers) local state
 .wrangler
 .dev.vars*
+
+# Infisical local project link — contains workspaceId (infra inventory, HOT/SZBI:
+# stays in personal private repos only, never in a public repo)
+.infisical.json
+
+# Claude Code project-local state (personal, not shared) — .claude/settings.json
+# itself IS meant to be committed (repo-wide guardrails), so only ignore the rest.
+.claude/settings.local.json
+.claude/worktrees/
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Context

Handsoncode's 2026-08-03 AI usage policy update ([HOT-15476](https://app.clickup.com/t/86cazbfk1), due 2026-08-14) extends the Information Security Policy with rules for AI tool usage: a 4-tier data classification (Public/Internal/Confidential/Restricted) and a requirement that AI sessions never mix Confidential/Restricted company data with anything that can reach a public destination.

This repo's `origin`/`upstream` both point directly at the public `github.com/handsontable/hyperformula`, and this Claude Code account also carries claude.ai cloud MCP connectors (ClickUp, Gmail, Slack, Fireflies, Google Drive, Google Calendar) that attach to any project directory regardless of which repo is checked out. There was no technical control preventing a session in this repo from also reaching those connectors.

## Changes

- **`.claude/settings.json`** (new, committed so it applies to anyone working in this repo): denies the MCP tool patterns for those six connectors, so a Claude Code session here cannot reach them even if connected at the account level. Verified live — writing this file immediately dropped those connectors' tools from the active session.
- **`.gitignore`**: 
  - ignore `.infisical.json` (contains an Infisical `workspaceId` — infrastructure inventory, which Handsoncode's data-classification matrix keeps out of shared/public repos)
  - ignore the personal/local parts of `.claude/` (`settings.local.json`, `worktrees/`, `scheduled_tasks.lock`) while keeping `settings.json` itself trackable, since that's the guardrail this PR adds.

No behavior change to HyperFormula itself — this is tooling/process hygiene only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and ignore-list only; HyperFormula behavior is unchanged and the changes reduce accidental exposure of internal MCP or secrets in a public repo.
> 
> **Overview**
> **Policy guardrails for AI work in the public HyperFormula repo** — no library/runtime changes.
> 
> A new **`.claude/settings.json`** is committed so anyone opening this repo in Claude Code gets a shared **permissions.deny** list for six claude.ai MCP integrations (ClickUp, Gmail, Google Calendar/Drive, Slack, Fireflies). Sessions here cannot invoke those tools even when the account still has them connected elsewhere.
> 
> **`.gitignore`** now excludes **`.infisical.json`** (workspace linkage / infra inventory) and personal Claude paths (**`settings.local.json`**, **`worktrees/`**, **`scheduled_tasks.lock`**) while leaving **`settings.json`** trackable as the team-wide control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d07ea186c0c20b9225ab088f6800cf3dbfc3ed37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->