### PR TITLE
Fix the stale documentation links in the changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,7 +242,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 - Removed all polyfills from the CommonJS build and the ES modules build. In the UMD build, kept only the polyfills
-  required by the [supported browsers](https://hyperformula.handsontable.com/guide/supported-browsers.html).
+  required by the [supported browsers](https://hyperformula.handsontable.com/docs/guide/supported-browsers.html).
   [#1011](https://github.com/handsontable/hyperformula/issues/1011)
 
 ## [2.0.1] - 2022-06-14
@@ -261,9 +261,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For more information on this release, see:
 
-- [Release notes](https://hyperformula.handsontable.com/guide/release-notes.html)
+- [Release notes](https://hyperformula.handsontable.com/docs/guide/release-notes.html)
 - [Blog post](https://handsontable.com/blog/articles/2022/04/whats-new-in-hyperformula-2.0.0)
-- [Migration guide](https://hyperformula.handsontable.com/guide/migration-from-1.0-to-2.0.html)
+- [Migration guide](https://hyperformula.handsontable.com/docs/guide/migration-from-1.x-to-2.0.html)
 
 ### Added
 

--- a/docs/guide/release-notes.md
+++ b/docs/guide/release-notes.md
@@ -291,7 +291,7 @@ HyperFormula adheres to
 ### Removed
 
 - Removed all polyfills from the CommonJS build and the ES modules build. In the UMD build, kept only the polyfills
-  required by the [supported browsers](https://hyperformula.handsontable.com/guide/supported-browsers.html).
+  required by the [supported browsers](https://hyperformula.handsontable.com/docs/guide/supported-browsers.html).
   [#1011](https://github.com/handsontable/hyperformula/issues/1011)
 
 ## 2.0.1


### PR DESCRIPTION
### Context

Follow-up to [#1750](https://github.com/handsontable/hyperformula/pull/1750), which re-pointed the documentation links in `README.md` and the pull request template but deliberately left `CHANGELOG.md` and `docs/guide/release-notes.md` untouched. These are the four links that were left behind.

All four used the pre-Cloudflare `hyperformula.handsontable.com/guide/<slug>.html` form. The documentation is built under `/docs/` and served from `https://hyperformula.handsontable.com/docs/` (`docs/README.md`, `docs/.vuepress/build.config.js`) — the form the rest of the repository already uses — so each now carries the `/docs/` prefix:

| file | link |
| --- | --- |
| `CHANGELOG.md` (2.0.2 → Removed) | `supported-browsers.html` |
| `CHANGELOG.md` (2.0.0 header) | `release-notes.html` |
| `CHANGELOG.md` (2.0.0 header) | `migration-from-1.0-to-2.0.html` → `migration-from-1.x-to-2.0.html` |
| `docs/guide/release-notes.md` (2.0.2 → Removed) | `supported-browsers.html` |

The 2.0.0 migration guide link needed more than the prefix. `c27a9d5` ("Fix language files for Node+ESM (#1377)") renamed `docs/guide/migration-from-1.0-to-2.0.md` to `docs/guide/migration-from-1.x-to-2.0.md` and did not update the link, so it pointed at a page that does not exist under either prefix. It now uses the current slug.

`script/release/release.sh` generates the release notes from the changelog section verbatim, so both files keep the same absolute URL and stay mirrors of each other.

### How did you test your changes?

- Every rewritten URL was checked against the sources: `docs/guide/supported-browsers.md`, `docs/guide/release-notes.md` and `docs/guide/migration-from-1.x-to-2.0.md` all exist; the old `migration-from-1.0-to-2.0` slug does not, which `git log --diff-filter=R` confirms was a rename in `c27a9d5`.
- A repository-wide grep for the old `hyperformula.handsontable.com/guide/` and `/api/` forms now returns nothing in either file, and nothing anywhere else in the repository.
- Markdown-only change to two documentation files, so no lint, unit test or build step is affected; both files keep their existing wrapping and no other line is touched.

### Types of changes
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [x] Change to the documentation

### Related issues:
1. Follow-up to [#1750](https://github.com/handsontable/hyperformula/pull/1750) ([HF-353](https://app.clickup.com/t/9015210959/HF-353))

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/docs/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [ ] My change is compatible with Microsoft Excel.
- [ ] My change is compatible with Google Sheets.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.

No changelog entry: this only corrects links inside the changelog and the release notes, and the repository does not require an entry for a documentation-only change. The edited entries belong to already-released versions, so their wording is unchanged — only the URLs move.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AXFK3TQ32DUAP3LR2T9b5q)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only URL corrections in changelog and release notes; no runtime or API impact.
> 
> **Overview**
> Updates **stale documentation URLs** in `CHANGELOG.md` and `docs/guide/release-notes.md` so they match the current site layout under `https://hyperformula.handsontable.com/docs/`.
> 
> Links that used `hyperformula.handsontable.com/guide/...` now include the **`/docs/`** prefix (e.g. supported browsers, release notes). In the 2.0.0 changelog header, the **migration guide** URL is corrected to **`migration-from-1.x-to-2.0.html`**, matching the renamed guide page instead of the old `migration-from-1.0-to-2.0` slug.
> 
> `docs/guide/release-notes.md` gets the same supported-browsers URL fix so it stays aligned with the changelog content copied by the release script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fac749e62e91a688e40c052e5211ec20f0e2e53d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->