### PR TITLE
Improve the docs search with frontmatter tags (HF-353)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@
 ### Checklist:
 <!--- Go through the points below, and put an `x` in each box that applies. -->
 <!--- If you're unsure about any of these, contact us. We're always glad to help! -->
-- [ ] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
+- [ ] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/docs/guide/contributing.html) and I confirm that my code follows the code style of this project.
 - [ ] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
 - [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
 - [ ] My change is compatible with Microsoft Excel.

--- a/DOCS_CONTENT_GUIDE.md
+++ b/DOCS_CONTENT_GUIDE.md
@@ -220,6 +220,10 @@ and hallucinate the parts you omit.
   description: Register and use your own functions in HyperFormula.
   ---
   ```
+- Add a `tags` frontmatter **list** to make a page findable by words it does not use in
+its title or its `##`/`###` headings — the search box matches those three things only,
+never the body text (see `docs/guide/setup-coding-agent.md`, tagged `skills`, `Cursor`,
+`MCP`). A plain string instead of a list breaks the search box site-wide.
 - Use containers for asides: `::: tip`, `::: warning`, `::: danger` … `:::`. Put
 essential steps in the body, not hidden inside a tip.
 - Use **relative links** between guide pages (`./named-expressions.md`) and link to

--- a/DOCS_CONTENT_GUIDE.md
+++ b/DOCS_CONTENT_GUIDE.md
@@ -223,7 +223,10 @@ and hallucinate the parts you omit.
 - Add a `tags` frontmatter **list** to make a page findable by words it does not use in
 its title or its `##`/`###` headings — the search box matches those three things only,
 never the body text (see `docs/guide/setup-coding-agent.md`, tagged `skills`, `Cursor`,
-`MCP`). A plain string instead of a list breaks the search box site-wide.
+`MCP`). Keep it to at most 10 tags a page, each one a word a reader would really type, and
+leave a query to the page that answers it best — a tag ten pages claim is decided by file
+order, not relevance, once the 10-result limit bites. A plain string instead of a list breaks
+the search box site-wide.
 - Use containers for asides: `::: tip`, `::: warning`, `::: danger` … `:::`. Put
 essential steps in the body, not hidden inside a tip.
 - Use **relative links** between guide pages (`./named-expressions.md`) and link to

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
 
 ---
 
-
 HyperFormula is a headless spreadsheet built in TypeScript, serving as both a parser and evaluator of spreadsheet formulas. It can be integrated into your browser or utilized as a service with Node.js as your back-end technology.
 
 ## What HyperFormula can be used for?
@@ -39,36 +38,36 @@ HyperFormula doesn't assume any existing user interface, making it a general-pur
 
 ## Features
 
-- [Function syntax compatible with Microsoft Excel](https://hyperformula.handsontable.com/guide/compatibility-with-microsoft-excel.html) and [Google Sheets](https://hyperformula.handsontable.com/guide/compatibility-with-google-sheets.html)
+- [Function syntax compatible with Microsoft Excel](https://hyperformula.handsontable.com/docs/guide/compatibility-with-microsoft-excel.html) and [Google Sheets](https://hyperformula.handsontable.com/docs/guide/compatibility-with-google-sheets.html)
 - High-speed parsing and evaluation of spreadsheet formulas
-- [A library of ~400 built-in functions](https://hyperformula.handsontable.com/guide/built-in-functions.html)
-- [Support for custom functions](https://hyperformula.handsontable.com/guide/custom-functions.html)
-- [Support for Node.js](https://hyperformula.handsontable.com/guide/server-side-installation.html#install-with-npm-or-yarn)
-- [Support for undo/redo](https://hyperformula.handsontable.com/guide/undo-redo.html)
-- [Support for CRUD operations](https://hyperformula.handsontable.com/guide/basic-operations.html)
-- [Support for clipboard](https://hyperformula.handsontable.com/guide/clipboard-operations.html)
-- [Support for named expressions](https://hyperformula.handsontable.com/guide/named-expressions.html)
-- [Support for data sorting](https://hyperformula.handsontable.com/guide/sorting-data.html)
-- [Support for formula localization with 17 built-in languages](https://hyperformula.handsontable.com/guide/i18n-features.html)
+- [A library of ~400 built-in functions](https://hyperformula.handsontable.com/docs/guide/built-in-functions.html)
+- [Support for custom functions](https://hyperformula.handsontable.com/docs/guide/custom-functions.html)
+- [Support for Node.js](https://hyperformula.handsontable.com/docs/guide/server-side-installation.html#install-with-npm-or-yarn)
+- [Support for undo/redo](https://hyperformula.handsontable.com/docs/guide/undo-redo.html)
+- [Support for CRUD operations](https://hyperformula.handsontable.com/docs/guide/basic-operations.html)
+- [Support for clipboard](https://hyperformula.handsontable.com/docs/guide/clipboard-operations.html)
+- [Support for named expressions](https://hyperformula.handsontable.com/docs/guide/named-expressions.html)
+- [Support for data sorting](https://hyperformula.handsontable.com/docs/guide/sorting-data.html)
+- [Support for formula localization with 17 built-in languages](https://hyperformula.handsontable.com/docs/guide/i18n-features.html)
 - Easy integration with any front-end or back-end application
 - GPLv3 or a [commercial license](https://handsontable.com/get-a-quote)
 - Maintained by the team that stands behind the [Handsontable](https://handsontable.com/) data grid
 
 ## Documentation
 
-- [Client-side installation](https://hyperformula.handsontable.com/guide/client-side-installation.html)
-- [Server-side installation](https://hyperformula.handsontable.com/guide/server-side-installation.html)
-- [Basic usage](https://hyperformula.handsontable.com/guide/basic-usage.html)
-- [Configuration options](https://hyperformula.handsontable.com/guide/configuration-options.html)
-- [List of built-in functions](https://hyperformula.handsontable.com/guide/built-in-functions.html)
-- [API Reference](https://hyperformula.handsontable.com/api/)
+- [Client-side installation](https://hyperformula.handsontable.com/docs/guide/client-side-installation.html)
+- [Server-side installation](https://hyperformula.handsontable.com/docs/guide/server-side-installation.html)
+- [Basic usage](https://hyperformula.handsontable.com/docs/guide/basic-usage.html)
+- [Configuration options](https://hyperformula.handsontable.com/docs/guide/configuration-options.html)
+- [List of built-in functions](https://hyperformula.handsontable.com/docs/guide/built-in-functions.html)
+- [API Reference](https://hyperformula.handsontable.com/docs/api/)
 
 ## Integrations
 
-- [Integration with React](https://hyperformula.handsontable.com/guide/integration-with-react.html#demo)
-- [Integration with Angular](https://hyperformula.handsontable.com/guide/integration-with-angular.html#demo)
-- [Integration with Vue](https://hyperformula.handsontable.com/guide/integration-with-vue.html#demo)
-- [Integration with Svelte](https://hyperformula.handsontable.com/guide/integration-with-svelte.html#demo)
+- [Integration with React](https://hyperformula.handsontable.com/docs/guide/integration-with-react.html#demo)
+- [Integration with Angular](https://hyperformula.handsontable.com/docs/guide/integration-with-angular.html#demo)
+- [Integration with Vue](https://hyperformula.handsontable.com/docs/guide/integration-with-vue.html#demo)
+- [Integration with Svelte](https://hyperformula.handsontable.com/docs/guide/integration-with-svelte.html#demo)
 
 ## Installation and usage
 
@@ -104,9 +103,11 @@ console.log(`${hf.getCellValue({ sheet: sheetId, row: 0, col: 0 })}: ${hf.getCel
 
 [Run this code in StackBlitz](https://stackblitz.com/github/handsontable/hyperformula-demos/tree/3.4.x/mortgage-calculator)
 
+HyperFormula ships an official Claude skill and machine-readable docs, so your AI coding agent can scaffold, configure, and debug HyperFormula correctly. To install the skill in Claude Code, or to point Cursor, GitHub Copilot, or another agent at the docs, see [Set up your coding agent](https://hyperformula.handsontable.com/docs/guide/setup-coding-agent.html).
+
 ## Contributing
 
-Contributions are welcome, but before you make them, please read the [Contributing Guide](https://hyperformula.handsontable.com/guide/contributing.html) and accept the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
+Contributions are welcome, but before you make them, please read the [Contributing Guide](https://hyperformula.handsontable.com/docs/guide/contributing.html) and accept the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
 
 ## License
 

--- a/docs/guide/advanced-usage.md
+++ b/docs/guide/advanced-usage.md
@@ -1,3 +1,11 @@
+---
+tags:
+  - buildEmpty
+  - simpleCellAddressFromString
+  - getSheetValues
+  - cross-sheet
+---
+
 # Advanced usage
 
 ::: tip

--- a/docs/guide/ai-sdk.md
+++ b/docs/guide/ai-sdk.md
@@ -1,3 +1,14 @@
+---
+tags:
+  - AI agents
+  - LLM
+  - tool calling
+  - deterministic
+  - createSpreadsheetTools
+  - OpenAI
+  - what-if analysis
+---
+
 # HyperFormula AI SDK for Vercel
 
 A [Vercel AI SDK](https://sdk.vercel.ai/docs) tool that gives your agents deterministic spreadsheet and formula computation — backed by HyperFormula's Excel-compatible engine.

--- a/docs/guide/arrays.md
+++ b/docs/guide/arrays.md
@@ -1,3 +1,13 @@
+---
+tags:
+  - ARRAYFORMULA
+  - useArrayArithmetic
+  - ARRAY_CONSTRAIN
+  - spilling
+  - arrayRowSeparator
+  - arrayColumnSeparator
+---
+
 # Array formulas
 
 Use array formulas to perform an operation (or call a function) on multiple cells at a time.

--- a/docs/guide/basic-operations.md
+++ b/docs/guide/basic-operations.md
@@ -1,3 +1,16 @@
+---
+tags:
+  - CRUD
+  - insert rows
+  - delete rows
+  - setCellContents
+  - SimpleCellAddress
+  - A1 notation
+  - workbook
+  - sheet tabs
+  - NoSheetWithIdError
+---
+
 # Basic operations
 
 HyperFormula can perform efficient **CRUD** operations on the workbook.

--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -1,3 +1,12 @@
+---
+tags:
+  - getting started
+  - quickstart
+  - tutorial
+  - buildFromArray
+  - buildFromSheets
+---
+
 # Basic usage
 
 ::: tip

--- a/docs/guide/batch-operations.md
+++ b/docs/guide/batch-operations.md
@@ -1,3 +1,12 @@
+---
+tags:
+  - batching
+  - isEvaluationSuspended
+  - EvaluationSuspendedError
+  - bulk updates
+  - recalculation
+---
+
 # Batch operations
 
 HyperFormula offers a built-in feature for doing batch operations.

--- a/docs/guide/branding.md
+++ b/docs/guide/branding.md
@@ -1,3 +1,11 @@
+---
+tags:
+  - brand book
+  - brand guidelines
+  - brand assets
+  - press kit
+---
+
 # Branding
 
 ## Our logo

--- a/docs/guide/building.md
+++ b/docs/guide/building.md
@@ -1,3 +1,14 @@
+---
+tags:
+  - UMD
+  - ESM
+  - bundles
+  - TypeScript typings
+  - Jest
+  - Karma
+  - ESLint
+---
+
 # Building
 
 The build process uses Webpack and Babel, as well as npm tasks

--- a/docs/guide/built-in-functions.tmpl.md
+++ b/docs/guide/built-in-functions.tmpl.md
@@ -1,3 +1,11 @@
+---
+tags:
+  - supported functions
+  - function syntax
+  - function categories
+  - statistics
+---
+
 # Built-in functions
 
 <!--

--- a/docs/guide/cell-references.md
+++ b/docs/guide/cell-references.md
@@ -1,3 +1,14 @@
+---
+tags:
+  - A1 notation
+  - dollar sign
+  - mixed references
+  - cross-sheet references
+  - column range
+  - "#CYCLE!"
+  - circular dependency
+---
+
 # Cell references
 
 A formula can reference one or more cells and automatically update its

--- a/docs/guide/client-side-installation.md
+++ b/docs/guide/client-side-installation.md
@@ -83,3 +83,11 @@ You can download all resources as a ZIP archive directly from the
 [GitHub repository](https://github.com/handsontable/hyperformula).
 Then, you can use one of the above-mentioned methods to install the
 library.
+
+## Set up your coding agent
+
+HyperFormula ships an official Claude skill and machine-readable docs, so
+your AI coding agent can scaffold, configure, and debug HyperFormula
+correctly. To install the skill in Claude Code, or to point Cursor, GitHub
+Copilot, or another agent at the docs, see
+[Set up your coding agent](setup-coding-agent.md).

--- a/docs/guide/client-side-installation.md
+++ b/docs/guide/client-side-installation.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - jsDelivr
+  - script tag
+---
+
 # Client-side installation
 
 ### Install with npm or Yarn

--- a/docs/guide/clipboard-operations.md
+++ b/docs/guide/clipboard-operations.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - clearClipboard
+  - isClipboardEmpty
+  - system clipboard
+---
+
 # Clipboard operations
 
 Through a set of dedicated methods, HyperFormula supports clipboard operations, such as copying, cutting,

--- a/docs/guide/code-of-conduct.md
+++ b/docs/guide/code-of-conduct.md
@@ -1,3 +1,13 @@
+---
+tags:
+  - CoC
+  - Contributor Covenant
+  - harassment
+  - report abuse
+  - unacceptable behavior
+  - community guidelines
+---
+
 # Code of conduct
 
 ## Our Pledge

--- a/docs/guide/compatibility-with-google-sheets.md
+++ b/docs/guide/compatibility-with-google-sheets.md
@@ -1,3 +1,12 @@
+---
+tags:
+  - GSheets
+  - Google Spreadsheets
+  - 1900 leap year
+  - OpenDocument
+  - interoperability
+---
+
 # Compatibility with Google Sheets
 
 Achieve nearly full compatibility wih Google Sheets, using the right HyperFormula configuration.

--- a/docs/guide/compatibility-with-microsoft-excel.md
+++ b/docs/guide/compatibility-with-microsoft-excel.md
@@ -1,3 +1,15 @@
+---
+tags:
+  - MS Excel
+  - missing Excel functions
+  - wildcards
+  - regex
+  - useRegularExpressions
+  - 1900 leap year
+  - OpenDocument
+  - interoperability
+---
+
 # Compatibility with Microsoft Excel
 
 Achieve nearly full compatibility with Microsoft Excel, using the right HyperFormula configuration.

--- a/docs/guide/configuration-options.md
+++ b/docs/guide/configuration-options.md
@@ -1,3 +1,11 @@
+---
+tags:
+  - settings
+  - configure
+  - ConfigParams
+  - buildEmpty
+---
+
 # Configuration options
 
 HyperFormula can be customized through easy-to-setup `options`.

--- a/docs/guide/contact.md
+++ b/docs/guide/contact.md
@@ -1,3 +1,14 @@
+---
+tags:
+  - pricing
+  - get a quote
+  - purchase
+  - email
+  - VAT
+  - invoice
+  - Handsoncode
+---
+
 # Contact
 
 HyperFormula is a product of Handsoncode, the company that stands behind

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -1,3 +1,13 @@
+---
+tags:
+  - CLA
+  - Contributor License Agreement
+  - pull request
+  - bug report
+  - feature request
+  - develop branch
+---
+
 # Contributing
 
 You are welcome to contribute to HyperFormula's development. Your help

--- a/docs/guide/currency-handling.md
+++ b/docs/guide/currency-handling.md
@@ -1,3 +1,14 @@
+---
+tags:
+  - stringifyCurrency
+  - currencySymbol
+  - money
+  - accounting format
+  - Intl.NumberFormat
+  - LCID
+  - NUMBER_CURRENCY
+---
+
 # Currency handling
 
 HyperFormula treats currency through **two independent mechanisms**:

--- a/docs/guide/custom-functions.md
+++ b/docs/guide/custom-functions.md
@@ -1,3 +1,15 @@
+---
+tags:
+  - registerFunctionPlugin
+  - implementedFunctions
+  - runFunction
+  - FunctionArgumentType
+  - SimpleRangeValue
+  - CellError
+  - UDF
+  - user-defined function
+---
+
 # Custom functions
 
 Expand the function library of your application by adding custom functions.

--- a/docs/guide/date-and-time-handling.md
+++ b/docs/guide/date-and-time-handling.md
@@ -1,3 +1,15 @@
+---
+tags:
+  - dates
+  - dateFormats
+  - timeFormats
+  - parseDateTime
+  - stringifyDateTime
+  - stringifyDuration
+  - nullYear
+  - date parsing
+---
+
 # Date and time handling
 
 The formats for the default date and time parsing functions can be set using configuration options:

--- a/docs/guide/demo.md
+++ b/docs/guide/demo.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - live demo
+  - playground
+  - calculateFormula
+---
+
 # Demo
 
 ::: example #example1 --html 1 --css 2 --js 3 --ts 4

--- a/docs/guide/dependencies.md
+++ b/docs/guide/dependencies.md
@@ -1,3 +1,14 @@
+---
+tags:
+  - bessel
+  - Chevrotain
+  - core-js
+  - jStat
+  - tiny-emitter
+  - third-party libraries
+  - dependency licenses
+---
+
 # Dependencies
 
 HyperFormula depends on a few external libraries, as listed below.

--- a/docs/guide/dependency-graph.md
+++ b/docs/guide/dependency-graph.md
@@ -1,3 +1,14 @@
+---
+tags:
+  - getCellPrecedents
+  - getCellDependents
+  - DAG
+  - trace precedents
+  - evaluation order
+  - dependency tree
+  - BFS
+---
+
 # Dependency graph
 
 For accuracy and performance, HyperFormula needs to process cells in a correct and optimal order. For example: in formula `C1=A1+B1`, cells `A1` and `B1` need to be evaluated before `C1`.

--- a/docs/guide/file-import.md
+++ b/docs/guide/file-import.md
@@ -1,3 +1,12 @@
+---
+tags:
+  - ExcelJS
+  - SheetJS
+  - PapaParse
+  - CSV parser
+  - read Excel file
+---
+
 # File import
 
 Import XLSX and CSV files into HyperFormula.

--- a/docs/guide/i18n-features.md
+++ b/docs/guide/i18n-features.md
@@ -1,3 +1,13 @@
+---
+tags:
+  - i18n
+  - localization
+  - localeLang
+  - decimalSeparator
+  - thousandSeparator
+  - Intl.Collator
+---
+
 # Internationalization features
 
 Configure HyperFormula to match the languages and regions of your users.

--- a/docs/guide/integration-with-angular.md
+++ b/docs/guide/integration-with-angular.md
@@ -1,3 +1,16 @@
+---
+tags:
+  - SSR
+  - signals
+  - zoneless
+  - OnPush change detection
+  - Injectable service
+  - standalone components
+  - RxJS
+  - BehaviorSubject
+  - ngOnDestroy
+---
+
 # Integration with Angular
 
 The HyperFormula API is identical in an Angular app and in plain JavaScript. This guide demonstrates how HyperFormula is integrated with an Angular app (typically as an injectable service), how it is cleaned up, and how you bridge its values into the change-detection cycle.

--- a/docs/guide/integration-with-langchain.md
+++ b/docs/guide/integration-with-langchain.md
@@ -1,3 +1,12 @@
+---
+tags:
+  - AI agents
+  - LLM
+  - tool calling
+  - deterministic
+  - createSpreadsheetTools
+---
+
 # Integration with LangChain/LangGraph
 
 A [LangChain.js](https://js.langchain.com/) / [LangGraph](https://langchain-ai.github.io/langgraphjs/) tool that gives your agents deterministic spreadsheet and formula computation — backed by HyperFormula's Excel-compatible engine.

--- a/docs/guide/integration-with-react.md
+++ b/docs/guide/integration-with-react.md
@@ -1,3 +1,15 @@
+---
+tags:
+  - SSR
+  - React hooks
+  - useEffect
+  - useRef
+  - useState
+  - dynamic import
+  - use client
+  - lifecycle
+---
+
 # Integration with React
 
 The HyperFormula API is identical in a React app and in plain JavaScript. This guide demonstrates how HyperFormula is integrated with the React component tree and how its lifecycle maps to React hooks.

--- a/docs/guide/integration-with-svelte.md
+++ b/docs/guide/integration-with-svelte.md
@@ -1,3 +1,12 @@
+---
+tags:
+  - SSR
+  - onMount
+  - onDestroy
+  - reactivity
+  - lifecycle
+---
+
 # Integration with Svelte
 
 The HyperFormula API is identical in a Svelte app and in plain JavaScript. This guide demonstrates how HyperFormula integrates with the Svelte component's lifecycle and how you bridge its values into Svelte's reactivity.

--- a/docs/guide/integration-with-vue.md
+++ b/docs/guide/integration-with-vue.md
@@ -1,3 +1,15 @@
+---
+tags:
+  - Vue 3
+  - Vue.js
+  - markRaw
+  - shallowRef
+  - Pinia
+  - ClientOnly
+  - SSR
+  - licenseKeyValidityState
+---
+
 # Integration with Vue
 
 The HyperFormula API is identical in a Vue 3 app and in plain JavaScript. This guide demonstrates how HyperFormula integrates with the Vue reactivity system and how to surface its values in the template.

--- a/docs/guide/key-concepts.md
+++ b/docs/guide/key-concepts.md
@@ -1,3 +1,13 @@
+---
+tags:
+  - architecture
+  - internals
+  - parser
+  - Abstract Syntax Tree
+  - Chevrotain
+  - topological order
+---
+
 # Key concepts
 
 ## High-level design diagram

--- a/docs/guide/known-limitations.md
+++ b/docs/guide/known-limitations.md
@@ -1,3 +1,13 @@
+---
+tags:
+  - unsupported features
+  - multiple workbooks
+  - 3D references
+  - dynamic arrays
+  - asynchronous functions
+  - structured references
+---
+
 # Known limitations
 
 This page lists the known limitations of HyperFormula at its current development stage:

--- a/docs/guide/license-key.md
+++ b/docs/guide/license-key.md
@@ -1,3 +1,14 @@
+---
+tags:
+  - licenseKey
+  - gpl-v3
+  - licence key
+  - invalid license key
+  - expired license key
+  - console warning
+  - offline validation
+---
+
 # License key
 
 To use HyperFormula, you need to specify which [license type](licensing.md#available-licenses) you use, by entering a license key in your [configuration options](configuration-options.md).

--- a/docs/guide/licensing.md
+++ b/docs/guide/licensing.md
@@ -1,3 +1,13 @@
+---
+tags:
+  - commercial licence
+  - non-commercial
+  - dual licensing
+  - open source
+  - free
+  - buy a license
+---
+
 # Licensing
 
 To make HyperFormula a better fit for different types of projects, the source code is available under different licenses.

--- a/docs/guide/list-of-differences.md
+++ b/docs/guide/list-of-differences.md
@@ -1,3 +1,13 @@
+---
+tags:
+  - Microsoft Excel
+  - Google Sheets
+  - compatibility
+  - OpenDocument
+  - negative numbers
+  - rounding
+---
+
 # List of differences with other spreadsheets
 
 <!--

--- a/docs/guide/localizing-functions.md
+++ b/docs/guide/localizing-functions.md
@@ -1,3 +1,11 @@
+---
+tags:
+  - translations
+  - translate
+  - locales
+  - registerLanguage
+---
+
 # Localizing functions
 
 You can localize a function's ID and error

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -1,3 +1,13 @@
+---
+tags:
+  - Model Context Protocol
+  - Claude Desktop
+  - AI agents
+  - LLM
+  - tool calling
+  - deterministic
+---
+
 # HyperFormula MCP Server
 
 An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that exposes HyperFormula as a tool for any MCP-compatible AI client (Claude Desktop, Cursor, VS Code, and others) — giving LLMs deterministic spreadsheet and formula computation.

--- a/docs/guide/migration-from-0.6-to-1.0.md
+++ b/docs/guide/migration-from-0.6-to-1.0.md
@@ -1,3 +1,13 @@
+---
+tags:
+  - migration
+  - migrate
+  - upgrade
+  - breaking changes
+  - agpl-v3
+  - v1.0
+---
+
 # Migrating from 0.6 to 1.0
 
 To upgrade your HyperFormula version from 0.6.x to 1.0.x, follow this guide.

--- a/docs/guide/migration-from-1.x-to-2.0.md
+++ b/docs/guide/migration-from-1.x-to-2.0.md
@@ -1,3 +1,14 @@
+---
+tags:
+  - migration
+  - migrate
+  - upgrade
+  - breaking changes
+  - gpu.js
+  - GPU acceleration
+  - v2.0
+---
+
 # Migrating from 1.x to 2.0
 
 To upgrade your HyperFormula version from 1.x.x to 2.0.0, follow this guide.

--- a/docs/guide/migration-from-2.x-to-3.0.md
+++ b/docs/guide/migration-from-2.x-to-3.0.md
@@ -1,3 +1,17 @@
+---
+tags:
+  - migration
+  - migrate
+  - upgrade
+  - breaking changes
+  - v3.0
+  - ESM
+  - mjs
+  - tsconfig
+  - moduleResolution
+  - bundlers
+---
+
 # Migrating from 2.x to 3.0
 
 To upgrade your HyperFormula version from 2.x.x to 3.0.0, follow this guide.

--- a/docs/guide/named-expressions.md
+++ b/docs/guide/named-expressions.md
@@ -1,3 +1,15 @@
+---
+tags:
+  - defined names
+  - global scope
+  - variables
+  - named constants
+  - addNamedExpression
+  - changeNamedExpression
+  - removeNamedExpression
+  - listNamedExpressions
+---
+
 # Named expressions
 
 An expression can be assigned a human-friendly name. Thanks to this you can

--- a/docs/guide/order-of-precendece.md
+++ b/docs/guide/order-of-precendece.md
@@ -1,3 +1,11 @@
+---
+tags:
+  - operator precedence
+  - order of operations
+  - parenthesis
+  - brackets
+---
+
 # Order of precedence
 
 HyperFormula supports multiple [operators](types-of-operators.md) that

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -1,3 +1,15 @@
+---
+tags:
+  - speed
+  - slow
+  - memory
+  - optimize
+  - recalculate
+  - useColumnIndex
+  - chooseAddressMappingPolicy
+  - maxPendingLazyTransformations
+---
+
 # Performance
 
 We implemented various techniques to boost the performance of

--- a/docs/guide/quality.md
+++ b/docs/guide/quality.md
@@ -1,3 +1,13 @@
+---
+tags:
+  - audits
+  - OWASP
+  - penetration testing
+  - test coverage
+  - vulnerability scanning
+  - reliability
+---
+
 # Quality & Security
 
 HyperFormula is built with the highest standards of software quality, backed by rigorous research, comprehensive testing, and transparent development practices.

--- a/docs/guide/release-notes.md
+++ b/docs/guide/release-notes.md
@@ -1,3 +1,12 @@
+---
+tags:
+  - changelog
+  - version history
+  - breaking changes
+  - bug fixes
+  - new features
+---
+
 # Release notes
 
 This page lists HyperFormula release notes. The format is based on

--- a/docs/guide/server-side-installation.md
+++ b/docs/guide/server-side-installation.md
@@ -46,3 +46,12 @@ const { HyperFormula } = require('hyperformula');
 
 // your code
 ```
+
+## Set up your coding agent
+
+HyperFormula ships an official Claude skill and machine-readable docs, so
+your AI coding agent can scaffold, configure, and debug HyperFormula
+correctly. That applies to a Node.js project as much as to a browser one.
+To install the skill in Claude Code, or to point Cursor, GitHub Copilot, or
+another agent at the docs, see
+[Set up your coding agent](setup-coding-agent.md).

--- a/docs/guide/server-side-installation.md
+++ b/docs/guide/server-side-installation.md
@@ -1,3 +1,11 @@
+---
+tags:
+  - Node.js version
+  - full-icu
+  - CommonJS
+  - backend
+---
+
 # Server-side installation
 
 ::: tip

--- a/docs/guide/setup-coding-agent.md
+++ b/docs/guide/setup-coding-agent.md
@@ -2,27 +2,15 @@
 description: Install the official HyperFormula skill for Claude Code, or point any other AI coding agent at HyperFormula's machine-readable docs.
 tags:
   - skills
-  - SKILL.md
-  - HyperFormula skill
-  - Claude Code skill
   - plugin marketplace
-  - AI coding agent setup
-  - agentic coding
-  - Cursor
-  - GitHub Copilot
+  - AI agents
   - Codex
   - Windsurf
-  - MCP
-  - Model Context Protocol
   - GitMCP
   - Context7
   - llms.txt
-  - llms-full.txt
-  - Markdown docs
-  - machine-readable docs
   - AGENTS.md
-  - rules file
-  - LLM
+  - Markdown docs
 ---
 
 # Set up your coding agent

--- a/docs/guide/setup-coding-agent.md
+++ b/docs/guide/setup-coding-agent.md
@@ -1,3 +1,30 @@
+---
+description: Install the official HyperFormula skill for Claude Code, or point any other AI coding agent at HyperFormula's machine-readable docs.
+tags:
+  - skills
+  - SKILL.md
+  - HyperFormula skill
+  - Claude Code skill
+  - plugin marketplace
+  - AI coding agent setup
+  - agentic coding
+  - Cursor
+  - GitHub Copilot
+  - Codex
+  - Windsurf
+  - MCP
+  - Model Context Protocol
+  - GitMCP
+  - Context7
+  - llms.txt
+  - llms-full.txt
+  - Markdown docs
+  - machine-readable docs
+  - AGENTS.md
+  - rules file
+  - LLM
+---
+
 # Set up your coding agent
 
 HyperFormula ships an official Claude skill and machine-readable docs so your AI coding agent can scaffold, configure, and debug HyperFormula correctly. Pick your tool below, or use the interactive wizard.

--- a/docs/guide/sorting-data.md
+++ b/docs/guide/sorting-data.md
@@ -1,3 +1,14 @@
+---
+tags:
+  - setRowOrder
+  - setColumnOrder
+  - ascending
+  - descending
+  - reordering
+  - permutation
+  - sort by column
+---
+
 # Sorting data
 
 In HyperFormula, you can sort data by reordering rows and columns.

--- a/docs/guide/specifications-and-limits.md
+++ b/docs/guide/specifications-and-limits.md
@@ -1,3 +1,15 @@
+---
+tags:
+  - maxRows
+  - maxColumns
+  - nested functions
+  - nesting levels
+  - precisionRounding
+  - significant digits
+  - iterative calculation
+  - floating point
+---
+
 # Specifications and limits
 
 The following table presents the limits of features. Many of them

--- a/docs/guide/supported-browsers.md
+++ b/docs/guide/supported-browsers.md
@@ -1,3 +1,13 @@
+---
+tags:
+  - full-icu
+  - IE11
+  - Internet Explorer
+  - mobile
+  - iOS
+  - Android
+---
+
 # Supported browsers
 
 Each release of HyperFormula is tested on the **two latest versions**

--- a/docs/guide/types-of-errors.md
+++ b/docs/guide/types-of-errors.md
@@ -1,3 +1,17 @@
+---
+tags:
+  - "#REF!"
+  - "#VALUE!"
+  - "#DIV/0!"
+  - "#N/A"
+  - "#NAME?"
+  - "#NUM!"
+  - "#CYCLE!"
+  - "#ERROR!"
+  - "#LIC!"
+  - division by zero
+---
+
 # Types of errors
 
 HyperFormula returns an error when a formula cannot be processed

--- a/docs/guide/types-of-operators.md
+++ b/docs/guide/types-of-operators.md
@@ -1,3 +1,17 @@
+---
+tags:
+  - modulo
+  - caseSensitive
+  - accentSensitive
+  - caseFirst
+  - ignorePunctuation
+  - implicit conversion
+  - case insensitive
+  - concatenate
+  - intersection
+  - union
+---
+
 # Types of operators
 
 The operators specify what type of actions are performed on arguments

--- a/docs/guide/types-of-values.md
+++ b/docs/guide/types-of-values.md
@@ -1,3 +1,17 @@
+---
+tags:
+  - boolean
+  - logical
+  - DateTime
+  - percentage
+  - scientific notation
+  - apostrophe
+  - leading zeros
+  - empty cell
+  - type detection
+  - serial number
+---
+
 # Types of values
 
 In HyperFormula, values can be of type Number, Text, Logical, Date, Time, DateTime, Error, Currency, or Percentage depending on the data.

--- a/docs/guide/undo-redo.md
+++ b/docs/guide/undo-redo.md
@@ -1,3 +1,12 @@
+---
+tags:
+  - undoLimit
+  - undo history
+  - undo stack
+  - revert changes
+  - Ctrl+Z
+---
+
 # Undo-redo
 
 HyperFormula supports undo-redo for CRUD and move operations.

--- a/docs/guide/volatile-functions.md
+++ b/docs/guide/volatile-functions.md
@@ -1,3 +1,14 @@
+---
+tags:
+  - recalculation triggers
+  - recalculate
+  - isVolatile
+  - RANDBETWEEN
+  - NOW
+  - TODAY
+  - dirty
+---
+
 # Volatile functions
 
 If you work with spreadsheet software regularly, then you've probably

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,6 +108,8 @@ console.log(`${hf.getCellValue({ sheet: sheetId, row: 0, col: 0 })}: ${hf.getCel
 
 [Run this code in StackBlitz](https://stackblitz.com/github/handsontable/hyperformula-demos/tree/3.4.x/mortgage-calculator)
 
+HyperFormula ships an official Claude skill and machine-readable docs, so your AI coding agent can scaffold, configure, and debug HyperFormula correctly. To install the skill in Claude Code, or to point Cursor, GitHub Copilot, or another agent at the docs, see [Set up your coding agent](guide/setup-coding-agent.md).
+
 ## Contributing
 
 Contributions are welcome, but before you make them, please read the [Contributing Guide](guide/contributing.md) and accept the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).


### PR DESCRIPTION
### Context

[HF-353](https://app.clickup.com/t/9015210959/HF-353) started from one symptom: the official HyperFormula skill for Claude Code was documented only on the [Set up your coding agent](https://hyperformula.handsontable.com/docs/guide/setup-coding-agent.html) page, and searching the docs for `skill` returned nothing.

The cause is general, not specific to that page. The docs search box builds its match domain from a page's **title + `tags` frontmatter + `h2`/`h3` heading titles** only ([`docs/.vuepress/plugins/search-box/match-query.js`](docs/.vuepress/plugins/search-box/match-query.js)) — body text is never indexed. Until now **no page in the repository used `tags`**, so every page was findable only by the words it happened to put in a heading. A reader who types the Excel term, the error value, the method name or the abbreviation found nothing.

Changes:

- **Every guide page** (55 of them) now carries a `tags` list of the words a reader really types: the Excel or Google Sheets term (`GSheets`, `MS Excel`, `defined names`), the literal error value (`#REF!`, `#DIV/0!`), the API method (`buildFromArray`, `setRowOrder`, `registerFunctionPlugin`), the abbreviation (`CLA`, `GPL`, `CRUD`, `SSR`, `IE11`, `UDF`), the third-party name (`ExcelJS`, `Pinia`, `Chevrotain`, `Context7`) and the plain-language word for the problem (`slow`, `memory`, `division by zero`, `quickstart`).
- **`docs/index.md`** and **`README.md`** — one paragraph at the end of "Installation and usage" mentioning the skill and linking to the coding-agent guide. The two files are hand-maintained mirrors of one page, so the paragraph went into both.
- **`docs/guide/client-side-installation.md`** and **`docs/guide/server-side-installation.md`** — both installation guides now close with a short "Set up your coding agent" section pointing at the same guide. These are the pages a reader actually lands on when installing, and neither repeats the skill's setup commands.
- **`README.md`** (same page, drive-by) — its 22 documentation links, and the one in `.github/pull_request_template.md`, still used the pre-Cloudflare `hyperformula.handsontable.com/guide/<slug>.html` form. The docs are built under `/docs/` and served from `https://hyperformula.handsontable.com/docs/` (`docs/README.md`, `docs/.vuepress/build.config.js`) — the form `src/interpreter/functionMetadata/**` already uses — so all of them now carry the `/docs/` prefix.
- **`DOCS_CONTENT_GUIDE.md`** — documents `tags` in "VuePress conventions": what it is for, the 10-tag limit, why a tag ten pages claim is worthless, and that it must be a YAML **list** (a plain string makes `match-query.js` call `.join()` on a string and breaks the search box site-wide).

The tags follow four rules:

1. **At most 10 per page**, fewer where fewer will do — the range is 2 to 10, 353 in total.
2. **Never a word the page's own title or headings already match** — those match anyway, so such a tag buys nothing. This is why `setup-coding-agent.md` lost `Cursor`, `Copilot` and `Claude Code` (all in its own headings) and `LLM` (a substring of `llms.txt`) when it was trimmed to the same limit.
3. **Never a generic word the page is not the best destination for**, remembering that a multi-word tag is matched word by word, so `rules file` would drag the page into results for `file` and `rules`.
4. **Only what the page truly answers** — nothing tags a feature it does not document. `timezone`, for instance, is tagged nowhere, because no page covers time zones.

`tags` has exactly one consumer in the repo (that search plugin), and frontmatter is stripped from the `.md` companions and `llms-full.txt`, so nothing outside the search index changes. Tags on `built-in-functions.tmpl.md` reach the generated built-in functions page, which `script/generate-builtin-functions-doc.ts` splices from that template.

### How did you test your changes?

**The search behaviour.** `npm run docs:build` cannot run in the authoring environment (no `node_modules`, no registry access), so this was tested by **executing the shipped search code** — `match-query.js` and `SearchBox.vue`'s `suggestions` / `suggestionsFromCategory` logic, loaded through `vm` with `lodash/get` stubbed — against page objects built from the real Markdown sources the way `@vuepress/core` 1.9.10 does (title from frontmatter or the first `H1`, headers from `h2`/`h3` only, frontmatter from the YAML block).

Results over the whole tag set:

| check | result |
| --- | --- |
| tag queries run (every tag of every page) | 353 |
| tags that fail to surface their own page | **0** |
| tags returning more than 6 rows (limit is 10, unranked) | **0** |
| `skill` → the coding-agent page | `Guides: Set up your coding agent` (was: no results) |

Spot checks land where they should, page-level or deep-linked: `#REF!` → `Cell references > The #REF! error` and `Types of errors`; `CLA` → `Contributing`; `GPL` → `License key`, `Licensing > GPLv3 license`; `IE11` → `Supported browsers`; `buildFromArray` → `Basic usage`; `Pinia` → `Integration with Vue`; `modulo` → `Types of operators`; `trace precedents` → `Dependency graph`; `division by zero` → `Types of errors`.

The error values are quoted in YAML (`- "#REF!"`) on purpose: unquoted, `#` starts a comment, and the unprefixed `REF!` would miss the `#REF!` a reader actually types. The quoted form matches `ref`, `REF!` and `#REF!` alike.

**The rest.**

- Every frontmatter block parses with a real YAML parser — `tags` reads back as a list of strings on all 56 pages, and no page exceeds 10.
- The applier refuses to write a tag list that breaks an invariant (over 10, duplicates, a tag that is a substring of another on the same page, an unquotable value), so none of those can slip in.
- `build-docs` (a real `npm run docs:build`) and the Cloudflare preview deployment both passed on the commit carrying all 55 tagged pages, which is the authoritative check that VuePress accepts this frontmatter.
- The new sections on the two installation guides keep `skill` pointed at the coding-agent page (still a single row for that query); `coding agent` now returns three rows — the guide itself plus the two new deep links.
- Every rewritten README link was checked against the docs sources: all 21 distinct URLs resolve to an existing page, and the two anchors in use (`#install-with-npm-or-yarn`, `#demo`) exist.
- README.md and docs/index.md were diffed under the link-form normalisation and are line-for-line identical apart from the docs page's frontmatter and its leading `<br>` spacing.
- The diff is Markdown and YAML only, so no lint, unit test or build step is affected; each edited page keeps its own line-wrapping convention, no trailing whitespace, no CRLF.

Worth a reviewer's eye:

1. `Codex` and `Windsurf` are tagged on the coding-agent page although it never names them — they fall under its "Cursor, Copilot & other agents" section, and pointing such a user at `llms-full.txt` is exactly the advice they need.
2. Four pages share `SSR` and four share `breaking changes`; three share the AI-integration vocabulary (`AI agents`, `LLM`, `tool calling`). Each genuinely answers those queries, and the row counts stay well under the limit, but it is the kind of thing to keep an eye on as more tags are added.
3. `docs/index.md` is deliberately untagged: it has no `H1`, so VuePress infers no title for it and its search rows would be labelled by path.

### Types of changes
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [x] Change to the documentation

### Related issues:
1. [HF-353](https://app.clickup.com/t/9015210959/HF-353)

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/docs/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [ ] My change is compatible with Microsoft Excel.
- [ ] My change is compatible with Google Sheets.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [x] My changes require a documentation update.
- [ ] My changes require a migration guide.

Deliberately left out: no `CHANGELOG.md` / release-notes entry (documentation-only change, and the 3.4.0 mention of the coding-agent page was dropped from this PR on request). Four links of the old `/guide/` form survive in `CHANGELOG.md` (3) and `docs/guide/release-notes.md` (1) — those two files were off limits here, so they are worth a separate one-line fix.
