### PR TITLE
Document the HF-349 static metadata API removal in the 3.4.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added an Indonesian (Bahasa Indonesia) language pack. [#1674](https://github.com/handsontable/hyperformula/pull/1674)
 - Added a `stringifyCurrency` config option that lets you plug in a custom currency formatter for the `TEXT` function. [#1145](https://github.com/handsontable/hyperformula/issues/1145)
 
+### Removed
+
+- Removed the static `HyperFormula.getAvailableFunctions()` and `HyperFormula.getFunctionDetails()` methods. Use the instance methods of the same names instead — an instance knows its configuration and license key, so only it can answer for the engine you actually hold. [#1724](https://github.com/handsontable/hyperformula/pull/1724)
+
 ### Fixed
 
 - Fixed the behavior of `MATCH`, `VLOOKUP`, `HLOOKUP`, and `XLOOKUP` functions when the search range contained empty cells. [#1697](https://github.com/handsontable/hyperformula/pull/1697)


### PR DESCRIPTION
The 3.4.0 release removed the static `HyperFormula.getAvailableFunctions()` / `HyperFormula.getFunctionDetails()` methods (HF-349, #1724) — a breaking public-API change — but the changelog never mentioned it: the [3.4.0] section has no `Removed` entry, and `[Unreleased]` doesn't either. This adds the entry under the release that actually carried it.

Two things this deliberately does NOT do, for the reviewer to weigh:

- it does not touch the migration guide — a breaking removal normally gets a section there (DEV_DOCS DoD); that needs an author's call on wording and placement, so it is flagged rather than guessed;
- it does not re-announce the removal in `[Unreleased]` — the change shipped in 3.4.0, so documenting it there would misstate when it happened.

Docs-only change; no tests, per DoD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pxNP45obT2LZfjitaCv9o

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3443ff25842c5bbe6f67748a546135ba0ef09efb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->