### PR TITLE
docs: improve table responsiveness on narrow screens (closes #1359)

### DIFF
--- a/docs/guide/list-of-differences.md
+++ b/docs/guide/list-of-differences.md
@@ -17,6 +17,14 @@ It makes the page wider to accommodate large tables
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
 }
+/* Allow table cells to wrap text for better responsiveness */
+.page:has(.widePage) td,
+.page:has(.widePage) th {
+  white-space: normal !important;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  min-width: 100px;
+}
 </style>
 
 See a full list of differences between HyperFormula, Microsoft Excel, and Google Sheets.


### PR DESCRIPTION
## What Problem This Solves

The "List of differences with other spreadsheets" guide has a very wide table with long text in each cell that overflows on narrower screens, making it hard to read. Issue #1359 reports that while the built-in functions guide scales well, the differences guide doesn't.

## Why This Change Was Made

The existing CSS makes tables horizontally scrollable but doesn't handle text wrapping in cells. When table cells contain long descriptions (as in the "General functionalities" section), the text extends beyond the viewport width.

## What Changed

Added CSS rules to `list-of-differences.md` that:
- Set `white-space: normal` on table cells to allow text wrapping
- Add `word-wrap: break-word` and `overflow-wrap: break-word` for long words
- Set `min-width: 100px` on cells to prevent overly narrow columns

## How Tested

- Verified the page renders correctly at various viewport widths
- No breaking changes — the existing horizontal scroll behavior is preserved for tables that still exceed the container width

Fixes #1359

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only CSS on a single guide page; no runtime or API impact.
> 
> **Overview**
> Fixes narrow-screen readability on the **List of differences** guide (#1359) by extending the existing `widePage` CSS so wide comparison tables wrap cell text instead of forcing horizontal overflow.
> 
> New rules target `td` and `th` under `.page:has(.widePage)`: **`white-space: normal`** overrides nowrap defaults, **`word-wrap` / `overflow-wrap: break-word`** split long tokens, and **`min-width: 100px`** keeps columns from collapsing too far. Horizontal scrolling on the table block is unchanged when content still exceeds the layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8761e70c4d23d03774cc723a523f28c6f481611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->