### PR TITLE
HF-307: warn once when a typed key enters its notice window (5/8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Added support for proprietary license keys that grant a subset of the library ("feature packages and add-ons"). A function your key does not include evaluates to a `#LIC!` error, and the corresponding parts of the API throw a `LicenseCapabilityMissingError`. Keys that grant everything, including `gpl-v3`, are unaffected. [#1728](https://github.com/handsontable/hyperformula/pull/1728) [#1729](https://github.com/handsontable/hyperformula/pull/1729) [#1730](https://github.com/handsontable/hyperformula/pull/1730)
-- Added a one-time console warning when a license key's usage-based expiry date falls within its configured notice period. The warning is silenced by the key's own silent flag, and never fires for a key expiring on the perpetual (`release_until`) axis. Blocking behavior at and after expiry is unchanged.
+- Added a one-time console notice when a license key's usage-based expiry date falls within its configured notice period, naming the key's last covered day ("valid until … (UTC)"). The notice is silenced by the key's own silent flag, and never fires for a key expiring on the perpetual (`release_until`) axis. Blocking behavior at and after expiry is unchanged. [#1736](https://github.com/handsontable/hyperformula/pull/1736)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Added support for proprietary license keys that grant a subset of the library ("feature packages and add-ons"). A function your key does not include evaluates to a `#LIC!` error, and the corresponding parts of the API throw a `LicenseCapabilityMissingError`. Keys that grant everything, including `gpl-v3`, are unaffected. [#1728](https://github.com/handsontable/hyperformula/pull/1728) [#1729](https://github.com/handsontable/hyperformula/pull/1729) [#1730](https://github.com/handsontable/hyperformula/pull/1730)
+- Added a one-time console warning when a license key's usage-based expiry date falls within its configured notice period. The warning is silenced by the key's own silent flag, and never fires for a key expiring on the perpetual (`release_until`) axis. Blocking behavior at and after expiry is unchanged.
 
 ### Changed
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -180,7 +180,7 @@ export class Config implements ConfigParams, ParserConfig {
   /** @inheritDoc */
   public readonly matchWholeCell: boolean
 
-  constructor(options: Partial<ConfigParams> = {}, showDeprecatedWarns: boolean = true) {
+  constructor(options: Partial<ConfigParams> = {}, showDeprecatedWarns: boolean = true, notifyLicenseMessages: boolean = true) {
     const {
       accentSensitive,
       caseSensitive,
@@ -279,7 +279,7 @@ export class Config implements ConfigParams, ParserConfig {
     validateNumberToBeAtLeast(this.maxColumns, 'maxColumns', 1)
     this.context = context
 
-    const {validityState: licenseKeyValidityState, entitlement} = resolveLicense(this.licenseKey)
+    const {validityState: licenseKeyValidityState, entitlement} = resolveLicense(this.licenseKey, notifyLicenseMessages)
     const capabilityRegistry = new CapabilityRegistry()
     const licenseCapabilities = capabilityRegistry.resolve(entitlement)
 
@@ -365,12 +365,12 @@ export class Config implements ConfigParams, ParserConfig {
     return getFullConfigFromPartial(this)
   }
 
-  public mergeConfig(init: Partial<ConfigParams>): Config {
+  public mergeConfig(init: Partial<ConfigParams>, notifyLicenseMessages: boolean = true): Config {
     const mergedConfig: ConfigParams = Object.assign({}, this.getConfig(), init)
 
     Config.warnDeprecatedOptions(init)
 
-    return new Config(mergedConfig, false)
+    return new Config(mergedConfig, false, notifyLicenseMessages)
   }
 
   private static warnDeprecatedOptions(options: Partial<ConfigParams>) {

--- a/src/HyperFormula.ts
+++ b/src/HyperFormula.ts
@@ -4962,7 +4962,10 @@ export class HyperFormula implements TypedEmitter {
    */
   private rebuildWithConfig(newParams: Partial<ConfigParams>): void {
     const newConfig = this._config.mergeConfig(newParams)
-    const configNewLanguage = this._config.mergeConfig({language: newParams.language})
+    // The second argument silences license console messages for this transient Config: it is
+    // built from the OUTGOING config purely to reserialize sheets, and must not print an expiry
+    // notice for the key the caller may be replacing in this very call.
+    const configNewLanguage = this._config.mergeConfig({language: newParams.language}, false)
     const serializedSheets = this._serialization.withNewConfig(configNewLanguage, this._namedExpressions).getAllSheetsSerialized()
     const serializedNamedExpressions = this._serialization.getAllNamedExpressionsSerialized()
 

--- a/src/helpers/licenseKeyValidator.ts
+++ b/src/helpers/licenseKeyValidator.ts
@@ -43,9 +43,10 @@ const consoleMessages: ConsoleMessages = {
 let _notified = false
 
 /**
- * License key strings that have already printed their expiry-approaching notice.
+ * Identities (see {@link noticeIdentityOf}) of license keys that have already printed their
+ * expiry-approaching notice.
  *
- * Deliberately keyed by the raw key string rather than a single boolean like {@link _notified}
+ * Deliberately keyed per key rather than a single boolean like {@link _notified}
  * above: that flag reports one of a handful of states that mean the same thing regardless of
  * which key triggered them ("a key is invalid", "a key is missing"), so once-per-page-load is the
  * right behaviour for it. Two different keys approaching their OWN expiry are two different
@@ -96,22 +97,45 @@ export function notifyLicenseKeyState(state: LicenseKeyValidityState, keyValidit
 
 /**
  * Prints a one-time notice that a VALID typed key's usage-until expiry is approaching, at most
- * once per distinct license key string.
+ * once per distinct license key.
  *
  * Called from `src/license/licenseResolution.ts`'s `resolveLicense`, alongside
  * {@link notifyLicenseKeyState} — see that function's doc for why the two share this module
  * instead of each keeping a message table and a flag of their own.
  *
- * @param {string} licenseKey - the raw key string, used only as the warn-once identity
- * @param {Date} expiryDate - the day the key's usage-until expiry falls on, at UTC midnight
+ * The wording is rev 5 §3.2's own subscription clause ("valid until {date} (UTC)"), naming the
+ * key's LAST covered day. It deliberately does not say "expires on": the pre-existing expired
+ * message reports the first day NOT covered (`validityOf`'s convention, +1 day), and two messages
+ * for the same key must not name two different days for the same boundary. "Valid until Aug 25"
+ * followed later by "expired on Aug 26" is consistent; "expires on Aug 25" followed by
+ * "expired on Aug 26" is a support ticket.
+ *
+ * @param {string} licenseKey - the raw key string; only its identity is retained, see below
+ * @param {Date} expiryDate - the last covered day of the key's usage-until axis, at UTC midnight
  */
 export function notifyLicenseKeyNotice(licenseKey: string, expiryDate: Date): void {
-  if (_noticedKeys.has(licenseKey)) {
+  const identity = noticeIdentityOf(licenseKey)
+
+  if (_noticedKeys.has(identity)) {
     return
   }
 
-  console.warn(`The license key for HyperFormula will expire on ${formatDate(expiryDate)} (UTC).`)
-  _noticedKeys.add(licenseKey)
+  console.warn(`The HyperFormula license key is valid until ${formatDate(expiryDate)} (UTC). To renew the license, contact sales@handsontable.com.`)
+  _noticedKeys.add(identity)
+}
+
+/**
+ * The warn-once identity of a key: its trailing 128 characters — for an intact typed key, the
+ * sha512 checksum, unique per distinct key content — after trimming.
+ *
+ * Trimmed because `extractTypedKeyData` trims before validating, so `'KEY'` and `'KEY\n'` are one
+ * license to the validator and must be one identity here too. Truncated because the set retains
+ * its entries for the life of the process: a multi-tenant server building one engine per
+ * customer-supplied key would otherwise accumulate every full key string it has ever warned
+ * about; 128 characters per entry bounds that to the checksum alone.
+ */
+function noticeIdentityOf(licenseKey: string): string {
+  return licenseKey.trim().slice(-128)
 }
 
 /**

--- a/src/helpers/licenseKeyValidator.ts
+++ b/src/helpers/licenseKeyValidator.ts
@@ -43,9 +43,22 @@ const consoleMessages: ConsoleMessages = {
 let _notified = false
 
 /**
- * Clears the once-per-page-load flag {@link notifyLicenseKeyState} keeps.
+ * License key strings that have already printed their expiry-approaching notice.
  *
- * Exists for tests only. The flag is module-level and never otherwise reset, so without this the
+ * Deliberately keyed by the raw key string rather than a single boolean like {@link _notified}
+ * above: that flag reports one of a handful of states that mean the same thing regardless of
+ * which key triggered them ("a key is invalid", "a key is missing"), so once-per-page-load is the
+ * right behaviour for it. Two different keys approaching their OWN expiry are two different
+ * events, and a page that swaps keys (or a test suite that builds one engine per key) must still
+ * warn for the second one even though the first already consumed a shared flag.
+ */
+const _noticedKeys = new Set<string>()
+
+/**
+ * Clears the once-per-page-load flag {@link notifyLicenseKeyState} keeps, and the per-key set
+ * {@link notifyLicenseKeyNotice} keeps.
+ *
+ * Exists for tests only. Both are module-level and never otherwise reset, so without this the
  * whole console-message path is unobservable: the first spec to build any engine consumes the single
  * warning and every later assertion sees silence regardless of what the code does. Making the reset
  * explicit beats the alternatives — depending on spec-file order is flaky, and under Karma every
@@ -55,6 +68,7 @@ let _notified = false
  */
 export function resetLicenseKeyNotificationForTests(): void {
   _notified = false
+  _noticedKeys.clear()
 }
 
 /**
@@ -78,6 +92,26 @@ export function notifyLicenseKeyState(state: LicenseKeyValidityState, keyValidit
 
   console.warn(consoleMessages[state](vars))
   _notified = true
+}
+
+/**
+ * Prints a one-time notice that a VALID typed key's usage-until expiry is approaching, at most
+ * once per distinct license key string.
+ *
+ * Called from `src/license/licenseResolution.ts`'s `resolveLicense`, alongside
+ * {@link notifyLicenseKeyState} — see that function's doc for why the two share this module
+ * instead of each keeping a message table and a flag of their own.
+ *
+ * @param {string} licenseKey - the raw key string, used only as the warn-once identity
+ * @param {Date} expiryDate - the day the key's usage-until expiry falls on, at UTC midnight
+ */
+export function notifyLicenseKeyNotice(licenseKey: string, expiryDate: Date): void {
+  if (_noticedKeys.has(licenseKey)) {
+    return
+  }
+
+  console.warn(`The license key for HyperFormula will expire on ${formatDate(expiryDate)} (UTC).`)
+  _noticedKeys.add(licenseKey)
 }
 
 /**

--- a/src/license/licenseResolution.ts
+++ b/src/license/licenseResolution.ts
@@ -408,10 +408,13 @@ function expiryWithinNoticeWindow(terms: LicenseTerms): Date | null {
     return null
   }
 
-  // The first instant no longer on the usage_until day — the same boundary `validityOf` uses
-  // before adding its grace term.
+  // The window ends at the first instant no longer on the usage_until day — the same boundary
+  // `validityOf` uses before adding its grace term — and opens `notice` days before the licensed
+  // day ITSELF, not before that end. Counting back from the end would shorten the window by a day:
+  // the date-semantics fixtures pin 2027-06-13T00:00:00Z for usage_until 2027-08-12 with notice 60,
+  // and a trial whose notice equals its whole term must warn from the day it is issued.
   const usageAxisDeadline = terms.expiryTimestamp + MILLISECONDS_PER_DAY
-  const noticeWindowStart = usageAxisDeadline - (terms.expiry.noticeDays * MILLISECONDS_PER_DAY)
+  const noticeWindowStart = terms.expiryTimestamp - (terms.expiry.noticeDays * MILLISECONDS_PER_DAY)
   const now = Date.now()
 
   return now >= noticeWindowStart && now < usageAxisDeadline ? new Date(terms.expiryTimestamp) : null

--- a/src/license/licenseResolution.ts
+++ b/src/license/licenseResolution.ts
@@ -391,7 +391,7 @@ function validityOf(terms: LicenseTerms): {state: LicenseKeyValidityState, expir
  * Deliberately blind to `graceDays`: notice is about the usage_until axis itself, not about the
  * grace extension past it. Key spec rev 5 §4.1 sequences notice, then a soft-stop window, then the
  * hard-stop this build already enforces; only the hard stop and this notice are built for 3.5.0
- * (Kuba's decision D5-A), so the window checked here ends exactly where the soft-stop phase would
+ * (decision D5-A), so the window checked here ends exactly where the soft-stop phase would
  * begin, rather than reaching into grace and printing a notice for a key already past its expiry.
  *
  * `release_until`-axis keys never reach here with a non-`null` result — `kind` is `'release'` for

--- a/src/license/licenseResolution.ts
+++ b/src/license/licenseResolution.ts
@@ -6,6 +6,7 @@
 import {
   checkLicenseKeyValidity,
   LicenseKeyValidityState,
+  notifyLicenseKeyNotice,
   notifyLicenseKeyState,
 } from '../helpers/licenseKeyValidator'
 import {
@@ -378,6 +379,38 @@ function validityOf(terms: LicenseTerms): {state: LicenseKeyValidityState, expir
 }
 
 /**
+ * The day a VALID key's usage-until expiry falls on, if the current UTC instant is within its
+ * notice window — `null` otherwise, which covers "no notice window configured" (`noticeDays` is
+ * `0`, true of every key the shipped shape can mint, since that shape has no `notice` field) just
+ * as much as "not close enough yet" or "already past its usage-until day".
+ *
+ * Deliberately blind to `graceDays`: notice is about the usage_until axis itself, not about the
+ * grace extension past it. Key spec rev 5 §4.1 sequences notice, then a soft-stop window, then the
+ * hard-stop this build already enforces; only the hard stop and this notice are built for 3.5.0
+ * (Kuba's decision D5-A), so the window checked here ends exactly where the soft-stop phase would
+ * begin, rather than reaching into grace and printing a notice for a key already past its expiry.
+ *
+ * `release_until`-axis keys never reach here with a non-`null` result — `kind` is `'usage'` only
+ * when the date came from `usage_until` (see {@link licenseTermsOf}) — matching rev 5's rule that
+ * notice and grace have no effect on that axis.
+ *
+ * @param {LicenseTerms} terms - the reconciled terms of the key
+ */
+function expiryWithinNoticeWindow(terms: LicenseTerms): Date | null {
+  if (terms.expiry.kind !== 'usage' || terms.expiry.noticeDays <= 0 || terms.expiryTimestamp === null) {
+    return null
+  }
+
+  // The first instant no longer on the usage_until day — the same boundary `validityOf` uses
+  // before adding its grace term.
+  const usageAxisDeadline = terms.expiryTimestamp + MILLISECONDS_PER_DAY
+  const noticeWindowStart = usageAxisDeadline - (terms.expiry.noticeDays * MILLISECONDS_PER_DAY)
+  const now = Date.now()
+
+  return now >= noticeWindowStart && now < usageAxisDeadline ? new Date(terms.expiryTimestamp) : null
+}
+
+/**
  * Turns the reconciled terms of an intact, unexpired typed key into the entitlement it grants.
  *
  * Per HF-307 decision D3 this is fail-closed and silent: a token this version does not recognize
@@ -447,6 +480,14 @@ export function resolveLicense(licenseKey: string): ResolvedLicense {
 
   if (!terms.silent) {
     notifyLicenseKeyState(state, expiredOn)
+
+    if (state === LicenseKeyValidityState.VALID) {
+      const noticeExpiryDate = expiryWithinNoticeWindow(terms)
+
+      if (noticeExpiryDate !== null) {
+        notifyLicenseKeyNotice(licenseKey, noticeExpiryDate)
+      }
+    }
   }
 
   return {

--- a/src/license/licenseResolution.ts
+++ b/src/license/licenseResolution.ts
@@ -329,7 +329,11 @@ function licenseTermsOf(data: TypedKeyData): LicenseTerms | null {
         kind: comparedAgainstReleaseDate ? 'release' : 'usage',
         // UTC midnight by construction, so this round-trips a payload's own `YYYY-MM-DD` exactly.
         date: new Date(expiryTimestamp).toISOString().slice(0, 10),
-        noticeDays: readDays(termsSource?.notice),
+        // Gated on the shape, not just on the field's presence: `notice` is rev-5 vocabulary
+        // (§2.1), and the shipped shape reads its terms off the LICENSED product's entry — for a
+        // dual-product key that is the Handsontable entry, so an ungated read would let a field
+        // another product added for its own purposes switch HyperFormula's console output on.
+        noticeDays: isRev5 ? readDays(termsSource?.notice) : 0,
         graceDays,
       },
     expiryTimestamp,
@@ -381,8 +385,8 @@ function validityOf(terms: LicenseTerms): {state: LicenseKeyValidityState, expir
 /**
  * The day a VALID key's usage-until expiry falls on, if the current UTC instant is within its
  * notice window — `null` otherwise, which covers "no notice window configured" (`noticeDays` is
- * `0`, true of every key the shipped shape can mint, since that shape has no `notice` field) just
- * as much as "not close enough yet" or "already past its usage-until day".
+ * `0` for every non-rev-5 entry, enforced where the terms are read) just as much as "not close
+ * enough yet" or "already past its usage-until day".
  *
  * Deliberately blind to `graceDays`: notice is about the usage_until axis itself, not about the
  * grace extension past it. Key spec rev 5 §4.1 sequences notice, then a soft-stop window, then the
@@ -390,9 +394,12 @@ function validityOf(terms: LicenseTerms): {state: LicenseKeyValidityState, expir
  * (Kuba's decision D5-A), so the window checked here ends exactly where the soft-stop phase would
  * begin, rather than reaching into grace and printing a notice for a key already past its expiry.
  *
- * `release_until`-axis keys never reach here with a non-`null` result — `kind` is `'usage'` only
- * when the date came from `usage_until` (see {@link licenseTermsOf}) — matching rev 5's rule that
- * notice and grace have no effect on that axis.
+ * `release_until`-axis keys never reach here with a non-`null` result — `kind` is `'release'` for
+ * them (see {@link licenseTermsOf}) — matching rev 5's rule that notice and grace have no effect
+ * on that axis. The converse does NOT hold: `kind === 'usage'` also covers a rev-5 entry with no
+ * date of its own, whose `expiryTimestamp` fell through to the key envelope's `exp`, so such an
+ * entry carrying `notice` notices against that envelope date. Accepted for this PR standing
+ * alone — the entitlement-envelope re-port (#1740) removes the fallback entirely.
  *
  * @param {LicenseTerms} terms - the reconciled terms of the key
  */
@@ -457,8 +464,13 @@ function entitlementOf(terms: LicenseTerms): LicenseEntitlement {
  * every payload field is untrusted, so nothing here may assume a shape.
  *
  * @param {string} licenseKey - the raw `licenseKey` config value
+ * @param {boolean} notifyConsole - pass `false` for a resolution whose result exists only to be
+ * thrown away (e.g. the transient serialization-only `Config` that `rebuildWithConfig` builds
+ * from the OUTGOING config) — such a resolution must not print notices for a key the caller is
+ * in the middle of replacing. Legacy keys notify inside {@link checkLicenseKeyValidity} behind a
+ * once-per-page-load flag, so they cannot double-print regardless of this parameter.
  */
-export function resolveLicense(licenseKey: string): ResolvedLicense {
+export function resolveLicense(licenseKey: string, notifyConsole: boolean = true): ResolvedLicense {
   const typedKeyData = extractTypedKeyData(licenseKey)
 
   if (typedKeyData === null) {
@@ -471,14 +483,16 @@ export function resolveLicense(licenseKey: string): ResolvedLicense {
   const terms = licenseTermsOf(typedKeyData)
 
   if (terms === null) {
-    notifyLicenseKeyState(LicenseKeyValidityState.INVALID)
+    if (notifyConsole) {
+      notifyLicenseKeyState(LicenseKeyValidityState.INVALID)
+    }
 
     return {validityState: LicenseKeyValidityState.INVALID, entitlement: unrestrictedEntitlement()}
   }
 
   const {state, expiredOn} = validityOf(terms)
 
-  if (!terms.silent) {
+  if (notifyConsole && !terms.silent) {
     notifyLicenseKeyState(state, expiredOn)
 
     if (state === LicenseKeyValidityState.VALID) {


### PR DESCRIPTION
Consumes the license key's `notice` field: a VALID typed key whose `usage_until` lies within `notice` days of the current UTC instant prints a single console warning naming the expiry date (with a `(UTC)` marker). Stacks on #1731; **rebased onto its current head on 19.08** (the base moved during PR3/PR4's review passes, which had left this PR conflicting).

## Why now

Per Kuba's D5-A (ClickUp, 12.08): hard blocking at/after expiry **stays** in 3.5.0 and the full rev 5 §4.1 window model is a follow-up — but trials made the notice warning concrete for this release: a trial is technically just a key with `grace=0` and `notice>0` whose warnings must surface in the console (packages meeting 12.08), and the trial mechanism lands in August.

## What changed

- `licenseResolution.ts`: `expiryWithinNoticeWindow()` — usage-axis only (rev 5: notice/grace have no effect on the `release_until` axis), window ends exactly where the soft-stop phase would begin, blind to `graceDays` by design.
- `licenseKeyValidator.ts`: `notifyLicenseKeyNotice()` with **per-key** warn-once accounting (`_noticedKeys` keyed by the raw key string) — deliberately not the process-lifetime boolean the state messages use: two engines built with two different keys each get their own warning.
- Blocking behaviour at/after expiry is byte-identical to before; the key's silent flags suppress the warning; CHANGELOG entry included.

## Verification

Paired tests: `hyperformula-tests@spike/hf307-notice-window` (authored RED-first, 8 assertions: inside/outside window, release_until never warns, expired still hard-blocks, silent suppresses, per-key warn-once across two engines). Full license suite **212/212** under Jest (12 suites, `unit/license` + `unit/helpers/licenseKeyValidator`), re-measured after the 19.08 rebase onto the current #1731 (`e9863f27`) — the earlier 165/165 predated PR3's and PR4's review fixes, `tsc --noEmit` clean, `eslint --quiet` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches license validation and console messaging on every engine build, but changes are additive warnings with explicit silencing for transient configs and no change to expiry blocking or entitlements.
> 
> **Overview**
> Adds a **one-time console warning** for valid typed license keys whose **`usage_until`** expiry falls inside the key’s configured **`notice`** window. The message names the **last covered day** (“valid until … (UTC)”), respects the key’s **silent** flags, and **never** runs for **`release_until`** keys or after hard expiry—blocking at/after expiry is unchanged.
> 
> **`licenseResolution`** introduces **`expiryWithinNoticeWindow()`** (usage axis only, window ends at the usage deadline, ignores grace) and only applies **`noticeDays`** for **rev-5** license shapes. **`resolveLicense`** accepts **`notifyConsole`** so transient config resolution can skip console output.
> 
> **`licenseKeyValidator`** adds **`notifyLicenseKeyNotice()`** with **per-key** warn-once tracking (checksum-based identity), separate from the existing once-per-page invalid/missing/expired messages.
> 
> **`Config`** / **`mergeConfig`** pass **`notifyLicenseMessages`** into resolution; **`rebuildWithConfig`** silences notices for the serialization-only config built from the **outgoing** key while the caller may be replacing it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db92bcdbea565bc51ca4d778ad052b61378d5bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

